### PR TITLE
Allow Content-Encoding header to have no whitespace

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -318,7 +318,7 @@ if has_test "compression"; then
 
     # Must return Content-Encoding: gzip when Accept-Encoding: gzip is sent
     comp_headers=$(curl -s -D- -o /dev/null -H "Accept-Encoding: gzip" "http://localhost:$PORT/compression")
-    comp_encoding=$(echo "$comp_headers" | grep -i "^content-encoding:" | tr -d '\r' | awk '{print tolower($2)}' || true)
+    comp_encoding=$(echo "$comp_headers" | grep -i "^content-encoding:" | sed 's/^[^:]*: *//' | tr -d '\r' | awk '{print tolower($1)}' || true)
     if [ "$comp_encoding" = "gzip" ]; then
         echo "  PASS [compression Content-Encoding: gzip]"
         PASS=$((PASS + 1))


### PR DESCRIPTION
Some framework return headers without whitespace:

    content-type:application/json
    content-encoding:gzip

The `check_header` method already takes this into account, but the encoding header check does not.