### PR TITLE
docs: implementation rules for realistic benchmarks

### DIFF
--- a/site/content/docs/add-framework/_index.md
+++ b/site/content/docs/add-framework/_index.md
@@ -9,6 +9,7 @@ Adding a framework to HttpArena takes a few steps: create a Dockerfile, add meta
   {{< card link="directory-structure" title="Directory Structure" subtitle="How to organize your framework's files — Dockerfile, meta.json, and source code." icon="folder" >}}
   {{< card link="test-profiles" title="Test Profiles" subtitle="All HTTP endpoints your framework must implement, organized by test profile." icon="code" >}}
   {{< card link="meta-json" title="meta.json" subtitle="Framework metadata — display name, language, type, and which tests to participate in." icon="document-text" >}}
+  {{< card link="implementation-rules" title="Implementation Rules" subtitle="Rules for keeping benchmarks realistic — use framework APIs, production settings only, standard libraries." icon="shield-check" >}}
   {{< card link="testing" title="Testing & Submitting" subtitle="How to validate your implementation locally and submit a pull request." icon="check-circle" >}}
   {{< card link="ci" title="CI & Runner" subtitle="GitHub Actions workflows and the self-hosted benchmark runner." icon="cog" >}}
 {{< /cards >}}

--- a/site/content/docs/add-framework/implementation-rules.md
+++ b/site/content/docs/add-framework/implementation-rules.md
@@ -1,0 +1,79 @@
+---
+title: Implementation Rules
+weight: 5
+---
+
+These rules exist to keep HttpArena results meaningful and representative of real-world framework performance. They apply to all framework submissions and can be cited during PR reviews.
+
+## Use framework-level APIs
+
+If a framework provides a documented, high-level way to accomplish a task, the benchmark implementation **must** use it.
+
+Don't bypass the framework to hand-roll a faster solution. We're testing frameworks, not testing how clever you are at writing raw socket code.
+
+**Example — route parameter parsing:**
+
+{{< tabs items="Good,Bad" >}}
+
+{{< tab >}}
+```python
+# Use the framework's built-in parameter binding
+@app.get("/baseline")
+def baseline(a: int, b: int):
+    return {"result": a + b}
+```
+{{< /tab >}}
+
+{{< tab >}}
+```python
+# Manually parse query string for speed
+@app.get("/baseline")
+def baseline(request):
+    qs = request.url.query.encode()
+    a = fast_parse_int(qs, b"a=")
+    b = fast_parse_int(qs, b"b=")
+    return custom_json_bytes(a + b)
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+**Why:** People want to see how their framework performs the way they actually use it — with its routing, serialization, and middleware. If the framework's built-in JSON serializer is slow, that's useful signal. Bypassing it hides the truth.
+
+## Settings must be production-documented
+
+Non-default configuration is allowed **only if the framework's official documentation recommends it for production use**. If you can't link to a docs page that says "use this in production," it doesn't belong in the benchmark.
+
+**Allowed:**
+- .NET Server GC ([documented for production workloads](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector))
+- JVM `-server` and ergonomics flags (standard production tuning)
+- Worker/thread counts matching available CPU cores
+
+**Not allowed:**
+- Undocumented flags found by reading framework source code
+- Experimental/unstable options that trade safety for speed
+- Settings that disable buffering, validation, or error handling
+
+**The test:** If a reviewer asks "where's this setting documented?", you should be able to link the official docs within 30 seconds.
+
+## Use standard libraries and drivers
+
+If the ecosystem has a well-established, production-grade library for a task (database driver, JSON serializer, HTTP client), use it. Don't bring an experimental or hand-rolled alternative just because it's faster in microbenchmarks.
+
+**Example:** If every production app in your language uses `libpq` bindings for Postgres, don't swap in an experimental zero-copy driver that nobody ships to production.
+
+**Exception:** If the framework itself bundles or officially recommends a specific library, that's fine to use.
+
+## Deployment-environment tuning is fine
+
+Adapting to the benchmark hardware is normal and expected:
+
+- Setting worker count to match CPU cores
+- Configuring connection pool sizes
+- Adjusting memory limits for the container
+
+This is what every production deployment does. The line is: **adapt to the environment, don't exploit it.**
+
+---
+
+These rules boil down to one principle: **benchmark the framework as people actually use it.** If a real team shipping a production API wouldn't do it, it doesn't belong in HttpArena.


### PR DESCRIPTION
Draft of the implementation rules we discussed in #211.

Adds a new **Implementation Rules** page to the Add a Framework docs with four rules:

1. **Use framework-level APIs** — if the framework provides a high-level way to do something, use it. No bypassing for speed.
2. **Settings must be production-documented** — non-default config is fine only if the official docs recommend it for production. No mystery flags.
3. **Use standard libraries** — production-grade drivers and serializers, not experimental alternatives.
4. **Deployment-environment tuning is fine** — adapting worker counts, pool sizes, memory to the hardware is expected.

Included some good/bad code examples and linked the page from the Add a Framework index.

This is a starting point — figured it's easier to iterate on actual text in a PR than keep discussing in the issue. Happy to adjust the wording, add more examples, or restructure.

Closes #211

cc @Kaliumhexacyanoferrat