### PR TITLE
fix(fiber): use built-in compression middleware instead of manual gzip/deflate

### DIFF
--- a/frameworks/fiber/main.go
+++ b/frameworks/fiber/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"compress/flate"
-	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -16,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "modernc.org/sqlite"
 )
@@ -172,6 +171,12 @@ func main() {
 		BodyLimit:             25 * 1024 * 1024, // 25 MB
 	})
 
+	// Use Fiber's built-in compression middleware globally.
+	// The framework handles Accept-Encoding negotiation and Content-Encoding headers.
+	app.Use(compress.New(compress.Config{
+		Level: compress.LevelBestSpeed,
+	}))
+
 	app.Get("/pipeline", func(c *fiber.Ctx) error {
 		c.Set("Server", "fiber")
 		return c.SendString("ok")
@@ -215,26 +220,6 @@ func main() {
 
 	app.Get("/compression", func(c *fiber.Ctx) error {
 		c.Set("Server", "fiber")
-		ae := c.Get("Accept-Encoding")
-		if strings.Contains(ae, "deflate") {
-			c.Set("Content-Type", "application/json")
-			c.Set("Content-Encoding", "deflate")
-			w, err := flate.NewWriter(c.Response().BodyWriter(), flate.BestSpeed)
-			if err == nil {
-				w.Write(jsonLargeResponse)
-				w.Close()
-			}
-			return nil
-		} else if strings.Contains(ae, "gzip") {
-			c.Set("Content-Type", "application/json")
-			c.Set("Content-Encoding", "gzip")
-			w, err := gzip.NewWriterLevel(c.Response().BodyWriter(), gzip.BestSpeed)
-			if err == nil {
-				w.Write(jsonLargeResponse)
-				w.Close()
-			}
-			return nil
-		}
 		c.Set("Content-Type", "application/json")
 		return c.Send(jsonLargeResponse)
 	})


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `compress/flate` and `compress/gzip` writers in the `/compression` handler with Fiber's built-in [`compress` middleware](https://docs.gofiber.io/api/middleware/compress/).

## What changed

- **Removed:** Manual `Accept-Encoding` parsing, manual `Content-Encoding` header setting, direct `flate.NewWriter` / `gzip.NewWriterLevel` calls
- **Added:** `compress.New(compress.Config{Level: compress.LevelBestSpeed})` applied globally via `app.Use()`
- **Result:** The `/compression` handler just sends the raw JSON payload. Fiber's middleware handles Accept-Encoding negotiation and compression transparently.

## Why

As flagged in #221, the previous implementation bypassed Fiber's documented compression API. The benchmark should measure how Fiber handles compression, not how Go's stdlib compressors perform behind Fiber's router.

## Impact on other endpoints

None — gcannon doesn't send `Accept-Encoding` headers by default, so baseline, json, upload, db, etc. won't be compressed. Only the compression test (which explicitly sends `Accept-Encoding: gzip`) will trigger compression.

Fixes #221