### PR TITLE
fix(gleam-mist): use gzip level 1 (BEST_SPEED) for compression endpoint

### DIFF
--- a/frameworks/gleam-mist/src/bench_zlib.erl
+++ b/frameworks/gleam-mist/src/bench_zlib.erl
@@ -1,0 +1,10 @@
+-module(bench_zlib).
+-export([gzip_level1/1]).
+
+gzip_level1(Data) ->
+    Z = zlib:open(),
+    ok = zlib:deflateInit(Z, 1, deflated, 31, 8, default),
+    Compressed = zlib:deflate(Z, Data, finish),
+    ok = zlib:deflateEnd(Z),
+    zlib:close(Z),
+    iolist_to_binary(Compressed).

--- a/frameworks/gleam-mist/src/httparena_gleam_mist.gleam
+++ b/frameworks/gleam-mist/src/httparena_gleam_mist.gleam
@@ -220,10 +220,10 @@ fn get_query_float(
 }
 
 // ---------------------------------------------------------------------------
-// Erlang zlib FFI for gzip compression
+// Erlang zlib FFI for gzip compression (level 1 = BEST_SPEED)
 // ---------------------------------------------------------------------------
 
-@external(erlang, "zlib", "gzip")
+@external(erlang, "bench_zlib", "gzip_level1")
 fn gzip(data: BitArray) -> BitArray
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #117

## What

Replace `:zlib.gzip/1` (which uses `Z_DEFAULT_COMPRESSION` = level 6) with a custom Erlang FFI module (`bench_zlib`) that calls `deflateInit2` with level 1 and window bits 31 (gzip format).

## Changes

- **New file:** `src/bench_zlib.erl` — Erlang NIF that opens a zlib stream with level 1 (`Z_BEST_SPEED`), deflates, and returns the gzip binary
- **Updated:** `src/httparena_gleam_mist.gleam` — changed the `@external` FFI declaration from `("zlib", "gzip")` to `("bench_zlib", "gzip_level1")`

## Context

Same underlying issue as Phoenix (#114/#116), Hummingbird (#113/#115), Vapor (#111/#112), and Vert.x (#108/#109) — Erlang's `:zlib.gzip/1` doesn't expose a compression level parameter, so it defaults to level 6.

Per-request compression, no caching — zlib stream is opened, used, and closed for each request.