### PR TITLE
Add maintainer

### DIFF
--- a/frameworks/ngx-php/Db.php
+++ b/frameworks/ngx-php/Db.php
@@ -3,30 +3,21 @@
 class Db
 {
     private static ?SQLite3Stmt $prepared = null;
-    private static bool $available = false;
 
     public static function init()
     {
-        if (!file_exists('/data/benchmark.db')) {
-            self::$available = false;
-            return;
-        }
         $db = new Sqlite3('/data/benchmark.db', SQLITE3_OPEN_READONLY);
 
         self::$prepared = $db->prepare('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count
                             FROM items
                             WHERE price BETWEEN ? AND ?
                             LIMIT 50');
-        self::$available = true;
     }
 
     public static function query($min, $max)
     {
-        if (!self::$available) {
-            return '{"items":[],"count":0}';
-        }
-        self::$prepared->bindValue(1, $min, SQLITE3_FLOAT);
-        self::$prepared->bindValue(2, $max, SQLITE3_FLOAT);
+        self::$prepared->bindValue(1, $min);
+        self::$prepared->bindValue(2, $max);
 
         $result = self::$prepared->execute();
 

--- a/frameworks/ngx-php/meta.json
+++ b/frameworks/ngx-php/meta.json
@@ -24,5 +24,5 @@
     "baseline-h2",
     "static-h2"
   ],
-  "maintainers": []
+  "maintainers": ["joanhey"]
 }


### PR DESCRIPTION
Add maintainer and change Benny changes.

## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/validate -f <framework>` | Run the 18-point validation suite |
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
