### PR TITLE
[workerman] Serve static files from HD

### DIFF
--- a/frameworks/workerman/Db.php
+++ b/frameworks/workerman/Db.php
@@ -7,6 +7,7 @@ class Db
     public static function init()
     {
         $db = new Sqlite3('/data/benchmark.db', SQLITE3_OPEN_READONLY);
+        $db->exec('PRAGMA mmap_size=268435456;');
 
         self::$prepared = $db->prepare('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count
                             FROM items

--- a/frameworks/workerman/meta.json
+++ b/frameworks/workerman/meta.json
@@ -1,9 +1,9 @@
 {
   "display_name": "workerman",
   "language": "PHP",
-  "type": "tuned",
+  "type": "production",
   "engine": "workerman",
-  "description": "Workerman with PHP content handlers for all benchmark endpoints.",
+  "description": "An asynchronous event driven PHP socket framework. Supports HTTP, Websocket, SSL and other custom protocols.",
   "repo": "https://github.com/walkor/Workerman",
   "enabled": true,
   "tests": [

--- a/frameworks/workerman/server.php
+++ b/frameworks/workerman/server.php
@@ -23,18 +23,6 @@ TcpConnection::$defaultMaxPackageSize = 30 * 1024 * 1024;
 define('JSON_DATA', json_decode(file_get_contents('/data/dataset.json'), true));
 define('LARGE_JSON', largeJson());
 
-const MIME = [
-    'css'   => "text/css",
-    'js'    => "application/javascript",
-    'html'  => "text/html",
-    'woff2' => "font/woff2",
-    'svg'   => "image/svg+xml",
-    'webp'  => "image/webp",
-    'json'  => "application/json"
-    ];
-
-define('STATIC_FILES', loadStaticFiles());
-
 function largeJson()
 {
     $data = json_decode(file_get_contents('/data/dataset-large.json'), true);
@@ -43,21 +31,6 @@ function largeJson()
     }
 
     return json_encode(['items' => $data, 'count' => count($data)], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-}
-
-function loadStaticFiles() 
-{
-    $files = [];
-    $dir = new DirectoryIterator('/data/static');
-    foreach ($dir as $fileinfo) {
-        if (!$fileinfo->isDot()) {
-            $files['/static/' . $fileinfo->getFilename()] = [
-                file_get_contents($fileinfo->getPathname()),
-                MIME[pathinfo($fileinfo->getFilename(), PATHINFO_EXTENSION)] ?? 'application/octet-stream'
-            ];
-        }
-    }
-    return $files;
 }
 
 $http_worker->onWorkerStart = static function () {
@@ -129,10 +102,8 @@ $http_worker->onMessage = static function ($connection, $request) {
 
     //Serve static files
     if (str_starts_with($path, '/static/')) {
-        if (isset(STATIC_FILES[$path])) {
-            $connection->headers = ['Content-Type' => STATIC_FILES[$path][1]];
-            return $connection->send(STATIC_FILES[$path][0]);
-        }
+        $response = (new Response())->withFile('/data' . $path);
+        return $connection->send($response);
     }
 
     return $connection->send(new Response(


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/validate -f <framework>` | Run the 18-point validation suite |
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
