### PR TITLE
[workerman] Remove require db.php

### DIFF
--- a/frameworks/workerman/Pgsql.php
+++ b/frameworks/workerman/Pgsql.php
@@ -31,18 +31,9 @@ class Pgsql
             );
     }
 
-    public static function reConnect(): PDOStatement
-    {
-        self::init();
-        return self::$bench;
-    }
-
     public static function query($min, $max, $limit)
     {
         $result = self::$bench;
-        if (!$result instanceof PDOStatement) {
-            $result = self::reConnect();
-        }
 
         $result->execute([$min, $max, $limit]);
         $data = [];

--- a/frameworks/workerman/server.php
+++ b/frameworks/workerman/server.php
@@ -6,7 +6,6 @@ use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Http;   
 
 require_once __DIR__ . '/vendor/autoload.php';
-require_once __DIR__ . '/Db.php';
 require_once __DIR__ . '/Pgsql.php';
 
 // #### http worker ####


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework on your own machine using the lite scripts — no CPU pinning, fixed connections, all load generators run in Docker.

**Linux:**
```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Windows / macOS (Docker Desktop):**
```bash
./scripts/validate-windows.sh <framework>
./scripts/benchmark-lite-windows.sh <framework> baseline
./scripts/benchmark-lite-windows.sh --load-threads 4 <framework>
```

The `-docker` variants use a Docker bridge network instead of `--network host` (which doesn't work on Docker Desktop).

**Requirements:** Docker Engine. Load generators (gcannon, h2load) are built as Docker images on first run. gcannon source is expected at `../gcannon` (override with `GCANNON_SRC`).

</details>
