### PR TITLE
Sticky floating header for leaderboard tables

### DIFF
--- a/site/layouts/shortcodes/leaderboard-composite.html
+++ b/site/layouts/shortcodes/leaderboard-composite.html
@@ -148,6 +148,8 @@ html.dark .composite-disclaimer { color: #fff !important; background: rgba(234,1
   </div>
 </div>
 
+<div class="lb-header-floating" id="lb-floating-header-composite"></div>
+
 <script>
 (function() {
 var currentEntries = compositeEntries;
@@ -655,6 +657,35 @@ document.querySelectorAll('.composite-type-filter').forEach(function(btn) {
     renderComposite();
   });
 });
+
+/* Floating header on scroll */
+var floaterComp = document.getElementById('lb-floating-header-composite');
+var lastHeaderComp = null;
+function updateFloatingHeaderComp() {
+  var table = document.getElementById('composite-table');
+  var header = table ? table.querySelector('.lb-row.lb-header') : null;
+  if (!header) { floaterComp.style.display = 'none'; return; }
+  var tableRect = table.getBoundingClientRect();
+  var headerRect = header.getBoundingClientRect();
+  var nav = document.querySelector('nav');
+  var navHeight = nav ? nav.getBoundingClientRect().bottom : 64;
+  if (headerRect.bottom < navHeight && tableRect.bottom > navHeight + 60) {
+    if (lastHeaderComp !== header || floaterComp.style.display === 'none') {
+      floaterComp.innerHTML = '';
+      floaterComp.appendChild(header.cloneNode(true));
+      lastHeaderComp = header;
+    }
+    floaterComp.style.left = tableRect.left + 'px';
+    floaterComp.style.width = tableRect.width + 'px';
+    floaterComp.style.display = 'block';
+  } else {
+    floaterComp.style.display = 'none';
+    lastHeaderComp = null;
+  }
+}
+window.addEventListener('scroll', updateFloatingHeaderComp, { passive: true });
+new MutationObserver(function() { lastHeaderComp = null; updateFloatingHeaderComp(); })
+  .observe(document.getElementById('composite-table'), { childList: true });
 
 })();
 </script>

--- a/site/layouts/shortcodes/leaderboard-grpc.html
+++ b/site/layouts/shortcodes/leaderboard-grpc.html
@@ -161,6 +161,8 @@ var lbGrpcProfiles = {{ $profiles | jsonify | safeJS }};
 </div>
 {{ end }}
 
+<div class="lb-header-floating" id="lb-floating-header-grpc"></div>
+
 <style>
 .lb-panel-grpc { display: none; }
 .lb-panel-grpc.active { display: block; margin-top: 1rem; }
@@ -556,5 +558,40 @@ window.addEventListener('roundChanged', function(ev) {
   });
 });
 applyFilters();
+
+/* Floating header on scroll */
+var floaterGrpc = document.getElementById('lb-floating-header-grpc');
+var lastHeaderGrpc = null;
+function updateFloatingHeaderGrpc() {
+  var activePanel = w.querySelector('.lb-panel-grpc.active');
+  if (!activePanel) { floaterGrpc.style.display = 'none'; return; }
+  var activeConn = activePanel.querySelector('.lb-conn-panel-grpc.active');
+  if (!activeConn) { floaterGrpc.style.display = 'none'; return; }
+  var header = activeConn.querySelector('.lb-row.lb-header');
+  if (!header) { floaterGrpc.style.display = 'none'; return; }
+  var lb = activeConn.querySelector('.lb');
+  var lbRect = lb.getBoundingClientRect();
+  var headerRect = header.getBoundingClientRect();
+  var nav = document.querySelector('nav');
+  var navHeight = nav ? nav.getBoundingClientRect().bottom : 64;
+  if (headerRect.bottom < navHeight && lbRect.bottom > navHeight + 60) {
+    if (lastHeaderGrpc !== header) {
+      floaterGrpc.innerHTML = '';
+      floaterGrpc.appendChild(header.cloneNode(true));
+      lastHeaderGrpc = header;
+    }
+    floaterGrpc.style.left = lbRect.left + 'px';
+    floaterGrpc.style.width = lbRect.width + 'px';
+    floaterGrpc.style.display = 'block';
+  } else {
+    floaterGrpc.style.display = 'none';
+    lastHeaderGrpc = null;
+  }
+}
+window.addEventListener('scroll', updateFloatingHeaderGrpc, { passive: true });
+var obsGrpc = new MutationObserver(function() { lastHeaderGrpc = null; updateFloatingHeaderGrpc(); });
+w.querySelectorAll('.lb-panel-grpc, .lb-conn-panel-grpc').forEach(function(el) {
+  obsGrpc.observe(el, { attributes: true, attributeFilter: ['class'] });
+});
 })();
 </script>

--- a/site/layouts/shortcodes/leaderboard-h2.html
+++ b/site/layouts/shortcodes/leaderboard-h2.html
@@ -161,6 +161,8 @@ var lbH2Profiles = {{ $profiles | jsonify | safeJS }};
 </div>
 {{ end }}
 
+<div class="lb-header-floating" id="lb-floating-header-h2"></div>
+
 <style>
 .lb-panel-h2 { display: none; }
 .lb-panel-h2.active { display: block; margin-top: 1rem; }
@@ -556,5 +558,40 @@ window.addEventListener('roundChanged', function(ev) {
   });
 });
 applyFilters();
+
+/* Floating header on scroll */
+var floaterH2 = document.getElementById('lb-floating-header-h2');
+var lastHeaderH2 = null;
+function updateFloatingHeaderH2() {
+  var activePanel = w.querySelector('.lb-panel-h2.active');
+  if (!activePanel) { floaterH2.style.display = 'none'; return; }
+  var activeConn = activePanel.querySelector('.lb-conn-panel-h2.active');
+  if (!activeConn) { floaterH2.style.display = 'none'; return; }
+  var header = activeConn.querySelector('.lb-row.lb-header');
+  if (!header) { floaterH2.style.display = 'none'; return; }
+  var lb = activeConn.querySelector('.lb');
+  var lbRect = lb.getBoundingClientRect();
+  var headerRect = header.getBoundingClientRect();
+  var nav = document.querySelector('nav');
+  var navHeight = nav ? nav.getBoundingClientRect().bottom : 64;
+  if (headerRect.bottom < navHeight && lbRect.bottom > navHeight + 60) {
+    if (lastHeaderH2 !== header) {
+      floaterH2.innerHTML = '';
+      floaterH2.appendChild(header.cloneNode(true));
+      lastHeaderH2 = header;
+    }
+    floaterH2.style.left = lbRect.left + 'px';
+    floaterH2.style.width = lbRect.width + 'px';
+    floaterH2.style.display = 'block';
+  } else {
+    floaterH2.style.display = 'none';
+    lastHeaderH2 = null;
+  }
+}
+window.addEventListener('scroll', updateFloatingHeaderH2, { passive: true });
+var obsH2 = new MutationObserver(function() { lastHeaderH2 = null; updateFloatingHeaderH2(); });
+w.querySelectorAll('.lb-panel-h2, .lb-conn-panel-h2').forEach(function(el) {
+  obsH2.observe(el, { attributes: true, attributeFilter: ['class'] });
+});
 })();
 </script>

--- a/site/layouts/shortcodes/leaderboard-h3.html
+++ b/site/layouts/shortcodes/leaderboard-h3.html
@@ -168,6 +168,8 @@ html.dark .h3-disclaimer { color: #fff !important; background: rgba(234,179,8,0.
 </div>
 {{ end }}
 
+<div class="lb-header-floating" id="lb-floating-header-h3"></div>
+
 <style>
 .lb-panel-h3 { display: none; }
 .lb-panel-h3.active { display: block; margin-top: 1rem; }
@@ -563,5 +565,40 @@ window.addEventListener('roundChanged', function(ev) {
   });
 });
 applyFilters();
+
+/* Floating header on scroll */
+var floaterH3 = document.getElementById('lb-floating-header-h3');
+var lastHeaderH3 = null;
+function updateFloatingHeaderH3() {
+  var activePanel = w.querySelector('.lb-panel-h3.active');
+  if (!activePanel) { floaterH3.style.display = 'none'; return; }
+  var activeConn = activePanel.querySelector('.lb-conn-panel-h3.active');
+  if (!activeConn) { floaterH3.style.display = 'none'; return; }
+  var header = activeConn.querySelector('.lb-row.lb-header');
+  if (!header) { floaterH3.style.display = 'none'; return; }
+  var lb = activeConn.querySelector('.lb');
+  var lbRect = lb.getBoundingClientRect();
+  var headerRect = header.getBoundingClientRect();
+  var nav = document.querySelector('nav');
+  var navHeight = nav ? nav.getBoundingClientRect().bottom : 64;
+  if (headerRect.bottom < navHeight && lbRect.bottom > navHeight + 60) {
+    if (lastHeaderH3 !== header) {
+      floaterH3.innerHTML = '';
+      floaterH3.appendChild(header.cloneNode(true));
+      lastHeaderH3 = header;
+    }
+    floaterH3.style.left = lbRect.left + 'px';
+    floaterH3.style.width = lbRect.width + 'px';
+    floaterH3.style.display = 'block';
+  } else {
+    floaterH3.style.display = 'none';
+    lastHeaderH3 = null;
+  }
+}
+window.addEventListener('scroll', updateFloatingHeaderH3, { passive: true });
+var obsH3 = new MutationObserver(function() { lastHeaderH3 = null; updateFloatingHeaderH3(); });
+w.querySelectorAll('.lb-panel-h3, .lb-conn-panel-h3').forEach(function(el) {
+  obsH3.observe(el, { attributes: true, attributeFilter: ['class'] });
+});
 })();
 </script>

--- a/site/layouts/shortcodes/leaderboard-ws.html
+++ b/site/layouts/shortcodes/leaderboard-ws.html
@@ -160,6 +160,8 @@ var lbWsProfiles = {{ $profiles | jsonify | safeJS }};
 </div>
 {{ end }}
 
+<div class="lb-header-floating" id="lb-floating-header-ws"></div>
+
 <style>
 .lb-panel-ws { display: none; }
 .lb-panel-ws.active { display: block; margin-top: 1rem; }
@@ -555,5 +557,40 @@ window.addEventListener('roundChanged', function(ev) {
   });
 });
 applyFilters();
+
+/* Floating header on scroll */
+var floaterWs = document.getElementById('lb-floating-header-ws');
+var lastHeaderWs = null;
+function updateFloatingHeaderWs() {
+  var activePanel = w.querySelector('.lb-panel-ws.active');
+  if (!activePanel) { floaterWs.style.display = 'none'; return; }
+  var activeConn = activePanel.querySelector('.lb-conn-panel-ws.active');
+  if (!activeConn) { floaterWs.style.display = 'none'; return; }
+  var header = activeConn.querySelector('.lb-row.lb-header');
+  if (!header) { floaterWs.style.display = 'none'; return; }
+  var lb = activeConn.querySelector('.lb');
+  var lbRect = lb.getBoundingClientRect();
+  var headerRect = header.getBoundingClientRect();
+  var nav = document.querySelector('nav');
+  var navHeight = nav ? nav.getBoundingClientRect().bottom : 64;
+  if (headerRect.bottom < navHeight && lbRect.bottom > navHeight + 60) {
+    if (lastHeaderWs !== header) {
+      floaterWs.innerHTML = '';
+      floaterWs.appendChild(header.cloneNode(true));
+      lastHeaderWs = header;
+    }
+    floaterWs.style.left = lbRect.left + 'px';
+    floaterWs.style.width = lbRect.width + 'px';
+    floaterWs.style.display = 'block';
+  } else {
+    floaterWs.style.display = 'none';
+    lastHeaderWs = null;
+  }
+}
+window.addEventListener('scroll', updateFloatingHeaderWs, { passive: true });
+var obsWs = new MutationObserver(function() { lastHeaderWs = null; updateFloatingHeaderWs(); });
+w.querySelectorAll('.lb-panel-ws, .lb-conn-panel-ws').forEach(function(el) {
+  obsWs.observe(el, { attributes: true, attributeFilter: ['class'] });
+});
 })();
 </script>

--- a/site/layouts/shortcodes/leaderboard.html
+++ b/site/layouts/shortcodes/leaderboard.html
@@ -288,6 +288,12 @@ html.dark .lb-popup-link { color: #60a5fa; }
   border-bottom: 2px solid #e5e7eb;
   padding-bottom: 0.4rem; border-radius: 0;
 }
+.lb-header-floating {
+  position: fixed; top: var(--navbar-height, 4rem); z-index: 9999;
+  background: #fff; box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  display: none;
+}
+html.dark .lb-header-floating { background: #0d1117; box-shadow: 0 2px 8px rgba(0,0,0,0.4); }
 .lb-rank { font-weight: 400; font-size: 0.85rem; color: #000; }
 .lb-name { font-weight: 400; font-size: 0.8rem; color: #000; text-transform: lowercase; }
 .lb-lang { font-size: 0.8rem; color: #000; }
@@ -566,6 +572,8 @@ var lbProfiles = {{ $profiles | jsonify | safeJS }};
 
 </div>
 {{ end }}
+
+<div class="lb-header-floating" id="lb-floating-header"></div>
 
 <script>
 var barClasses = ['lb-bar-1', 'lb-bar-2', 'lb-bar-3', 'lb-bar-4', 'lb-bar-5'];
@@ -1366,4 +1374,50 @@ function applyMixedScores() {
   });
 }
 applyFilters();
+
+/* Floating header on scroll */
+(function() {
+  var floater = document.getElementById('lb-floating-header');
+  var lastHeader = null;
+
+  function updateFloatingHeader() {
+    var activePanel = document.querySelector('.lb-panel.active');
+    if (!activePanel) { floater.style.display = 'none'; return; }
+    var activeConn = activePanel.querySelector('.lb-conn-panel.active');
+    if (!activeConn) { floater.style.display = 'none'; return; }
+    var header = activeConn.querySelector('.lb-row.lb-header');
+    if (!header) { floater.style.display = 'none'; return; }
+
+    var lb = activeConn.querySelector('.lb');
+    var lbRect = lb.getBoundingClientRect();
+    var headerRect = header.getBoundingClientRect();
+
+    /* Show floating header when the real header scrolls above the navbar
+       and the table bottom is still visible */
+    var nav = document.querySelector('nav');
+    var navHeight = nav ? nav.getBoundingClientRect().bottom : 64;
+    if (headerRect.bottom < navHeight && lbRect.bottom > navHeight + 60) {
+      if (lastHeader !== header) {
+        floater.innerHTML = '';
+        var clone = header.cloneNode(true);
+        floater.appendChild(clone);
+        lastHeader = header;
+      }
+      floater.style.left = lbRect.left + 'px';
+      floater.style.width = lbRect.width + 'px';
+      floater.style.display = 'block';
+    } else {
+      floater.style.display = 'none';
+      lastHeader = null;
+    }
+  }
+
+  window.addEventListener('scroll', updateFloatingHeader, { passive: true });
+
+  /* Reset when switching tabs/connections */
+  var observer = new MutationObserver(function() { lastHeader = null; updateFloatingHeader(); });
+  document.querySelectorAll('.lb-panel, .lb-conn-panel').forEach(function(el) {
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] });
+  });
+})();
 </script>


### PR DESCRIPTION
## Summary
- Adds a floating header row that sticks below the navbar when scrolling through leaderboard tables
- Header clones the active table's column layout and matches its exact width/position
- Automatically hides when scrolling back up or past the table bottom
- Resets on tab/connection switches via MutationObserver
- Applied to all 6 leaderboard templates: HTTP/1.1, H2, H3, gRPC, WebSocket, and Composite
- Supports both light and dark mode

## Test plan
- [x] Scroll down any leaderboard table — header should float below the navbar
- [x] Switch profile tabs / connection counts — floating header should update
- [x] Verify column alignment matches the real table header exactly
- [x] Test in dark mode
- [x] Test composite leaderboard with type filter switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)