### PR TITLE
fix(actix): use gzip level 1 instead of default level 6

### DIFF
--- a/frameworks/actix/Cargo.toml
+++ b/frameworks/actix/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 num_cpus = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }
+flate2 = "1"
 
 [profile.release]
 opt-level = 3

--- a/frameworks/actix/src/main.rs
+++ b/frameworks/actix/src/main.rs
@@ -220,10 +220,19 @@ async fn json_endpoint(state: web::Data<Arc<AppState>>) -> HttpResponse {
 }
 
 async fn compression(state: web::Data<Arc<AppState>>) -> HttpResponse {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    encoder.write_all(&state.json_large_cache).unwrap();
+    let compressed = encoder.finish().unwrap();
+
     HttpResponse::Ok()
         .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Content-Encoding", "gzip"))
         .insert_header(("Server", "actix"))
-        .body(state.json_large_cache.clone())
+        .body(compressed)
 }
 
 async fn db_endpoint(req: HttpRequest, db: web::Data<WorkerDb>) -> HttpResponse {


### PR DESCRIPTION
Fixes #73

actix-web's `Compress::default()` middleware uses gzip level 6, but the benchmark spec requires level 1.

This PR updates the `/compression` handler to manually compress using `flate2::write::GzEncoder` with `Compression::fast()` (level 1) and sets the `Content-Encoding: gzip` header so the Compress middleware skips re-compressing the response.

**Changes:**
- Added `flate2 = "1"` dependency to `frameworks/actix/Cargo.toml`
- Updated the `compression()` handler in `main.rs` to manually gzip at level 1