### PR TITLE
fix(echo): use built-in compression middleware instead of manual gzip/deflate

### DIFF
--- a/frameworks/echo/main.go
+++ b/frameworks/echo/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"compress/flate"
-	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -18,6 +16,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	_ "modernc.org/sqlite"
 )
 
@@ -172,6 +171,10 @@ func main() {
 	e.HideBanner = true
 	e.HidePort = true
 
+	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
+		Level: 1,
+	}))
+
 	e.GET("/pipeline", func(c echo.Context) error {
 		c.Response().Header().Set("Server", "echo")
 		return c.String(http.StatusOK, "ok")
@@ -214,28 +217,6 @@ func main() {
 
 	e.GET("/compression", func(c echo.Context) error {
 		c.Response().Header().Set("Server", "echo")
-		ae := c.Request().Header.Get("Accept-Encoding")
-		if strings.Contains(ae, "deflate") {
-			c.Response().Header().Set("Content-Type", "application/json")
-			c.Response().Header().Set("Content-Encoding", "deflate")
-			c.Response().WriteHeader(http.StatusOK)
-			w, err := flate.NewWriter(c.Response(), flate.BestSpeed)
-			if err == nil {
-				w.Write(jsonLargeResponse)
-				w.Close()
-			}
-			return nil
-		} else if strings.Contains(ae, "gzip") {
-			c.Response().Header().Set("Content-Type", "application/json")
-			c.Response().Header().Set("Content-Encoding", "gzip")
-			c.Response().WriteHeader(http.StatusOK)
-			w, err := gzip.NewWriterLevel(c.Response(), gzip.BestSpeed)
-			if err == nil {
-				w.Write(jsonLargeResponse)
-				w.Close()
-			}
-			return nil
-		}
 		return c.Blob(http.StatusOK, "application/json", jsonLargeResponse)
 	})
 


### PR DESCRIPTION
## What

Replaces hand-rolled `compress/gzip` and `compress/flate` writers in the `/compression` endpoint with Echo's built-in `middleware.GzipWithConfig()`.

## Why

Same pattern as #222 (Fiber) — the [implementation rules](https://github.com/MDA2AV/HttpArena/blob/main/CONTRIBUTING.md) require using framework-level APIs when available. Echo provides [`middleware.Gzip`](https://echo.labstack.com/docs/middleware/gzip) out of the box, so we should use it instead of hand-rolling compression.

## Changes

- Register `middleware.GzipWithConfig(middleware.GzipConfig{Level: 1})` globally
- Simplify `/compression` handler to just serve the JSON blob — the middleware handles encoding negotiation and compression automatically
- Remove unused `compress/flate` and `compress/gzip` imports

**Note:** Echo's built-in middleware only supports gzip (not deflate). Since gcannon sends `Accept-Encoding: gzip, deflate` and gzip takes priority, this shouldn't affect benchmark results. The middleware short-circuits on endpoints where no `Accept-Encoding` header is present, so overhead on other tests should be negligible.

Fixes #229