### PR TITLE
[rails] Call `render :json` for JSON calls

### DIFF
--- a/frameworks/rails/app/controllers/benchmark_controller.rb
+++ b/frameworks/rails/app/controllers/benchmark_controller.rb
@@ -57,12 +57,10 @@ class BenchmarkController < ActionController::API
         response.headers['content-encoding'] = 'gzip'
         send_data sio.string, disposition: :inline
       else
-        response.headers['content-type'] = 'application/json'
-        render plain: result
+        render json: result
       end
     else
-      response.headers['content-type'] = 'application/json'
-      render plain: result
+      render json: result
     end
   end
 


### PR DESCRIPTION
This is the more common way to render json calls in Rails.