### PR TITLE
[workerman-websocket] Add maintainer and prod [ci skip]

### DIFF
--- a/frameworks/workerman-websocket/meta.json
+++ b/frameworks/workerman-websocket/meta.json
@@ -3,7 +3,7 @@
   "language": "PHP",
   "type": "production",
   "engine": "workerman",
-  "description": "Workerman WebSocket echo server",
+  "description": "An asynchronous event driven PHP socket framework. Supports HTTP, Websocket, SSL and other custom protocols.",
   "repo": "https://github.com/walkor/Workerman",
   "enabled": true,
   "tests": [

--- a/frameworks/workerman-websocket/meta.json
+++ b/frameworks/workerman-websocket/meta.json
@@ -1,7 +1,7 @@
 {
   "display_name": "workerman-websocket",
   "language": "PHP",
-  "type": "tuned",
+  "type": "production",
   "engine": "workerman",
   "description": "Workerman WebSocket echo server",
   "repo": "https://github.com/walkor/Workerman",
@@ -9,5 +9,5 @@
   "tests": [
     "echo-ws"
   ],
-  "maintainers": []
+  "maintainers": ["joanhey"]
 }


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/validate -f <framework>` | Run the 18-point validation suite |
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
