### PR TITLE
Update to rust:1.94

### DIFF
--- a/frameworks/actix-websocket/Dockerfile
+++ b/frameworks/actix-websocket/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-bookworm AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock* ./

--- a/frameworks/actix/Dockerfile
+++ b/frameworks/actix/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-actix* target/release/deps/httparena_actix*

--- a/frameworks/hyper/Dockerfile
+++ b/frameworks/hyper/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-hyper* target/release/deps/httparena_hyper*

--- a/frameworks/may-minihttp/Dockerfile
+++ b/frameworks/may-minihttp/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-may-minihttp* target/release/deps/httparena_may_minihttp*

--- a/frameworks/ntex-iouring/Dockerfile
+++ b/frameworks/ntex-iouring/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-ntex* target/release/deps/httparena_ntex*

--- a/frameworks/ntex-tokio/Dockerfile
+++ b/frameworks/ntex-tokio/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-ntex-tokio* target/release/deps/httparena_ntex_tokio*

--- a/frameworks/rocket/Dockerfile
+++ b/frameworks/rocket/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-rocket* target/release/deps/httparena_rocket*

--- a/frameworks/rust-epoll/Dockerfile
+++ b/frameworks/rust-epoll/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-rust-epoll* target/release/deps/httparena_rust_epoll*

--- a/frameworks/salvo/Dockerfile
+++ b/frameworks/salvo/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 COPY Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src/ target/release/httparena-salvo* target/release/deps/httparena_salvo*

--- a/frameworks/tonic-grpc/Dockerfile
+++ b/frameworks/tonic-grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-bookworm AS build
+FROM rust:1.94 AS build
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Actually they all use rust:1.88 !!

PD: check, perhaps we need to update dependencies, as they use a .lock file.
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/validate -f <framework>` | Run the 18-point validation suite |
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
