### PR TITLE
fix: benchmark PR workflow --save scoping

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -56,9 +56,10 @@ jobs:
           cp -r site/data /tmp/main_site_data 2>/dev/null || true
           cp -r /tmp/pr_site_data/* site/data/ 2>/dev/null || true
 
-      - name: Clean previous containers
+      - name: Clean previous containers and stale results
         run: |
           docker ps -aq --filter "name=httparena-" | xargs -r docker rm -f 2>/dev/null || true
+          rm -rf results/
 
       - name: Run benchmarks
         id: bench
@@ -93,11 +94,21 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          find results -name "${{ inputs.framework }}.json" -exec git add -f {} +
           find site/static/logs -name "${{ inputs.framework }}.log" -exec git add -f {} +
           git add -f site/data/frameworks.json site/data/current.json 2>/dev/null || true
-          # Only add leaderboard files that the benchmark actually changed
-          git diff --name-only site/data/ 2>/dev/null | xargs -r git add -f
+          # Only add leaderboard files for the profiles that were actually benchmarked
+          profile="${{ inputs.profile }}"
+          if [ -n "$profile" ]; then
+            git add -f site/data/${profile}-*.json 2>/dev/null || true
+          else
+            for f in results/*/*/${{ inputs.framework }}.json; do
+              [ -f "$f" ] || continue
+              dir=$(dirname "$f")
+              conns=$(basename "$dir")
+              prof=$(basename "$(dirname "$dir")")
+              git add -f "site/data/${prof}-${conns}.json" 2>/dev/null || true
+            done
+          fi
           if git diff --cached --quiet; then
             echo "No results to commit"
           else


### PR DESCRIPTION
## Summary
- Clean stale `results/` before each benchmark run to prevent `rebuild_site_data` from merging old data
- Stop committing `results/` directory (gitignored intermediate files that don't belong in PRs)
- Scope `site/data/` commits to only the profiles that were actually benchmarked

**This must be merged before any `/benchmark --save` will work correctly.**

## Test plan
- [x] Merge this PR
- [x] On PR #339, run `/benchmark -f ringzero -t baseline --save`
- [x] Verify the commit only contains `site/data/baseline-*.json`, `site/data/frameworks.json`, `site/data/current.json`, and ringzero log files

🤖 Generated with [Claude Code](https://claude.com/claude-code)