### PR TITLE
Sinatra: Read uploaded file in smaller chunks

### DIFF
--- a/frameworks/sinatra/config.ru
+++ b/frameworks/sinatra/config.ru
@@ -30,7 +30,7 @@ class UploadHandler
       input = env['rack.input']
       input.rewind
       bytes = 0
-      while (chunk = input.read(65536))
+      while (chunk = input.read(4096))
         bytes += chunk.bytesize
       end
       [200, { 'content-type' => 'text/plain', 'server' => 'sinatra' }, [bytes.to_s]]


### PR DESCRIPTION
4096 bytes is recommended and what Rails uses as well.