### PR TITLE
Ruby: Ignore obsolete regexp

### DIFF
--- a/frameworks/rails/app/controllers/benchmark_controller.rb
+++ b/frameworks/rails/app/controllers/benchmark_controller.rb
@@ -32,11 +32,11 @@ class BenchmarkController < ActionController::API
   def baseline11
     total = 0
     request.query_parameters.each_value do |v|
-      total += v.to_i if v =~ /\A-?\d+\z/
+      total += v.to_i
     end
     if request.post?
       body_str = request.body.read.to_s.strip
-      total += body_str.to_i if body_str =~ /\A-?\d+\z/
+      total += body_str.to_i
     end
     response.headers['Server'] = 'rails'
     render plain: total.to_s
@@ -45,7 +45,7 @@ class BenchmarkController < ActionController::API
   def baseline2
     total = 0
     request.query_parameters.each_value do |v|
-      total += v.to_i if v =~ /\A-?\d+\z/
+      total += v.to_i
     end
     response.headers['Server'] = 'rails'
     render plain: total.to_s

--- a/frameworks/sinatra/app.rb
+++ b/frameworks/sinatra/app.rb
@@ -59,12 +59,12 @@ class App < Sinatra::Base
   def handle_baseline11
     total = 0
     request.GET.each do |_k, v|
-      total += v.to_i if v =~ /\A-?\d+\z/
+      total += v.to_i
     end
     if request.post?
       request.body.rewind
       body_str = request.body.read.strip
-      total += body_str.to_i if body_str =~ /\A-?\d+\z/
+      total += body_str.to_i
     end
     content_type 'text/plain'
     headers 'Server' => 'sinatra'


### PR DESCRIPTION
`String#to_i` already returns `0` if a String can't be converted to an Integer.