### PR TITLE
Add Webman

### DIFF
--- a/frameworks/webman/Dockerfile
+++ b/frameworks/webman/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common >/dev/null && \
+    LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php >/dev/null && \
+    apt-get update -yqq >/dev/null && apt-get upgrade -yqq >/dev/null
+
+RUN apt-get install -yqq php8.5-cli php8.5-xml php8.5-zip php8.5-pgsql >/dev/null
+
+COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
+
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null && \
+    pecl install event-3.1.4 >/dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
+
+WORKDIR /webman
+COPY composer.json .
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+COPY php.ini /etc/php/8.5/cli/php.ini
+
+COPY . .
+
+EXPOSE 8080 8081
+
+CMD ["php", "/webman/start.php", "start"]

--- a/frameworks/webman/README.md
+++ b/frameworks/webman/README.md
@@ -1,0 +1,34 @@
+# Webman
+
+Webman is a high-performance service framework built on Workerman, integrating HTTP, WebSocket, TCP, UDP, and other modules. Through advanced technologies such as resident memory, coroutines, and connection pools, Webman not only breaks through the performance bottlenecks of traditional PHP but also greatly expands its application scenarios.
+
+In addition, Webman provides a powerful plugin mechanism that enables developers to quickly integrate and reuse functional modules developed by other developers. Whether building websites, developing HTTP APIs, implementing instant messaging, building IoT systems, or developing games, TCP/UDP services, Unix Socket services, and more, Webman handles all of these effortlessly with outstanding performance and flexibility.
+
+https://github.com/walkor/webman
+https://webman.workerman.net/doc/en/
+
+https://github.com/walkor/workerman
+https://manual.workerman.net/doc/en/
+https://www.workerman.net/
+
+
+## Stack
+
+- **Language:** PHP
+- **Engine:** Workerman (event)
+
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/pipeline` | GET | Returns `ok` (plain text) |
+| `/baseline11` | GET | Sums query parameter values |
+| `/baseline11` | POST | Sums query parameters + request body |
+| `/json` | GET | Processes 50-item dataset, serializes JSON |
+| `/db` | GET | SQLite range query with JSON response |
+| `/upload` | POST | Receives 1 MB body, returns byte count |
+| `/static/{filename}` | GET | Serves preloaded static files |
+
+## Notes
+

--- a/frameworks/webman/app/bootstrap/Json.php
+++ b/frameworks/webman/app/bootstrap/Json.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace app\bootstrap;
+
+use Webman\Bootstrap;
+
+class Json implements Bootstrap {
+
+    /**
+     * @param \Workerman\Worker $worker
+     * @return void
+     */
+    public static function start($worker)
+    {
+        // benchmark data
+        define('JSON_DATA', json_decode(file_get_contents('/data/dataset.json'), true));
+    }
+
+}

--- a/frameworks/webman/app/bootstrap/Pgsql.php
+++ b/frameworks/webman/app/bootstrap/Pgsql.php
@@ -1,0 +1,78 @@
+<?php
+namespace app\bootstrap;
+
+use Webman\Bootstrap;
+use PDOStatement;
+use PDO;
+
+class Pgsql implements Bootstrap
+{
+    private static ?PDOStatement $bench;
+
+    /**
+     * @param \Workerman\Worker $worker
+     * @return void
+     */
+    public static function start($worker)
+    {
+        $dsn = \getenv('DATABASE_URL');
+        if (!$dsn) {
+            return;
+        }
+
+        // Parse postgres://user:pass@host:port/dbname
+        $parts = \parse_url($dsn);
+        $host = $parts['host'] ?? 'localhost';
+        $port = $parts['port'] ?? 5432;
+        $db = \ltrim($parts['path'] ?? '/benchmark', '/');
+        $user = $parts['user'] ?? 'bench';
+        $pass = $parts['pass'] ?? 'bench';
+
+        try {
+            $pdo = new PDO(
+                "pgsql:host=$host;port=$port;dbname=$db",
+                $user,
+                $pass,
+                [
+                    PDO::ATTR_DEFAULT_FETCH_MODE  => PDO::FETCH_ASSOC,
+                    PDO::ATTR_ERRMODE             => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_EMULATE_PREPARES    => false
+                ]
+            );
+            self::$bench = $pdo->prepare(
+                'SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN ? AND ? LIMIT ?'
+            );
+        } catch (\PDOException $e) {
+            self::$bench = null;
+        }
+    }
+
+    public static function query($min, $max, $limit)
+    {
+        $result = self::$bench;
+        if (!$result instanceof PDOStatement) {
+            return \json_encode(['items' => [], 'count' => 0],
+                        JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        $result->execute([$min, $max, $limit]);
+        $data = [];
+        while ($row = $result->fetch()) {
+            $data[] = [
+                'id' => $row['id'],
+                'name' => $row['name'],
+                'category' => $row['category'],
+                'price' => $row['price'],
+                'quantity' => $row['quantity'],
+                'active' => (bool) $row["active"],
+                'tags' => json_decode($row["tags"], true),
+                'rating' => [
+                    "score" => $row["rating_score"],
+                    "count" => $row["rating_count"]
+                ],
+            ];
+        }
+        return \json_encode(['items' => $data, 'count' => count($data)],
+                            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/frameworks/webman/app/controller/Index.php
+++ b/frameworks/webman/app/controller/Index.php
@@ -1,0 +1,85 @@
+<?php
+namespace app\controller;
+
+use support\Request;
+use app\bootstrap\Pgsql;
+use support\Response;
+use support\annotation\route\DisableDefaultRoute;
+use support\annotation\route\Get;
+use support\annotation\route\Post;
+use support\annotation\route\Route;
+
+#[DisableDefaultRoute]
+class Index
+{
+
+    #[Get('/pipeline')]
+    public function pipeline()
+    {
+        return new Response(
+            200,
+            ['Content-Type' => 'text/plain'],
+            'ok'
+        );
+    }
+
+    #[Route('/baseline', ['GET', 'POST'])]
+    public function baseline(Request $request)
+    {
+        $sum = \array_sum($request->get());
+        if($request->method() === 'POST') {
+            $sum += $request->rawBody();
+        }
+        
+        return new Response (
+            200,
+            ['Content-Type' => 'text/plain'],
+            $sum
+        );
+    }
+
+    #[Get('/json/{count:\d+}')]
+    public function json(Request $request, $count)
+    {
+        $m = $request->get('m', 1);
+        $total = [];
+        $i = 0;
+        while ($i < $count) {
+            $item = \JSON_DATA[$i++];
+            $item['total'] = $item['price'] * $item['quantity'] * $m;
+            $total[] = $item;
+        }
+
+        return json(['items' => $total, 'count' => $count]);
+    }
+
+    #[Get('/async-db')]
+    public function asyncDb(Request $request)
+    {
+        return new Response (
+            200,
+            ['Content-Type' => 'application/json'],
+            Pgsql::query(
+                $request->get('min', 10),
+                $request->get('max', 50),
+                $request->get('limit', 50)
+            )
+        );
+    }
+
+    #[Post('/upload')]
+    public function upload($request)
+    {
+        return new Response (
+            200,
+            ['Content-Type' => 'text/plain'],
+            \strlen($request->rawBody())
+        );
+    }
+
+    #[Get('/static/{path}')]
+    public function files($request, $path)
+    {
+        return new Response()->withFile('/data/static/' . $path);
+    }
+}

--- a/frameworks/webman/app/functions.php
+++ b/frameworks/webman/app/functions.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Here is your custom functions.
+ */

--- a/frameworks/webman/app/middleware/StaticFile.php
+++ b/frameworks/webman/app/middleware/StaticFile.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace app\middleware;
+
+use Webman\MiddlewareInterface;
+use Webman\Http\Response;
+use Webman\Http\Request;
+
+/**
+ * Class StaticFile
+ * @package app\middleware
+ */
+class StaticFile implements MiddlewareInterface
+{
+    public function process(Request $request, callable $handler): Response
+    {
+        // Access to files beginning with. Is prohibited
+        if (strpos($request->path(), '/.') !== false) {
+            return response('<h1>403 forbidden</h1>', 403);
+        }
+        /** @var Response $response */
+        $response = $handler($request);
+        // Add cross domain HTTP header
+        /*$response->withHeaders([
+            'Access-Control-Allow-Origin'      => '*',
+            'Access-Control-Allow-Credentials' => 'true',
+        ]);*/
+        return $response;
+    }
+}

--- a/frameworks/webman/composer.json
+++ b/frameworks/webman/composer.json
@@ -1,0 +1,55 @@
+{
+  "name": "workerman/webman",
+  "type": "library",
+  "keywords": [
+    "high performance",
+    "http service"
+  ],
+  "homepage": "http://www.workerman.net",
+  "license": "MIT",
+  "description": "High performance HTTP Service Framework.",
+  "authors": [
+    {
+      "name": "walkor",
+      "email": "walkor@workerman.net",
+      "homepage": "http://www.workerman.net",
+      "role": "Developer"
+    }
+  ],
+  "support": {
+    "email": "walkor@workerman.net",
+    "issues": "https://github.com/walkor/webman/issues",
+    "forum": "http://wenda.workerman.net/",
+    "wiki": "http://workerman.net/doc/webman",
+    "source": "https://github.com/walkor/webman"
+  },
+  "require": {
+    "php": ">=8.2",
+    "workerman/webman-framework": "dev-master",
+    "monolog/monolog": "^2.0",
+    "vlucas/phpdotenv": ">=4.1,<6.0",
+    "workerman/workerman": "dev-master"
+  },
+  "suggest": {
+    "ext-event": "For better performance. "
+  },
+  "autoload": {
+    "psr-4": {
+      "": "./",
+      "app\\": "./app",
+      "App\\": "./app"
+    }
+  },
+  "scripts": {
+    "post-package-install": [
+      "support\\Plugin::install"
+    ],
+    "post-package-update": [
+      "support\\Plugin::install"
+    ],
+    "pre-package-uninstall": [
+      "support\\Plugin::uninstall"
+    ]
+  },
+  "minimum-stability": "dev"
+}

--- a/frameworks/webman/config/app.php
+++ b/frameworks/webman/config/app.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+return [
+    'controller_suffix' => '',
+    'debug' => true,
+    'default_timezone' => 'Asia/Shanghai',
+];

--- a/frameworks/webman/config/bootstrap.php
+++ b/frameworks/webman/config/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+return [
+    app\bootstrap\Json::class,
+    app\bootstrap\Pgsql::class,
+];

--- a/frameworks/webman/config/container.php
+++ b/frameworks/webman/config/container.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+
+// 如果你需要自动依赖注入(包括注解注入)。
+// 请先运行 composer require php-di/php-di && composer require doctrine/annotations
+// 并将下面的代码注释解除，并注释掉最后一行 return new Webman\Container;
+/*$builder = new \DI\ContainerBuilder();
+$builder->addDefinitions(config('dependence', []));
+$builder->useAutowiring(true);
+$builder->useAnnotations(true);
+return $builder->build();*/
+
+
+return new Webman\Container;

--- a/frameworks/webman/config/log.php
+++ b/frameworks/webman/config/log.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+return [
+    'default' => [
+        'handlers' => [
+            [
+                'class' => Monolog\Handler\RotatingFileHandler::class,
+                'constructor' => [
+                    runtime_path() . '/logs/webman.log',
+                    Monolog\Logger::DEBUG,
+                ],
+                'formatter' => [
+                    'class' => Monolog\Formatter\LineFormatter::class,
+                    'constructor' => [ null, 'Y-m-d H:i:s', true],
+                ],
+            ]
+        ],
+    ],
+];

--- a/frameworks/webman/config/route.php
+++ b/frameworks/webman/config/route.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Webman\Route;
+
+// Route::get('/pipeline', [app\controller\Index::class, 'pipeline']);
+// Route::any('/baseline', [app\controller\Index::class, 'baseline']);
+// Route::get('/json[/[{count}]]', [app\controller\Index::class, 'json']);
+// Route::get('/asyn-db', [app\controller\Index::class, 'asyncDb']);
+// Route::post('/upload', [app\controller\Index::class, 'upload']);
+// Route::get('/static/{path}', [app\controller\Index::class, 'files']);

--- a/frameworks/webman/config/server.php
+++ b/frameworks/webman/config/server.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+return [
+    'listen'               => 'http://0.0.0.0:8080',
+    'transport'            => 'tcp',
+    'context'              => [],
+    'name'                 => 'webman',
+    'count'                => cpu_count(), //* ( getenv('TEST_TYPE') === 'default' ? 1 : 4 ),
+    'user'                 => '',
+    'group'                => '',
+    'reuse_port'           => true,
+    'pid_file' => runtime_path() . '/webman.pid',
+    'status_file' => runtime_path() . '/webman.status',
+    'stdout_file' => runtime_path() . '/logs/stdout.log',
+    'log_file' => runtime_path() . '/logs/workerman.log', 
+    'max_package_size'     => 25*1024*1024
+];

--- a/frameworks/webman/config/static.php
+++ b/frameworks/webman/config/static.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Static file settings
+ */
+return [
+    'enable' => false,
+    'middleware' => [     // Static file Middleware
+        //app\middleware\StaticFile::class,
+    ],
+];

--- a/frameworks/webman/meta.json
+++ b/frameworks/webman/meta.json
@@ -1,0 +1,25 @@
+{
+  "display_name": "webman",
+  "language": "PHP",
+  "type": "production",
+  "engine": "workerman",
+  "description": "Webman is a high-performance service framework built on Workerman, integrating HTTP, WebSocket, TCP, UDP, and other modules.",
+  "repo": "https://github.com/walkor/Workerman",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-tls",
+    "noisy",
+    "static",
+    "api-4",
+    "api-16",
+    "async-db",
+    "upload"
+  ],
+  "maintainers": [
+    "joanhey"
+  ]
+}

--- a/frameworks/webman/php.ini
+++ b/frameworks/webman/php.ini
@@ -1,0 +1,10 @@
+opcache.enable=1
+opcache.enable_cli=1
+opcache.validate_timestamps=0
+opcache.save_comments=0
+opcache.enable_file_override=1
+opcache.huge_code_pages=1
+
+memory_limit = 512M
+opcache.jit_buffer_size=128M
+opcache.jit=tracing

--- a/frameworks/webman/public/404.html
+++ b/frameworks/webman/public/404.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <title>404 Not Found - webman</title>
+</head>
+<body>
+<center><h1>404 Not Found</h1></center>
+<hr>
+<center><a href="https://www.workerman.net">webman</a></center>
+</body>
+</html>

--- a/frameworks/webman/runtime/.gitignore
+++ b/frameworks/webman/runtime/.gitignore
@@ -1,0 +1,3 @@
+*
+!logs
+!.gitignore

--- a/frameworks/webman/runtime/logs/.gitignore
+++ b/frameworks/webman/runtime/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/frameworks/webman/start.php
+++ b/frameworks/webman/start.php
@@ -1,0 +1,5 @@
+#!/usr/bin/env php
+<?php
+chdir(__DIR__);
+require_once __DIR__ . '/vendor/autoload.php';
+support\App::run();

--- a/frameworks/webman/support/Request.php
+++ b/frameworks/webman/support/Request.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace support;
+
+/**
+ * Class Request
+ * @package support
+ */
+class Request extends \Webman\Http\Request
+{
+
+}

--- a/frameworks/webman/support/Response.php
+++ b/frameworks/webman/support/Response.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace support;
+
+/**
+ * Class Response
+ * @package support
+ */
+class Response extends \Webman\Http\Response
+{
+
+}

--- a/frameworks/webman/support/bootstrap.php
+++ b/frameworks/webman/support/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/workerman/webman-framework/src/support/bootstrap.php';

--- a/frameworks/webman/support/bootstrap/Container.php
+++ b/frameworks/webman/support/bootstrap/Container.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace support\bootstrap;
+
+use Workerman\Worker;
+use Webman\Bootstrap;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Class Container
+ * @package support
+ * @method static mixed get($name)
+ * @method static mixed make($name, array $parameters)
+ * @method static bool has($name)
+ */
+class Container implements Bootstrap
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected static $_instance = null;
+
+    /**
+     * @param Worker $worker
+     * @return void
+     */
+    public static function start($worker)
+    {
+        static::$_instance = include config_path() . '/container.php';
+    }
+
+    /**
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        return static::$_instance->{$name}(... $arguments);
+    }
+
+    /**
+     * instance
+     * @return
+     */
+    public static function instance()
+    {
+        return static::$_instance;
+    }
+}

--- a/frameworks/webman/support/bootstrap/Date.php
+++ b/frameworks/webman/support/bootstrap/Date.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace support\bootstrap;
+
+use Webman\Bootstrap;
+use Workerman\Timer;
+
+/**
+ * Class Date
+ * @package support\bootstrap
+ */
+class Date implements Bootstrap {
+
+    public static $date = '';
+
+    /**
+     * @param \Workerman\Worker $worker
+     * @return void
+     */
+    public static function start($worker)
+    {
+        self::$date = gmdate('D, d M Y H:i:s \G\M\T');
+        Timer::add(1, function() {
+            self::$date = gmdate('D, d M Y H:i:s \G\M\T');
+        });
+    }
+
+}

--- a/frameworks/webman/support/bootstrap/Log.php
+++ b/frameworks/webman/support/bootstrap/Log.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace support\bootstrap;
+
+use Webman\Bootstrap;
+use Monolog\Logger;
+
+/**
+ * Class Redis
+ * @package support
+ *
+ * @method static void log($level, $message, array $context = [])
+ * @method static void debug($message, array $context = [])
+ * @method static void info($message, array $context = [])
+ * @method static void notice($message, array $context = [])
+ * @method static void warning($message, array $context = [])
+ * @method static void error($message, array $context = [])
+ * @method static void critical($message, array $context = [])
+ * @method static void alert($message, array $context = [])
+ * @method static void emergency($message, array $context = [])
+ */
+class Log implements Bootstrap {
+
+    /**
+     * @var array
+     */
+    protected static $_instance = [];
+
+    /**
+     * @param \Workerman\Worker $worker
+     * @return void
+     */
+    public static function start($worker)
+    {
+        $configs = config('log', []);
+        foreach ($configs as $channel => $config) {
+            $logger = static::$_instance[$channel] = new Logger($channel);
+            foreach ($config['handlers'] as $handler_config) {
+                $handler = new $handler_config['class'](... \array_values($handler_config['constructor']));
+                if (isset($handler_config['formatter'])) {
+                    $formatter = new $handler_config['formatter']['class'](... \array_values($handler_config['formatter']['constructor']));
+                    $handler->setFormatter($formatter);
+                }
+                $logger->pushHandler($handler);
+            }
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return Logger;
+     */
+    public static function channel($name = 'default')
+    {
+        return static::$_instance[$name] ?? null;
+    }
+
+
+    /**
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        return static::channel('default')->{$name}(... $arguments);
+    }
+}


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
