### PR TITLE
fix: clean stale /tmp artifacts between benchmark runs

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -56,10 +56,11 @@ jobs:
           cp -r site/data /tmp/main_site_data 2>/dev/null || true
           cp -r /tmp/pr_site_data/* site/data/ 2>/dev/null || true
 
-      - name: Clean previous containers and stale results
+      - name: Clean previous containers, results, and temp data
         run: |
           docker ps -aq --filter "name=httparena-" | xargs -r docker rm -f 2>/dev/null || true
           rm -rf results/
+          rm -rf /tmp/pr_site_data /tmp/main_site_data /tmp/bench_site_data /tmp/bench_comparison.md /tmp/bench_body.txt /tmp/bench_full.txt /tmp/bench_table.txt
 
       - name: Run benchmarks
         id: bench


### PR DESCRIPTION
Self-hosted runner persists /tmp between workflow runs. Stale temp data from prior runs leaked different actix/bun values into leaderboard files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)