### PR TITLE
Rage: Fix nil logger by setting environment to production

### DIFF
--- a/frameworks/rage/Dockerfile
+++ b/frameworks/rage/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV RUBY_YJIT_ENABLE=1
-ENV RACK_ENV=production
+ENV RAGE_ENV=production
 
 WORKDIR /app
 


### PR DESCRIPTION
Currently requests still get logged because RACK_ENV is ignored and the
application runs in development environment.
Set RAGE_ENV instead.