### PR TITLE
Nginx update to v1.30 and with brotli

### DIFF
--- a/frameworks/nginx/Dockerfile
+++ b/frameworks/nginx/Dockerfile
@@ -1,9 +1,9 @@
-ARG NGINX_VERSION=1.28.3
+ARG NGINX_VERSION=1.30.0
 
 FROM debian:bookworm AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential libpcre2-dev zlib1g-dev wget ca-certificates git perl
+    build-essential libpcre2-dev zlib1g-dev wget ca-certificates git perl cmake
 
 # Build quictls (OpenSSL fork with QUIC support)
 WORKDIR /tmp
@@ -18,6 +18,14 @@ ARG NGINX_VERSION
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar xzf nginx-${NGINX_VERSION}.tar.gz
 
+# Add ngx_brotli
+RUN git clone --recurse-submodules -j8 https://github.com/google/ngx_brotli && \
+    cd ngx_brotli/deps/brotli  && \
+    mkdir out && cd out  && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed .. && \
+    cmake --build . --config Release --target brotlienc  && \
+    cd ../../../..
+
 # Copy module
 COPY ngx_http_httparena_module.c config /tmp/module/
 
@@ -27,8 +35,9 @@ RUN ./configure \
     --with-http_ssl_module \
     --with-http_v2_module \
     --with-http_v3_module \
-    --add-module=/tmp/module \
     --with-http_gzip_static_module \
+    --add-module=/tmp/ngx_brotli \
+    --add-module=/tmp/module \
     --with-cc-opt="-O3 -march=native -DNDEBUG -I/opt/quictls/include" \
     --with-ld-opt="-lm -L/opt/quictls/lib -Wl,-rpath,/opt/quictls/lib" && \
     make -j$(nproc)

--- a/frameworks/nginx/nginx.conf
+++ b/frameworks/nginx/nginx.conf
@@ -38,8 +38,9 @@ http {
     client_body_buffer_size 25m;
 
     gzip on;
+    gzip_static on;
     gzip_min_length 100;
-    gzip_comp_level 5; 
+    gzip_comp_level 1; 
     # brotli 7 is similar to gzip 5 in compression ratio but much faster, so we set gzip to 5 to save CPU while still getting good compression
     # Not text/plain :(
     # text/html is included automatically when gzip is enabled
@@ -47,6 +48,15 @@ http {
                 application/javascript
                 text/css
                 image/svg+xml;
+    
+    brotli on;
+    brotli_static on;
+    brotli_comp_level 1;
+    brotli_min_length 256;
+    brotli_types  application/json
+                  application/javascript
+                  text/css
+                  image/svg+xml;
 
     server {
         listen 8080 reuseport;
@@ -58,7 +68,6 @@ http {
         location /static/ {
             root /data;
             add_header    Last-Modified '';
-            gzip_static on;
         }
     }
 
@@ -86,7 +95,6 @@ http {
         location /static/ { 
             root /data;
             add_header    Last-Modified '';
-            gzip_static on;
         }
     }
 }


### PR DESCRIPTION
## Description
Nginx v1.30.0 released 2026-04-14

Add ngx_broli module from google.
It's a shame than nginx don't include it with the open source version. Also thanks to F5,inc. Nginx Unit deprecated as of October 2025, Ingress NGINX Deprecation: EOL by March 2026,...
Also a lot of distributions than before include it, now is not available.

Perhaps we need to use forks than it's ready installed, like freenginx or angie and offer more functions.


---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
