### PR TITLE
Rage: silence warnings

### DIFF
--- a/frameworks/rage/config/application.rb
+++ b/frameworks/rage/config/application.rb
@@ -11,6 +11,9 @@ end
 
 require "rage/setup"
 
+# Silence warnings
+$VERBOSE = nil
+
 # Monkeypatch the parser to handle a request body that isn't multipart
 Rage::ParamsParser.class_eval do
   def self.prepare(env, url_params)


### PR DESCRIPTION
Silence warnings like:

    /usr/local/bundle/gems/rage-rb-1.22.1/lib/rage/middleware/fiber_wrapper.rb:11:
    warning: Scheduler should implement #fiber_interrupt INFO: 9 is running.