### PR TITLE
[workerman] Update

### DIFF
--- a/frameworks/workerman/Dockerfile
+++ b/frameworks/workerman/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.5-cli php8.5-xml php8.5-zip php8.5-sqlite3 php8.5-pgsql> /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-xml php8.5-zip php8.5-pgsql> /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 

--- a/frameworks/workerman/Pgsql.php
+++ b/frameworks/workerman/Pgsql.php
@@ -27,7 +27,7 @@ class Pgsql
                 ]
             );
             self::$bench = $pdo->prepare(
-                'SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN ? AND ? LIMIT 50'
+                'SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN ? AND ? LIMIT ?'
             );
     }
 
@@ -37,14 +37,14 @@ class Pgsql
         return self::$bench;
     }
 
-    public static function query($min, $max)
+    public static function query($min, $max, $limit)
     {
         $result = self::$bench;
         if (!$result instanceof PDOStatement) {
             $result = self::reConnect();
         }
 
-        $result->execute([$min, $max]);
+        $result->execute([$min, $max, $limit]);
         $data = [];
         while ($row = $result->fetch()) {
             $data[] = [

--- a/frameworks/workerman/meta.json
+++ b/frameworks/workerman/meta.json
@@ -11,13 +11,13 @@
     "pipelined",
     "limited-conn",
     "json",
-    "json-comp",
-    "upload",
+    "json-tls",
     "noisy",
     "static",
     "api-4",
     "api-16",
-    "async-db"
+    "async-db",
+    "upload"
   ],
   "maintainers": [
     "joanhey"

--- a/frameworks/workerman/php.ini
+++ b/frameworks/workerman/php.ini
@@ -8,5 +8,3 @@ opcache.huge_code_pages=1
 memory_limit = 512M
 opcache.jit_buffer_size=128M
 opcache.jit=tracing
-
-upload_tmp_dir = /dev/shm

--- a/frameworks/workerman/server.php
+++ b/frameworks/workerman/server.php
@@ -21,20 +21,9 @@ TcpConnection::$defaultMaxPackageSize = 30 * 1024 * 1024;
 
 // benchmark data
 define('JSON_DATA', json_decode(file_get_contents('/data/dataset.json'), true));
-define('LARGE_JSON', largeJson());
 
-function largeJson()
-{
-    $data = json_decode(file_get_contents('/data/dataset-large.json'), true);
-    foreach ($data as &$item) {
-        $item['total'] = $item['price'] * $item['quantity'];
-    }
-
-    return json_encode(['items' => $data, 'count' => count($data)], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-}
 
 $http_worker->onWorkerStart = static function () {
-    Db::Init();
     Pgsql::init();
 };
 
@@ -54,56 +43,82 @@ $http_worker->onMessage = static function ($connection, $request) {
             
             $connection->headers = ['Content-Type' => 'text/plain'];
             return $connection->send($sum);
-
-        case '/json':
-            $total = [];
-            foreach (JSON_DATA as $item) {
-                $item['total'] = $item['price'] * $item['quantity'];
-                $total[] = $item;
-            }
-
-            $connection->headers = ['Content-Type' => 'application/json'];
-            return $connection->send(json_encode(['items' => $total, 'count' => count($total)], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         
         case '/upload':
             $connection->headers = ['Content-Type' => 'text/plain'];
             return $connection->send(strlen($request->rawBody()));
-
-        case '/compression':
-            if (str_contains($request->header('Accept-Encoding', ''), 'gzip')) {
-                 $connection->headers = [
-                    'Content-Type' => 'application/json',
-                    'Content-Encoding' => 'gzip'
-                ];
-                return $connection->send(gzencode(LARGE_JSON, 1));
-            }
-
-            $resp = new Response(200, ['Content-Type' => 'application/json'], LARGE_JSON);
-            return $connection->send($resp);
-
-        case '/db':
-            $connection->headers = ['Content-Type' => 'application/json'];
-            return $connection->send(
-                Db::query(
-                    $request->get('min', 10),
-                    $request->get('max', 50)
-                )
-            );
 
         case '/async-db':
             $connection->headers = ['Content-Type' => 'application/json'];
             return $connection->send( 
                 Pgsql::query(
                     $request->get('min', 10),
-                    $request->get('max', 50)
+                    $request->get('max', 50),
+                    $request->get('limit', 50)
                 )
             );
+    }
+
+    if (str_starts_with($path, '/json/')) {
+        $count = explode('/', $path)[2];
+        $m = $request->get('m', 1);
+        $total = [];
+        $i = 0;
+        while ($i < $count) {
+            $item = JSON_DATA[$i++];
+            $item['total'] = $item['price'] * $item['quantity'] * $m;
+            $total[] = $item;
+        }
+        $connection->headers = ['Content-Type' => 'application/json'];
+        return $connection->send(json_encode(['items' => $total, 'count' => $count], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
     }
 
     //Serve static files
     if (str_starts_with($path, '/static/')) {
         $response = (new Response())->withFile('/data' . $path);
         return $connection->send($response);
+    }
+
+    return $connection->send(new Response(
+        404,
+        ['Content-Type' => 'text/plain'],
+        '404 Not Found')
+    );
+};
+
+
+// #### https worker ####
+// SSL context.
+$context = [
+    'ssl' => [
+        'local_cert'  => '/certs/server.crt',
+        'local_pk'    => '/certs/server.key',
+        'verify_peer' => false,
+    ]
+];
+
+$https = new Worker('http://0.0.0.0:8081', $context);
+$https->transport = 'ssl';
+$https->reusePort = true;
+$https->count = shell_exec('nproc');
+$https->name = 'bench';
+
+
+
+$https->onMessage = static function ($connection, $request) {
+
+    if(str_starts_with($request->path(), '/json/')) {
+        $count = explode('/', $request->path())[2];
+        $m = $request->get('m', 1);
+        $total = [];
+        $i = 0;
+        while ($i < $count) {
+            $item = JSON_DATA[$i++];
+            $item['total'] = $item['price'] * $item['quantity'] * $m;
+            $total[] = $item;
+        }
+        $connection->headers = ['Content-Type' => 'application/json'];
+        return $connection->send(json_encode(['items' => $total, 'count' => $count], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
     }
 
     return $connection->send(new Response(


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
