### PR TITLE
fix: prevent shell injection in PR Commands workflow

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -22,25 +22,27 @@ jobs:
       - name: Parse command
         id: parse
         run: |
-          COMMENT="${{ github.event.comment.body }}"
-          PR=${{ github.event.issue.number }}
+          PR="$PR_NUMBER"
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
 
           # Detect changed frameworks from PR files via API (most reliable)
-          FRAMEWORKS=$(gh api "/repos/${{ github.repository }}/pulls/$PR/files" --jq '.[].filename' | grep '^frameworks/' | cut -d'/' -f2 | sort -u | head -1)
+          FRAMEWORKS=$(gh api "/repos/$REPO/pulls/$PR/files" --jq '.[].filename' | grep '^frameworks/' | cut -d'/' -f2 | sort -u | head -1)
           echo "framework=$FRAMEWORKS" >> "$GITHUB_OUTPUT"
           echo "Detected framework: $FRAMEWORKS"
 
-          if echo "$COMMENT" | grep -q '/benchmark'; then
+          if echo "$COMMENT_BODY" | grep -q '/benchmark'; then
             echo "command=benchmark" >> "$GITHUB_OUTPUT"
             # Extract optional profile: /benchmark baseline
-            PROFILE=$(echo "$COMMENT" | grep -oP '/benchmark\s+\K\S+' || echo "")
+            PROFILE=$(echo "$COMMENT_BODY" | grep -oP '/benchmark\s+\K\S+' || echo "")
             echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMENT" | grep -q '/validate'; then
+          elif echo "$COMMENT_BODY" | grep -q '/validate'; then
             echo "command=validate" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
 
       - name: React to comment
         run: |


### PR DESCRIPTION
## What

The `Parse command` step in `pr-commands.yml` interpolated the raw comment body directly into bash:

```bash
COMMENT="${{ github.event.comment.body }}"
```

This means any backticked code in a PR comment (like \`req.content_length\`) gets executed as a shell command on the self-hosted runner. You can see this in the [latest failed run](https://github.com/MDA2AV/HttpArena/actions/runs/23128132566) — my PR #31 comment had backticked Zig code that bash tried to execute:

```
line 5: req.content_length: command not found
line 5: body.len: command not found
```

This is a security issue on self-hosted runners since arbitrary code could be injected via PR comments.

## Fix

Pass `github.event.comment.body`, `github.event.issue.number`, and `github.repository` through environment variables instead of direct \${{ }} interpolation. Environment variables are safely handled by the shell without interpretation.

This was my mistake from PR #32 — sorry about that! 🙈