### PR TITLE
fix(blitz): per-request JSON/compression, remove upload fallback and db cache

### DIFF
--- a/frameworks/blitz/src/main.zig
+++ b/frameworks/blitz/src/main.zig
@@ -605,7 +605,7 @@ fn buildCompressionJsonBody(items: []const DatasetItem) []const u8 {
         json_buf.appendSlice(",\"price\":") catch {};
         writeFloatToList(&json_buf, item.price);
 
-        var qty_buf: [32]u8 = undefined;
+        var qty_buf: [128]u8 = undefined;
         const qty_s = std.fmt.bufPrint(&qty_buf, ",\"quantity\":{d},\"active\":{s},\"tags\":", .{
             item.quantity,
             if (item.active) "true" else "false",
@@ -616,7 +616,7 @@ fn buildCompressionJsonBody(items: []const DatasetItem) []const u8 {
 
         json_buf.appendSlice(",\"rating\":{\"score\":") catch {};
         writeFloatToList(&json_buf, item.rating_score);
-        var rc_buf: [32]u8 = undefined;
+        var rc_buf: [64]u8 = undefined;
         const rc_s = std.fmt.bufPrint(&rc_buf, ",\"count\":{d}}},\"total\":", .{item.rating_count}) catch continue;
         json_buf.appendSlice(rc_s) catch {};
         writeFloatToList(&json_buf, total);


### PR DESCRIPTION
Addresses all four blitz audit issues from @jerrythetruckdriver:

## Fixes

### #119 — /json pre-computes totals at startup
- Dataset items are now parsed into a structured `DatasetItem` array at startup (fields only)
- On every `GET /json` request, we iterate all 50 items, compute `total = price × quantity` per-request, and serialize to JSON
- No more pre-built response cache

### #120 — /upload returns Content-Length instead of reading body
- Removed the `content_length` fallback path
- Handler now only returns the actual body length when the body has been fully read
- Returns `0` if no body available (no cheating via headers)

### #121 — /db caches response for default query params
- Removed `db_default_resp` and `initDbCache()` entirely
- Every `/db` request now executes the SQLite query regardless of params

### #122 — /compression uses default gzip level (~6) instead of level 1
- Compression is now done **per-request** with `.level = .best_speed` (gzip level 1)
- The JSON body for the large dataset is still pre-serialized at startup (spec allows this — only the gzip compression must happen per-request)
- Removed all pre-compressed response caching

Thanks jerry for the thorough audit 🙏