### PR TITLE
fix(ktor): gzip level 1 instead of default level 6

### DIFF
--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -16,6 +16,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.sql.Connection
 import java.sql.DriverManager
+import java.util.zip.Deflater
 import java.util.zip.GZIPOutputStream
 
 @Serializable
@@ -140,7 +141,9 @@ object AppData {
 
     fun gzipCompress(data: ByteArray): ByteArray {
         val bos = ByteArrayOutputStream(data.size / 4)
-        GZIPOutputStream(bos).use { it.write(data) }
+        object : GZIPOutputStream(bos) {
+            init { def.setLevel(Deflater.BEST_SPEED) }
+        }.use { it.write(data) }
         return bos.toByteArray()
     }
 }


### PR DESCRIPTION
Sets `Deflater.BEST_SPEED` (level 1) for gzip compression on `/compression` endpoint, matching the HttpArena test requirement.

The default `GZIPOutputStream` constructor uses `Deflater.DEFAULT_COMPRESSION` (level 6). This fix overrides it to level 1 via the `def` field.

Closes #107