### PR TITLE
Actix add Content-Type headers

### DIFF
--- a/frameworks/actix/src/main.rs
+++ b/frameworks/actix/src/main.rs
@@ -266,6 +266,7 @@ async fn baseline11_get(query: web::Query<BaselineQuery>) -> HttpResponse {
     let sum = query.a.unwrap_or(0) + query.b.unwrap_or(0);
     HttpResponse::Ok()
         .insert_header((SERVER, SERVER_HDR.clone()))
+        .content_type(ContentType::plaintext())
         .body(sum.to_string())
 }
 
@@ -286,6 +287,7 @@ async fn baseline2(query: web::Query<BaselineQuery>) -> HttpResponse {
     let sum = query.a.unwrap_or(0) + query.b.unwrap_or(0);
     HttpResponse::Ok()
         .insert_header((SERVER, SERVER_HDR.clone()))
+        .content_type(ContentType::plaintext())
         .body(sum.to_string())
 }
 


### PR DESCRIPTION
## Description
Validate.sh need to check it. #526

An HTTP response with body and without `Content-Type` header !!!!


---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
