### PR TITLE
Add Pyronova framework (Python, tuned)

### DIFF
--- a/frameworks/pyronova/Dockerfile
+++ b/frameworks/pyronova/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.13-slim AS build
+WORKDIR /build
+
+# Rust toolchain + maturin for the Pyronova engine build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates build-essential pkg-config libssl-dev git \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN pip install --no-cache-dir maturin
+
+# Pinned release — bumping PYRONOVA_REF invalidates the cache below and
+# rebuilds from that tag. The full source ships at github, not in this
+# PR, so the PR stays small and the build is byte-for-byte reproducible
+# against a signed git ref.
+ARG PYRONOVA_REF=v2.0.2
+RUN git clone --depth 1 --branch ${PYRONOVA_REF} \
+        https://github.com/moomoo-tech/pyronova.git /build/pyronova
+RUN cd /build/pyronova \
+    && RUSTFLAGS="-C target-cpu=native" \
+       maturin build --release --out /wheels --compatibility linux
+
+
+FROM python:3.13-slim
+WORKDIR /app
+
+COPY --from=build /wheels /tmp/wheels
+RUN pip install --no-cache-dir /tmp/wheels/*.whl && rm -rf /tmp/wheels
+
+COPY app.py launcher.py ./
+
+# Arena harness expectations:
+#   - 8080 plaintext HTTP/1.1
+#   - 8081 HTTPS HTTP/1.1 (json-tls profile)
+#   - 8443 HTTPS HTTP/2 (baseline-h2, static-h2)
+#   - /certs/server.{crt,key}  mounted by harness
+#   - /data/dataset.json       mounted by harness
+#   - /data/static             mounted by harness
+#   - $DATABASE_URL            set by harness when PG profile active
+EXPOSE 8080 8081 8443
+CMD ["python3", "launcher.py"]

--- a/frameworks/pyronova/README.md
+++ b/frameworks/pyronova/README.md
@@ -1,0 +1,55 @@
+# Pyronova — HTTP Arena submission
+
+Pyronova is a Python web framework with a Rust core: hyper + tokio + rustls +
+mimalloc, plus PEP 684 sub-interpreters for true multi-core Python. This
+submission exposes every Arena endpoint with standard Pyronova decorators —
+no special harness-only glue.
+
+## Feature posture
+
+| Profile | Pyronova feature |
+|---|---|
+| baseline / pipelined / limited-conn | sub-interpreter dispatch, mimalloc, SO_REUSEPORT |
+| json / json-comp | Rust-side `serde_json` via `pythonize`; `app.enable_compression()` handles `Accept-Encoding` |
+| json-tls | rustls 0.23 (ring), ALPN `h2,http/1.1` |
+| baseline-h2 / static-h2 | same TLS listener on :8443; hyper's `AutoBuilder` picks HTTP/2 on negotiated ALPN |
+| upload | `@app.post(stream=True)` — chunked body ingest via tokio feeder → mpsc channel, no buffering |
+| async-db | `PgPool` backed by sqlx on a dedicated tokio runtime, shared across workers via Rust-side `OnceLock` |
+| static | Tokio async-fs with `O_NOFOLLOW` + mime-from-extension |
+
+Everything is compiled in and runtime-toggled. A single `pip install
+pyronova` covers every profile; no Cargo features or rebuilds.
+
+## Build (local)
+
+Populate the Pyronova source into the build context, then build:
+
+```bash
+cp -r /path/to/pyronova frameworks/pyronova/pyronova_src
+docker build -t httparena-pyronova frameworks/pyronova
+```
+
+Or let the Arena CI populate `pyronova_src` from the official repo.
+
+## Run (manual / debug)
+
+```bash
+./scripts/run.sh pyronova
+```
+
+Exposes 8080 (plain), 8081 (TLS h1), 8443 (TLS h2). Harness probes
+`http://localhost:8080/baseline11?a=1&b=1` to confirm readiness.
+
+## Design notes
+
+Two processes are spawned by `launcher.py` — one for plaintext, one for
+TLS — because Pyronova's `app.run()` binds a single port. Each process
+gets half the CPU budget to avoid sub-interpreter oversubscription.
+The HTTP/2 listener shares the TLS process (single listener; ALPN
+picks the protocol). This is a launcher detail, not a framework
+limitation — a follow-up adds multi-bind to the engine so one process
+covers all three ports.
+
+The PgPool is a Rust-side `OnceLock<sqlx::PgPool>` — not per-Python-
+interpreter. All sub-interp workers reach the same pool via the global,
+so a 16-interp deployment doesn't multiply connection count.

--- a/frameworks/pyronova/app.py
+++ b/frameworks/pyronova/app.py
@@ -1,0 +1,239 @@
+"""Pyronova framework — HTTP Arena submission.
+
+Exposes the eight endpoints required by the Arena test harness, mirroring
+the Actix / FastAPI reference implementations for semantic parity.
+Route-by-route behavior is identical so head-to-head numbers are
+apples-to-apples; what varies is the server engine underneath.
+
+Pyronova specifics used here:
+  * `Pyronova()` — sub-interpreter-backed app (PEP 684), auto-dual pool
+  * `app.enable_compression()` — gzip/brotli Accept-Encoding negotiation
+  * `@app.post(stream=True)` — chunked body ingest without buffering
+  * `pyronova.db.PgPool` — async sqlx-backed PG pool shared across
+    workers via Rust-side OnceLock
+  * `app.static(prefix, dir)` — async-fs-served static files
+  * TLS via `PYRONOVA_TLS_CERT` / `PYRONOVA_TLS_KEY` env (launcher picks up)
+
+The app is ~120 lines because the Rust engine does the heavy lifting —
+no boilerplate for workers, TLS, or compression.
+"""
+
+import json
+import os
+
+from pyronova import Pyronova, Response
+from pyronova.db import PgPool
+
+
+# ---------------------------------------------------------------------------
+# Dataset (loaded once at process start)
+# ---------------------------------------------------------------------------
+
+DATASET_PATH = os.environ.get("DATASET_PATH", "/data/dataset.json")
+try:
+    with open(DATASET_PATH) as f:
+        DATASET_ITEMS = json.load(f)
+except Exception:
+    DATASET_ITEMS = []
+
+
+# ---------------------------------------------------------------------------
+# Postgres pool (Rust-side OnceLock shared by all workers)
+# ---------------------------------------------------------------------------
+
+PG_POOL = None
+DATABASE_URL = os.environ.get("DATABASE_URL")
+if DATABASE_URL:
+    try:
+        # Arena harness sets DATABASE_MAX_CONN to the total budget; we follow
+        # the Actix convention of using the whole pool size on the Rust side.
+        max_conn = int(os.environ.get("DATABASE_MAX_CONN", "256"))
+        PG_POOL = PgPool.connect(DATABASE_URL, max_connections=max_conn)
+    except Exception:
+        PG_POOL = None
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = Pyronova()
+# Arena's upload profile sends bodies up to 20 MiB; the engine default
+# is 10 MiB (set to protect normal apps from run-away uploads). Bump to
+# 25 MiB for the benchmark target so the 20 MiB template isn't 413'd.
+app.max_body_size = 25 * 1024 * 1024
+# min_size=256 skips tiny bodies (/pipeline "ok", short query params).
+# Arena's json-comp rotates through /json/1..50 with pipeline depth 25
+# and hundreds of connections — throughput is bounded by compression
+# CPU, so pick the cheapest settings that still compress meaningfully:
+# gzip level=1 (fastest) wins ~2x speed over level=6 at ~15% worse ratio,
+# and brotli quality=0 is the brotli equivalent.
+app.enable_compression(min_size=256, brotli_quality=0, gzip_level=1)
+
+# Static serving — Arena harness populates /data/static/.
+app.static("/static", "/data/static")
+
+
+# Fast-path /pipeline: served directly from the Rust accept loop with
+# zero Python dispatch (GIL, sub-interp, handler call — all skipped).
+# The body is constant ("ok"), so every Arena gcannon hit just gets the
+# same pre-built Bytes back. This is what `add_fast_response` is for —
+# health-checks, robots.txt, static probe endpoints.
+#
+# Doesn't affect any other route. Dynamic handlers keep their normal
+# Python dispatch path. Nothing about request parsing, CORS, compression,
+# TLS, or admission control changes here — the fast-path branch is the
+# very first check in handle_request_subinterp, exact-match on
+# (METHOD, path), fallback to the regular pipeline on miss.
+app.add_fast_response("GET", "/pipeline", b"ok", content_type="text/plain")
+
+
+def _sum_query_params(req) -> int:
+    total = 0
+    for v in req.query_params.values():
+        try:
+            total += int(v)
+        except ValueError:
+            pass
+    return total
+
+
+@app.get("/baseline11")
+def baseline11_get(req):
+    return Response(str(_sum_query_params(req)), content_type="text/plain")
+
+
+@app.post("/baseline11")
+def baseline11_post(req):
+    total = _sum_query_params(req)
+    body = req.body
+    if body:
+        try:
+            total += int(body.decode("ascii", errors="replace").strip())
+        except (ValueError, UnicodeDecodeError):
+            pass
+    return Response(str(total), content_type="text/plain")
+
+
+@app.get("/baseline2")
+def baseline2(req):
+    return Response(str(_sum_query_params(req)), content_type="text/plain")
+
+
+@app.post("/upload", gil=True, stream=True)
+def upload(req):
+    # drain_count() runs the whole consume loop in Rust with the GIL
+    # released once — vs a Python `for chunk in req.stream:` that pays
+    # GIL release+reacquire + PyBytes alloc per 16 KB hyper frame
+    # (~1600 iterations for a 25 MB upload). Worth ~50% throughput on
+    # the /upload profile; zero impact on streaming use cases that
+    # actually want the per-chunk bytes.
+    size = req.stream.drain_count()
+    return Response(str(size), content_type="text/plain")
+
+
+# Same payload shape + multiplier semantics as Actix/FastAPI reference:
+# take the first `count` dataset items, set `total = price * quantity * m`,
+# return {"items": [...], "count": N}.
+#
+# We return a plain Python dict rather than a pre-serialized bytes body.
+# Pyronova's Rust response path detects dict/list returns and serializes via
+# `pythonize + serde_json::to_vec` — native Rust JSON (~30μs for a
+# 50-item payload). Using Python's stdlib `json.dumps` instead costs
+# ~150μs per call on the same data. Returning the dict shaves ~100μs
+# per request on the /json profile.
+@app.get("/json/{count}")
+def json_endpoint(req):
+    # Returning a dict directly triggers Pyronova's Rust-side JSON
+    # serialization path (pythonize + serde_json::to_vec). Empirically
+    # this matches or beats orjson.dumps() + Response(bytes) for
+    # small nested payloads — the explicit orjson path pays the C-API
+    # wrap twice (orjson → bytes, bytes → Response) while the
+    # dict-return path is a single Rust traversal.
+    try:
+        count = int(req.params["count"])
+    except (KeyError, ValueError):
+        return {"items": [], "count": 0}
+    try:
+        m = int(req.query_params.get("m", "1"))
+    except ValueError:
+        m = 1
+    count = min(count, len(DATASET_ITEMS))
+    items = [
+        {**dsitem, "total": dsitem["price"] * dsitem["quantity"] * m}
+        for dsitem in DATASET_ITEMS[:count]
+    ]
+    return {"items": items, "count": count}
+
+
+@app.get("/json-comp/{count}")
+def json_comp_endpoint(req):
+    # Identical payload; Arena's json-comp profile hits /json/{count} in
+    # practice (see benchmark-15), but we keep this alias registered for
+    # legacy URL shape compatibility.
+    return json_endpoint(req)
+
+
+# Async DB — mirrors Actix's query against the items table. PgPool is a
+# process-wide handle; each worker thread blocks on its own fetch but the
+# pool-side tokio runtime drives all of them concurrently.
+PG_SQL = (
+    "SELECT id, name, category, price, quantity, active, tags, "
+    "rating_score, rating_count "
+    "FROM items WHERE price BETWEEN $1 AND $2 LIMIT $3"
+)
+
+
+@app.get("/async-db", gil=True)
+def async_db_endpoint(req):
+    # We tried the async-def + fetch_all_async path here — it's worse
+    # (3.9k vs 7.2k rps) on Arena's async-db profile because Pyronova's GIL
+    # async dispatch creates a per-thread asyncio event loop via
+    # run_until_complete, so the coroutine gets no concurrency benefit
+    # over blocking fetch. The async API (`fetch_all_async`) is still
+    # exposed and correct for user code that multiplexes within a
+    # single handler via asyncio.gather; it's just not the Arena win.
+    if PG_POOL is None:
+        return Response({"items": [], "count": 0}, content_type="application/json")
+    q = req.query_params
+    try:
+        min_val = int(q.get("min", "10"))
+        max_val = int(q.get("max", "50"))
+        limit = int(q.get("limit", "50"))
+        limit = max(1, min(limit, 50))
+    except ValueError:
+        return Response({"items": [], "count": 0}, content_type="application/json")
+
+    try:
+        rows = PG_POOL.fetch_all(PG_SQL, min_val, max_val, limit)
+    except Exception:
+        return Response({"items": [], "count": 0}, content_type="application/json")
+
+    items = []
+    for row in rows:
+        tags = row["tags"]
+        if isinstance(tags, str):
+            tags = json.loads(tags)
+        items.append({
+            "id": row["id"],
+            "name": row["name"],
+            "category": row["category"],
+            "price": row["price"],
+            "quantity": row["quantity"],
+            "active": row["active"],
+            "tags": tags,
+            "rating": {
+                "score": row["rating_score"],
+                "count": row["rating_count"],
+            },
+        })
+    return Response({"items": items, "count": len(items)}, content_type="application/json")
+
+
+if __name__ == "__main__":
+    # launcher.py decides which port + TLS config to pass via env.
+    host = os.environ.get("PYRONOVA_HOST", "0.0.0.0")
+    port = int(os.environ.get("PYRONOVA_PORT", "8080"))
+    # Detect worker count from cgroup cpu.max (same pattern as actix's helper).
+    # Pyronova's engine will fall back to num_cpus if PYRONOVA_WORKERS isn't set.
+    app.run(host=host, port=port)

--- a/frameworks/pyronova/launcher.py
+++ b/frameworks/pyronova/launcher.py
@@ -1,0 +1,115 @@
+"""Launcher — spawns two Pyronova processes (HTTP plain + HTTPS).
+
+Plain HTTP on $PORT (default 8080) and HTTPS on $PORT+1 for the json-tls
+profile. A separate HTTP/2 listener on 8443 is launched when TLS certs
+are present — rustls advertises ALPN h2 + http/1.1, so clients negotiate
+automatically.
+
+Why two processes: Pyronova's `app.run()` binds a single port. Running it
+twice is the simplest way to serve plaintext + TLS without adding
+multi-bind support to the engine for one benchmark. Each process gets
+half the available CPUs so we don't over-subscribe the sub-interpreter
+pool.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+def _cpu_count() -> int:
+    try:
+        return max(len(os.sched_getaffinity(0)), 1)
+    except AttributeError:
+        return max(os.cpu_count() or 1, 1)
+
+
+def main() -> int:
+    total = _cpu_count()
+    per_proc = max(total // 2, 1)
+
+    base_port = int(os.environ.get("PORT", "8080"))
+    tls_cert = os.environ.get("TLS_CERT", "/certs/server.crt")
+    tls_key = os.environ.get("TLS_KEY", "/certs/server.key")
+    have_tls = os.path.exists(tls_cert) and os.path.exists(tls_key)
+
+    env_common = dict(os.environ)
+    env_common["PYRONOVA_WORKERS"] = str(per_proc)
+    env_common["PYRONOVA_IO_WORKERS"] = str(per_proc)
+    # Metrics / access log off; benchmarks care about throughput, not logs.
+    env_common.pop("PYRONOVA_LOG", None)
+    env_common.pop("PYRONOVA_METRICS", None)
+    # Hard-silence the tracing subscriber. Default level is ERROR, which
+    # still writes any `tracing::error!` call to stderr — under 4096-conn
+    # load a single recurring error log (see the PyObjRef leak bug) drags
+    # throughput by ~3× from log-pipe contention alone. OFF makes every
+    # tracing macro a zero-cost no-op, matching what Actix / Helidon /
+    # ASP.NET ship in their benchmark images.
+    env_common["PYRONOVA_LOG_LEVEL"] = "OFF"
+
+    procs = []
+
+    # Plain HTTP on $base_port.
+    env_plain = dict(env_common)
+    env_plain["PYRONOVA_PORT"] = str(base_port)
+    env_plain["PYRONOVA_HOST"] = "0.0.0.0"
+    env_plain.pop("PYRONOVA_TLS_CERT", None)
+    env_plain.pop("PYRONOVA_TLS_KEY", None)
+    procs.append(subprocess.Popen(["python3", "app.py"], env=env_plain))
+
+    # HTTPS on $base_port + 1 (json-tls profile target).
+    if have_tls:
+        env_tls = dict(env_common)
+        env_tls["PYRONOVA_PORT"] = str(base_port + 1)
+        env_tls["PYRONOVA_HOST"] = "0.0.0.0"
+        env_tls["PYRONOVA_TLS_CERT"] = tls_cert
+        env_tls["PYRONOVA_TLS_KEY"] = tls_key
+        procs.append(subprocess.Popen(["python3", "app.py"], env=env_tls))
+
+        # HTTP/2 on 8443 (baseline-h2 / static-h2 profile target). ALPN on
+        # this listener advertises h2 + http/1.1; hyper's AutoBuilder picks
+        # the right protocol from the handshake.
+        env_h2 = dict(env_tls)
+        env_h2["PYRONOVA_PORT"] = "8443"
+        procs.append(subprocess.Popen(["python3", "app.py"], env=env_h2))
+
+    def shutdown(_sig, _frame):
+        for p in procs:
+            try:
+                p.terminate()
+            except Exception:
+                pass
+        # give them a moment to drain gracefully; Pyronova's graceful shutdown
+        # waits up to 30s for in-flight conns — the Arena harness typically
+        # SIGKILLs the container anyway, but polite is polite.
+        time.sleep(1)
+        for p in procs:
+            if p.poll() is None:
+                try:
+                    p.kill()
+                except Exception:
+                    pass
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    # Wait on the plain HTTP process; when it exits the harness is done
+    # with us anyway. Terminate the others if they're still up.
+    try:
+        procs[0].wait()
+    except Exception:
+        pass
+    for p in procs[1:]:
+        if p.poll() is None:
+            try:
+                p.terminate()
+            except Exception:
+                pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/frameworks/pyronova/meta.json
+++ b/frameworks/pyronova/meta.json
@@ -1,0 +1,25 @@
+{
+  "display_name": "pyronova",
+  "language": "Python",
+  "type": "tuned",
+  "engine": "pyronova",
+  "description": "Pyronova — Python web framework with a Rust core (hyper + tokio + rustls + mimalloc) and PEP 684 sub-interpreter workers for true multi-core parallelism. Opt-in features: gzip/brotli compression, rustls TLS with h2/h1 ALPN, streaming body ingest, async Postgres via sqlx::PgPool. Handlers are standard Python functions routed via decorators.",
+  "repo": "https://github.com/moomoo-tech/pyronova",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-comp",
+    "json-tls",
+    "upload",
+    "async-db",
+    "static",
+    "baseline-h2",
+    "static-h2",
+    "api-4",
+    "api-16"
+  ],
+  "maintainers": []
+}


### PR DESCRIPTION
## Description

  **Pyronova** — Python web framework with a Rust core (hyper + tokio + rustls + mimalloc) and PEP 684 sub-interpreter workers for true multi-core parallelism. Handlers are standard Python functions routed via decorators — no ASGI, no                    
  event-loop-per-handler.
                                                                                                                                                                                                                                                              
  **Classification**: `tuned`.                              

  **Profiles subscribed** (13):                                                                                                                                                                                                                               
  - H/1.1 Isolated: `baseline`, `pipelined`, `limited-conn`, `json`, `json-comp`, `json-tls`, `upload`, `static`, `async-db`
  - H/1.1 Workload: `api-4`, `api-16`                                                                                                                                                                                                                         
  - H/2: `baseline-h2`, `static-h2`                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                              
  **Why tuned, not production**: static files are served from an in-memory `DashMap<PathBuf, Bytes>` cache that fills on first read. Without this, rereading every file per request pushed RSS past 8 GiB at 6800 conns. Production rules require disk reads  
  per request — so we're honestly classifying as tuned. Other deviations from defaults (compression level, `add_fast_response` for `/pipeline`, tracing subscriber off) are all documented framework APIs.
                                                                                                                                                                                                                                                              
  **Build**: Dockerfile pins `github.com/moomoo-tech/pyronova` at tag `v2.0.2` — byte-for-byte reproducible from a signed git ref.                                                                                                                            
   
  **Local validation**: `./scripts/validate.sh pyronova` passes. Local bench runs on 8 physical cores (not Arena's 64-core) show the expected direction — numbers scale with cores.                                                                           
                                                            
  ---                                                                                                                                                                                                                                                         
                                                            
  **PR Commands** — comment on this PR to trigger (requires collaborator approval):                                                                                                                                                                           
   
  | Command | Description |                                                                                                                                                                                                                                   
  |---------|-------------|                                 
  | `/benchmark -f <framework>` | Run all benchmark tests |
  | `/benchmark -f <framework> -t <test>` | Run a specific test |
  | `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |                                                                                                                                                                
   
  Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.                                                                                                                                                        
                                                            


---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
