### PR TITLE
ci: remove auto-benchmark on push, keep manual dispatch only

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,10 +1,6 @@
 name: Benchmark
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'frameworks/**'
   workflow_dispatch:
     inputs:
       framework:


### PR DESCRIPTION
Removes the automatic benchmark trigger on push to main. Benchmarks now only run via workflow_dispatch.