### PR TITLE
[nginx] Update

### DIFF
--- a/frameworks/nginx/Dockerfile
+++ b/frameworks/nginx/Dockerfile
@@ -28,6 +28,7 @@ RUN ./configure \
     --with-http_v2_module \
     --with-http_v3_module \
     --add-module=/tmp/module \
+    --with-http_gzip_static_module \
     --with-cc-opt="-O3 -march=native -DNDEBUG -I/opt/quictls/include" \
     --with-ld-opt="-lm -L/opt/quictls/lib -Wl,-rpath,/opt/quictls/lib" && \
     make -j$(nproc)

--- a/frameworks/nginx/Dockerfile
+++ b/frameworks/nginx/Dockerfile
@@ -46,6 +46,9 @@ RUN ln -s libssl.so.81.3 /opt/quictls/lib/libssl.so.81 && \
 ARG NGINX_VERSION
 COPY --from=build /tmp/nginx-${NGINX_VERSION}/objs/nginx /usr/sbin/nginx
 RUN mkdir -p /usr/local/nginx/logs
+
 COPY nginx.conf /usr/local/nginx/conf/nginx.conf
+
 EXPOSE 8080 8443/tcp 8443/udp
-CMD ["nginx", "-g", "daemon off;"]
+
+CMD ["nginx"]

--- a/frameworks/nginx/README.md
+++ b/frameworks/nginx/README.md
@@ -17,11 +17,7 @@ Nginx with a custom C handler module (`ngx_http_httparena_module`) compiled with
 | `/baseline11` | GET | Sums query parameter values |
 | `/baseline11` | POST | Sums query parameters + request body |
 | `/baseline2` | GET | Sums query parameter values (HTTP/2 variant) |
-| `/json` | GET | Processes 50-item dataset, serializes JSON |
-| `/compression` | GET | Gzip-compressed large JSON response |
-| `/db` | GET | SQLite range query with JSON response |
-| `/upload` | POST | Receives 1 MB body, returns byte count |
-| `/static/{filename}` | GET | Serves preloaded static files with MIME types |
+| `/static/{filename}` | GET | Serves static files with MIME types |
 
 ## Notes
 
@@ -29,5 +25,4 @@ Nginx with a custom C handler module (`ngx_http_httparena_module`) compiled with
 - Worker processes auto-configured to CPU count
 - 65536 worker connections per process
 - HTTP/1.1, HTTP/2, and HTTP/3 support
-- Read-only SQLite access
 - Gzip compression at server level

--- a/frameworks/nginx/meta.json
+++ b/frameworks/nginx/meta.json
@@ -10,8 +10,11 @@
     "baseline",
     "pipelined",
     "limited-conn",
+    "static",
     "baseline-h2",
-    "static-h2"
+    "static-h2",
+    "baseline-h3",
+    "static-h3"
   ],
   "maintainers": []
 }

--- a/frameworks/nginx/nginx.conf
+++ b/frameworks/nginx/nginx.conf
@@ -17,11 +17,14 @@ http {
     types {
         text/html                            html htm;
         text/css                             css;
+        
         application/javascript               js;
         application/json                     json;
-        image/jpeg                           jpeg jpg;
-        image/png                            png;
+
+        image/webp                           webp;
         image/svg+xml                        svg;
+
+        font/woff2                           woff2;
     }
 
     sendfile on;

--- a/frameworks/nginx/nginx.conf
+++ b/frameworks/nginx/nginx.conf
@@ -2,6 +2,8 @@ worker_processes auto;
 worker_rlimit_nofile 65536;
 error_log stderr error;
 timer_resolution 1s;
+daemon off;
+pcre_jit on;
 
 events {
     worker_connections 65536;

--- a/frameworks/nginx/nginx.conf
+++ b/frameworks/nginx/nginx.conf
@@ -1,5 +1,7 @@
 worker_processes auto;
 worker_rlimit_nofile 65536;
+error_log stderr error;
+timer_resolution 1s;
 
 events {
     worker_connections 65536;
@@ -8,27 +10,50 @@ events {
 
 http {
     access_log off;
-    error_log /dev/null crit;
+    server_tokens off;
+    msie_padding off;
+    etag off;
+
+    types {
+        text/html                            html htm;
+        text/css                             css;
+        application/javascript               js;
+        application/json                     json;
+        image/jpeg                           jpeg jpg;
+        image/png                            png;
+        image/svg+xml                        svg;
+    }
 
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_requests 1000000;
-    server_tokens off;
     client_max_body_size 25m;
     client_body_buffer_size 25m;
 
     gzip on;
-    gzip_types application/json;
     gzip_min_length 100;
-    gzip_comp_level 1;
+    gzip_comp_level 5; 
+    # brotli 7 is similar to gzip 5 in compression ratio but much faster, so we set gzip to 5 to save CPU while still getting good compression
+    # Not text/plain :(
+    # text/html is included automatically when gzip is enabled
+    gzip_types  application/json
+                application/javascript
+                text/css
+                image/svg+xml;
 
     server {
         listen 8080 reuseport;
 
         location / {
             httparena;
+        }
+
+        location /static/ {
+            root /data;
+            add_header    Last-Modified '';
+            gzip_static on;
         }
     }
 
@@ -51,6 +76,12 @@ http {
 
         location / {
             httparena;
+        }
+
+        location /static/ { 
+            root /data;
+            add_header    Last-Modified '';
+            gzip_static on;
         }
     }
 }


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
