### PR TITLE
fix(phoenix): use gzip level 1 (BEST_SPEED) for compression endpoint

### DIFF
--- a/frameworks/phoenix/lib/httparena_phoenix/bench_controller.ex
+++ b/frameworks/phoenix/lib/httparena_phoenix/bench_controller.ex
@@ -61,7 +61,11 @@ defmodule HttparenaPhoenix.BenchController do
 
   def compression(conn, _params) do
     json_large_cache = :persistent_term.get(:json_large_cache)
-    compressed = :zlib.gzip(json_large_cache)
+    z = :zlib.open()
+    :ok = :zlib.deflateInit(z, 1, :deflated, 31, 8, :default)
+    compressed = IO.iodata_to_binary(:zlib.deflate(z, json_large_cache, :finish))
+    :zlib.deflateEnd(z)
+    :zlib.close(z)
 
     conn
     |> put_resp_header("server", "phoenix")


### PR DESCRIPTION
Replace `:zlib.gzip/1` (which uses `Z_DEFAULT_COMPRESSION` = level 6) with explicit `deflateInit` using level 1 and window bits 31 (gzip format).

`:zlib.gzip/1` doesn't accept a compression level parameter, so we use the lower-level `deflateInit/deflate/deflateEnd` API instead. The zlib stream is opened, used, and closed per-request.

Fixes #114