### PR TITLE
Rails: remove logger

### DIFF
--- a/frameworks/rails/config/application.rb
+++ b/frameworks/rails/config/application.rb
@@ -49,6 +49,6 @@ class BenchmarkApp < Rails::Application
   }
 
   # Silence logging
-  config.logger = Logger.new('/dev/null')
+  config.logger = nil
   config.log_level = :fatal
 end


### PR DESCRIPTION
Instead of having a nil logger, unset the logger.