### PR TITLE
fix(vertx): use gzip level 1 (BEST_SPEED) for compression endpoint

### DIFF
--- a/frameworks/vertx/src/main/java/com/httparena/MainVerticle.java
+++ b/frameworks/vertx/src/main/java/com/httparena/MainVerticle.java
@@ -249,7 +249,9 @@ public class MainVerticle extends AbstractVerticle {
         }
         try {
             java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
-            java.util.zip.GZIPOutputStream gz = new java.util.zip.GZIPOutputStream(baos);
+            java.util.zip.GZIPOutputStream gz = new java.util.zip.GZIPOutputStream(baos) {{
+                def.setLevel(java.util.zip.Deflater.BEST_SPEED);
+            }};
             gz.write(largeJsonResponse);
             gz.close();
             ctx.response()


### PR DESCRIPTION
Jerry caught this in #108 — the `GZIPOutputStream` default constructor uses `Deflater.DEFAULT_COMPRESSION` (level 6), but the spec requires gzip level 1 (fastest).

Fix uses the anonymous class initializer pattern to set `def.setLevel(Deflater.BEST_SPEED)` on the inherited Deflater:

```java
java.util.zip.GZIPOutputStream gz = new java.util.zip.GZIPOutputStream(baos) {{
    def.setLevel(java.util.zip.Deflater.BEST_SPEED);
}};
```

This was my oversight from the original vertx PR — thanks @jerrythetruckdriver for the audit!

Fixes #108