### PR TITLE
fix(hummingbird): use gzip level 1 (BEST_SPEED) for compression endpoint

### DIFF
--- a/frameworks/hummingbird/src/main.swift
+++ b/frameworks/hummingbird/src/main.swift
@@ -209,7 +209,7 @@ let state = AppState(
 let router = Router()
 
 // Add response compression (only activates when client sends accept-encoding)
-router.middlewares.add(ResponseCompressionMiddleware(minimumResponseSizeToCompress: 512))
+router.middlewares.add(ResponseCompressionMiddleware(minimumResponseSizeToCompress: 512, zlibCompressionLevel: .fastestCompression))
 
 // Server header middleware
 struct ServerHeaderMiddleware<Context: RequestContext>: RouterMiddleware {


### PR DESCRIPTION
Passes `.fastestCompression` (zlib level 1) to `ResponseCompressionMiddleware` instead of the default `.defaultCompressionLevel` which maps to `Z_DEFAULT_COMPRESSION` (level 6).

One-line fix — the hummingbird-compression package already exposes this parameter, it just wasn't being set.

Fixes #113