### PR TITLE
fix(vapor): use gzip level 1 (BEST_SPEED) for compression endpoint

### DIFF
--- a/frameworks/vapor/Dockerfile
+++ b/frameworks/vapor/Dockerfile
@@ -1,9 +1,9 @@
 FROM swift:6.2-jammy AS build
-RUN apt-get update && apt-get install -y --no-install-recommends libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libsqlite3-dev zlib1g-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY Package.swift .
 COPY Sources ./Sources
-RUN mkdir -p src && echo 'import CSQLite\nprint("stub")' > src/main.swift && \
+RUN mkdir -p src && echo 'import CSQLite; import CZlib; print("stub")' > src/main.swift && \
     swift build -c release 2>/dev/null || true && \
     rm -rf src/
 COPY src ./src
@@ -11,7 +11,7 @@ RUN swift build -c release -Xswiftc -O -Xswiftc -cross-module-optimization
 
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libsqlite3-0 libcurl4 libxml2 && \
+    libsqlite3-0 libcurl4 libxml2 zlib1g && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=build /usr/lib/swift/linux/lib*.so /usr/lib/swift/linux/
 COPY --from=build /app/.build/release/Server /server

--- a/frameworks/vapor/Package.swift
+++ b/frameworks/vapor/Package.swift
@@ -16,10 +16,18 @@ let package = Package(
                 .apt(["libsqlite3-dev"]),
             ]
         ),
+        .systemLibrary(
+            name: "CZlib",
+            path: "Sources/CZlib",
+            providers: [
+                .apt(["zlib1g-dev"]),
+            ]
+        ),
         .executableTarget(
             name: "Server",
             dependencies: [
                 "CSQLite",
+                "CZlib",
                 .product(name: "Vapor", package: "vapor"),
             ],
             path: "src"

--- a/frameworks/vapor/Sources/CZlib/module.modulemap
+++ b/frameworks/vapor/Sources/CZlib/module.modulemap
@@ -1,0 +1,5 @@
+module CZlib [system] {
+    header "shim.h"
+    link "z"
+    export *
+}

--- a/frameworks/vapor/Sources/CZlib/shim.h
+++ b/frameworks/vapor/Sources/CZlib/shim.h
@@ -1,0 +1,6 @@
+#ifndef CZLIB_SHIM_H
+#define CZLIB_SHIM_H
+
+#include <zlib.h>
+
+#endif

--- a/frameworks/vapor/src/main.swift
+++ b/frameworks/vapor/src/main.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Vapor
+import CZlib
 
 #if canImport(CSQLite)
 import CSQLite
@@ -185,6 +186,34 @@ func queryDb(dbPath: String, minPrice: Double, maxPrice: Double) -> [UInt8] {
     return [UInt8](jsonData)
 }
 
+// MARK: - Gzip Helper
+
+func gzipCompress(_ data: [UInt8], level: Int32 = 1) -> [UInt8] {
+    var stream = z_stream()
+    // windowBits = 15 + 16 = 31 for gzip format
+    let rc = deflateInit2_(&stream, level, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY,
+                           ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+    guard rc == Z_OK else { return data }
+
+    let bufferSize = deflateBound(&stream, UInt(data.count))
+    var output = [UInt8](repeating: 0, count: Int(bufferSize))
+
+    data.withUnsafeBufferPointer { inputPtr in
+        stream.next_in = UnsafeMutablePointer(mutating: inputPtr.baseAddress!)
+        stream.avail_in = uInt(data.count)
+
+        output.withUnsafeMutableBufferPointer { outputPtr in
+            stream.next_out = outputPtr.baseAddress!
+            stream.avail_out = uInt(outputPtr.count)
+            deflate(&stream, Z_FINISH)
+        }
+    }
+
+    let compressedSize = Int(stream.total_out)
+    deflateEnd(&stream)
+    return Array(output.prefix(compressedSize))
+}
+
 // MARK: - Main
 
 let datasetPath = ProcessInfo.processInfo.environment["DATASET_PATH"] ?? "/data/dataset.json"
@@ -217,8 +246,8 @@ app.http.server.configuration.hostname = "0.0.0.0"
 app.http.server.configuration.port = 8080
 app.http.server.configuration.serverName = "vapor"
 
-// Enable response compression
-app.http.server.configuration.responseCompression = .enabled
+// Note: NOT using Vapor's built-in responseCompression (.enabled uses zlib level 6).
+// The /compression endpoint handles gzip manually at level 1 per spec.
 
 // Routes
 
@@ -275,12 +304,14 @@ app.get("json") { req -> Response in
     return Response(status: .ok, headers: headers, body: .init(data: Data(jsonBytes)))
 }
 
-// GET /compression
+// GET /compression — manual gzip at level 1 (spec requirement)
 app.get("compression") { req -> Response in
+    let compressed = gzipCompress(state.jsonLargeCache, level: 1)
     var headers = HTTPHeaders()
     headers.add(name: .contentType, value: "application/json")
+    headers.add(name: .contentEncoding, value: "gzip")
     headers.add(name: "server", value: "vapor")
-    return Response(status: .ok, headers: headers, body: .init(data: Data(state.jsonLargeCache)))
+    return Response(status: .ok, headers: headers, body: .init(data: Data(compressed)))
 }
 
 // POST /upload


### PR DESCRIPTION
## Summary

Fixes #111 — Vapor's built-in `responseCompression = .enabled` delegates to NIO's `HTTPResponseCompressor` which initializes zlib with `Z_DEFAULT_COMPRESSION` (level 6). The spec requires level 1.

## Changes

- **Bypass Vapor's built-in compression** — removed `app.http.server.configuration.responseCompression = .enabled`
- **Manual gzip at level 1** — added `gzipCompress()` helper using zlib's `deflateInit2` with `Z_BEST_SPEED` (level 1)
- **CZlib system library module** — wraps the system zlib header for Swift access
- **Per-request compression** — `/compression` endpoint gzips the large payload on every request and sets `Content-Encoding: gzip` explicitly

Same pattern as PR #109 (vertx gzip fix) — NIO's API doesn't expose the compression level, so we go directly to zlib.

## Files changed

- `frameworks/vapor/src/main.swift` — import CZlib, add gzipCompress() helper, update /compression handler
- `frameworks/vapor/Package.swift` — add CZlib system library target
- `frameworks/vapor/Sources/CZlib/` — module.modulemap + shim.h wrapping zlib.h
- `frameworks/vapor/Dockerfile` — add zlib1g-dev (build) and zlib1g (runtime)