### PR TITLE
[ngx-php] Add upload_tmp_dir configuration to php.ini

### DIFF
--- a/frameworks/ngx-php/php.ini
+++ b/frameworks/ngx-php/php.ini
@@ -7,3 +7,5 @@ opcache.huge_code_pages=1
 memory_limit = 512M
 opcache.jit_buffer_size=128M
 opcache.jit=tracing
+
+upload_tmp_dir = /dev/shm


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger:

| Command | Description |
|---------|-------------|
| `/validate -f <framework>` | Run the 18-point validation suite |
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.
