### PR TITLE
fix: framework detection in /validate and /benchmark commands

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Parse command
         id: parse
@@ -26,9 +26,10 @@ jobs:
           PR=${{ github.event.issue.number }}
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
 
-          # Detect changed frameworks from the PR
-          FRAMEWORKS=$(gh pr diff "$PR" --name-only | grep '^frameworks/' | cut -d'/' -f2 | sort -u | head -1)
+          # Detect changed frameworks from PR files via API (most reliable)
+          FRAMEWORKS=$(gh api "/repos/${{ github.repository }}/pulls/$PR/files" --jq '.[].filename' | grep '^frameworks/' | cut -d'/' -f2 | sort -u | head -1)
           echo "framework=$FRAMEWORKS" >> "$GITHUB_OUTPUT"
+          echo "Detected framework: $FRAMEWORKS"
 
           if echo "$COMMENT" | grep -q '/benchmark'; then
             echo "command=benchmark" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes the 'No framework detected' issue when using `/benchmark` or `/validate` on PRs.

**Problem:** `gh pr diff --name-only` fails silently on the self-hosted runner, returning empty output.

**Fix:** Use the GitHub API (`/pulls/{pr}/files`) to get the list of changed files instead. This is more reliable and doesn't depend on git clone depth.