### PR TITLE
fix(spring-jvm): gzip level 1 instead of default level 6

### DIFF
--- a/frameworks/spring-jvm/src/main/java/com/httparena/BenchmarkController.java
+++ b/frameworks/spring-jvm/src/main/java/com/httparena/BenchmarkController.java
@@ -96,8 +96,17 @@ public class BenchmarkController {
     }
 
     @GetMapping(value = "/compression", produces = MediaType.APPLICATION_JSON_VALUE)
-    public byte[] compression() {
-        return largeJsonResponse;
+    public org.springframework.http.ResponseEntity<byte[]> compression() throws IOException {
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        java.util.zip.GZIPOutputStream gzip = new java.util.zip.GZIPOutputStream(baos) {{
+            def.setLevel(java.util.zip.Deflater.BEST_SPEED);
+        }};
+        gzip.write(largeJsonResponse);
+        gzip.close();
+        return org.springframework.http.ResponseEntity.ok()
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "gzip")
+            .body(baos.toByteArray());
     }
 
     @GetMapping(value = "/json", produces = MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Tomcat doesn't expose a property for compression level, so the `/compression` endpoint was using the default level (~6) instead of level 1.

This updates the compression handler to manually gzip at level 1 (`Deflater.BEST_SPEED`) and return pre-compressed bytes with the `Content-Encoding: gzip` header, so Tomcat skips re-compressing.

Fixes #91