### PR TITLE
[userver] move to v3.0

### DIFF
--- a/frameworks/userver/Dockerfile
+++ b/frameworks/userver/Dockerfile
@@ -1,12 +1,8 @@
-FROM ghcr.io/userver-framework/ubuntu-22.04-userver-pg AS builder
-
-RUN apt update && \
-    apt install -y lsb-release wget software-properties-common gnupg && \
-        wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
+FROM ghcr.io/userver-framework/ubuntu-24.04-userver-base AS builder
 
 WORKDIR /src
 RUN git clone https://github.com/userver-framework/userver.git && \
-    cd userver && git checkout bdd5e1e03921ff378b062f86a189c3cfa3d66332
+    cd userver && git checkout v3.0
 
 COPY userver_benchmark/ ./
 RUN mkdir build && cd build && \
@@ -15,7 +11,7 @@ RUN mkdir build && cd build && \
           -DUSERVER_FEATURE_POSTGRESQL=1 \
           -DUSERVER_FEATURE_ERASE_LOG_WITH_LEVEL=warning \
           -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native" -DCMAKE_C_FLAGS="-march=native" \
-          -DCMAKE_CXX_COMPILER=clang++-16 -DCMAKE_C_COMPILER=clang-16 -DUSERVER_USE_LD=lld-16 \
+          -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_C_COMPILER=clang-17 \
           -DUSERVER_LTO=0 .. && \
     make -j $(nproc)
 

--- a/frameworks/userver/userver_benchmark/CMakeLists.txt
+++ b/frameworks/userver/userver_benchmark/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(userver_httparena CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 file(GLOB_RECURSE SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/controllers/*.cpp

--- a/frameworks/userver/userver_benchmark/userver_httparena.cpp
+++ b/frameworks/userver/userver_benchmark/userver_httparena.cpp
@@ -36,7 +36,7 @@ class NoopTracingManager final
 
   void FillRequestWithTracingContext(
       const userver::tracing::Span&,
-      userver::clients::http::RequestTracingEditor) const final {}
+      userver::clients::http::MiddlewareRequest) const final {}
 
   void FillResponseWithTracingContext(
       const userver::tracing::Span&,

--- a/frameworks/userver/userver_configs/static_config.yaml
+++ b/frameworks/userver/userver_configs/static_config.yaml
@@ -40,9 +40,6 @@ components_manager:
                     level: ERROR
                     overflow_behavior: discard  # Drop logs if the system is too busy to write them down.
 
-        tracer:                                 # Component that helps to trace execution times and requests in logs.
-            service-name: userver-httparena     # "You know. You all know exactly who I am. Say my name. " (c)
-
         dns-client:
             fs-task-processor: fs-task-processor
 


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
