### PR TITLE
fix(run.sh): mount benchmark.db for frameworks with mixed test

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -74,6 +74,15 @@ if has_test "compression"; then
     docker_args+=(-v "$DATA_DIR/dataset-large.json:/data/dataset-large.json:ro")
 fi
 
+if has_test "db"; then
+    DB_FILE="$DATA_DIR/benchmark.db"
+    if [ ! -f "$DB_FILE" ]; then
+        echo "[db] benchmark.db not found, generating..."
+        python3 "$SCRIPT_DIR/generate-db.py" "$DATA_DIR/dataset.json" "$DB_FILE"
+    fi
+    docker_args+=(-v "$DB_FILE:/data/benchmark.db:ro")
+fi
+
 if has_test "static-h2" || has_test "static-h3"; then
     docker_args+=(-v "$DATA_DIR/static:/data/static:ro")
 fi


### PR DESCRIPTION
Adds SQLite database mounting to `run.sh` for frameworks that subscribe to the `mixed` test.

If `data/benchmark.db` doesn't exist yet, the script auto-generates it via `generate-db.py` before starting the container.

Follow-up from @joanhey's feedback on #161 — frameworks with the `mixed` endpoint need the database file mounted to work properly during manual testing.

**Changes:**
- Check if framework subscribes to `mixed` test
- Generate `benchmark.db` if missing (using existing `generate-db.py`)
- Mount at `/data/benchmark.db:ro` in the container