### PR TITLE
ci: bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -26,7 +26,7 @@ jobs:
   benchmark:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ inputs.pr }}/head
           fetch-depth: 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
   benchmark:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -40,7 +40,7 @@ jobs:
           hugo --minify --baseURL "https://MDA2AV.github.io/HttpArena/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site/public
 

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.issue.pull_request && (contains(github.event.comment.body, '/validate') || contains(github.event.comment.body, '/benchmark'))
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       frameworks: ${{ steps.find.outputs.frameworks }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: find
@@ -33,6 +33,6 @@ jobs:
       matrix:
         framework: ${{ fromJson(needs.detect.outputs.frameworks) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate ${{ matrix.framework }}
         run: ./scripts/validate.sh "${{ matrix.framework }}"


### PR DESCRIPTION
Bumps GitHub Actions to versions that support Node.js 24, resolving the deprecation warning.

**Changes:**
- `actions/checkout` v4 → v5 (Node 24 support)
- `actions/upload-pages-artifact` v3 → v4 (Node 24 support)

All other actions (`setup-go@v5`, `deploy-pages@v4`) already use Node 24 compatible versions.

Fixes #170