### PR TITLE
userver: add limited-conn

### DIFF
--- a/frameworks/userver/meta.json
+++ b/frameworks/userver/meta.json
@@ -9,6 +9,7 @@
   "tests": [
     "baseline",
     "pipelined",
+    "limited-conn",
     "static"
   ],
   "maintainers": []

--- a/frameworks/userver/meta.json
+++ b/frameworks/userver/meta.json
@@ -12,5 +12,5 @@
     "limited-conn",
     "static"
   ],
-  "maintainers": []
+  "maintainers": ["botanegg"]
 }


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
