### PR TITLE
[roda] Use plain hashes for the response headers

### DIFF
--- a/frameworks/roda/app.rb
+++ b/frameworks/roda/app.rb
@@ -31,8 +31,9 @@ class App < Roda
   PG_QUERY = 'SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN $1 AND $2 LIMIT $3'.freeze
 
   plugin :default_headers, 'Server' => SERVER_NAME
-  plugin :halt
   plugin :request_headers
+  plugin :plain_hash_response_headers
+  plugin :halt
   plugin :send_file
 
   route do |r|


### PR DESCRIPTION
This is recommended for Rack3:
https://roda.jeremyevans.net/rdoc/classes/Roda/RodaPlugins/PlainHashResponseHeaders.html
