### PR TITLE
add Dart a color, landing page changes

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -22,9 +22,15 @@ layout: hextra-home
 
 <div style="height:20px"></div>
 
+<style>
+.hextra-cards > a:first-child { background: rgba(22,163,74,0.08) !important; border-color: rgba(22,163,74,0.25) !important; }
+.hextra-cards > a:first-child:hover { border-color: rgba(22,163,74,0.5) !important; background: rgba(22,163,74,0.12) !important; }
+html.dark .hextra-cards > a:first-child { background: rgba(22,163,74,0.12) !important; border-color: rgba(22,163,74,0.3) !important; }
+html.dark .hextra-cards > a:first-child:hover { background: rgba(22,163,74,0.18) !important; border-color: rgba(22,163,74,0.5) !important; }
+</style>
+
 {{< cards >}}
   {{< card link="leaderboard" title="Leaderboard" subtitle="See which frameworks handle the most requests per second, ranked by throughput." icon="chart-bar" >}}
-  {{< card link="https://mda2av.github.io/Http11Probe/" title="Compliance & Security" subtitle="HTTP/1.1 compliance testing — RFC conformance, request smuggling vectors, and malformed input handling." icon="shield-check" >}}
   {{< card link="docs/running-locally" title="Run Locally" subtitle="Set up and run the full benchmark suite on your own machine with Docker and gcannon." icon="terminal" >}}
   {{< card link="docs/add-framework" title="Add a Framework" subtitle="Add your framework with a Dockerfile and open a PR. Three steps to join the arena." icon="plus-circle" >}}
 {{< /cards >}}

--- a/site/data/langcolors.json
+++ b/site/data/langcolors.json
@@ -17,5 +17,6 @@
   "Zig":        { "accent": "#f7a41d", "text": "#c47f0a", "textDark": "#f7a41d", "rgb": "247,164,29" },
   "Swift":      { "accent": "#f05138", "text": "#d63d25", "textDark": "#f47b6b", "rgb": "240,81,56" },
   "Elixir":     { "accent": "#6e4a7e", "text": "#5b3a6b", "textDark": "#b07cc6", "rgb": "110,74,126" },
-  "Kotlin":     { "accent": "#7f52ff", "text": "#6538d4", "textDark": "#a48bff", "rgb": "127,82,255" }
+  "Kotlin":     { "accent": "#7f52ff", "text": "#6538d4", "textDark": "#a48bff", "rgb": "127,82,255" },
+  "Dart":       { "accent": "#0175c2", "text": "#01589b", "textDark": "#40c4ff", "rgb": "1,117,194" }
 }

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -19,6 +19,9 @@ menu:
     - name: Knowledge Base
       pageRef: /docs
       weight: 2
+    - name: RFC Compliance
+      weight: 3
+      url: https://mda2av.github.io/Http11Probe/
     - name: Search
       weight: 5
       params:


### PR DESCRIPTION
Dart - Add characteristic blue

Landing page - remove compliance card, change Leaderboard card to stand out as green. Add RFC Compliance link to top bar.

Requested by  @Kaliumhexacyanoferrat 