### PR TITLE
[Java] Spring Boot: Enable JSON TLS

### DIFF
--- a/frameworks/spring-boot/meta.json
+++ b/frameworks/spring-boot/meta.json
@@ -12,6 +12,7 @@
     "pipelined",
     "json",
     "json-comp",
+    "json-tls",
     "upload",
     "static",
     "async-db",

--- a/frameworks/spring-boot/src/main/java/com/httparena/spring/boot/Application.java
+++ b/frameworks/spring-boot/src/main/java/com/httparena/spring/boot/Application.java
@@ -3,6 +3,8 @@ package com.httparena.spring.boot;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.net.SSLHostConfig;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
@@ -21,6 +23,7 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 import org.sqlite.SQLiteDataSource;
 
 import javax.sql.DataSource;
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -92,10 +95,31 @@ public class Application implements WebServerFactoryCustomizer<TomcatServletWebS
 		connector.setPort(8080);
 		connectorCustomizer.customize(connector);
 		factory.addAdditionalConnectors(connector);
+
+		String certPath = System.getenv().getOrDefault("TLS_CERT", "/certs/server.crt");
+		String keyPath = System.getenv().getOrDefault("TLS_KEY", "/certs/server.key");
+
+		if (new File(certPath).exists() && new File(keyPath).exists()) {
+			Connector tlsConnector = new Connector("HTTP/1.1");
+			tlsConnector.setPort(8081);
+			tlsConnector.setScheme("https");
+			tlsConnector.setSecure(true);
+			tlsConnector.setProperty("SSLEnabled", "true");
+
+			SSLHostConfig sslHostConfig = new SSLHostConfig();
+			SSLHostConfigCertificate certificate = new SSLHostConfigCertificate(sslHostConfig, SSLHostConfigCertificate.Type.UNDEFINED);
+			certificate.setCertificateFile(certPath);
+			certificate.setCertificateKeyFile(keyPath);
+			sslHostConfig.addCertificate(certificate);
+			tlsConnector.addSslHostConfig(sslHostConfig);
+
+			factory.addAdditionalConnectors(tlsConnector);
+		}
 	}
 
 	@Override
 	public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
 		registry.addHandler(new EchoWebSocketHandler(), "/ws");
 	}
+
 }

--- a/site/data/json-tls-4096.json
+++ b/site/data/json-tls-4096.json
@@ -384,6 +384,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "spring-boot",
+    "language": "Java",
+    "rps": 188030,
+    "avg_latency": "20.64ms",
+    "p99_latency": "20.64ms",
+    "cpu": "2659.2%",
+    "memory": "3.2GiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "651.02MB",
+    "reconnects": 0,
+    "status_2xx": 958731,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "Swoole",
     "language": "PHP",
     "rps": 776894,

--- a/site/static/logs/json-tls/4096/spring-boot.log
+++ b/site/static/logs/json-tls/4096/spring-boot.log
@@ -1,0 +1,23 @@
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+
+ :: Spring Boot ::                (v4.0.5)
+
+2026-04-27T18:31:28.780Z  INFO 1 --- [spring-boot] [           main] com.httparena.spring.boot.Application    : Starting Application v0.0.1-SNAPSHOT using Java 25.0.2 with PID 1 (/app/app.jar started by root in /app)
+2026-04-27T18:31:28.783Z  INFO 1 --- [spring-boot] [           main] com.httparena.spring.boot.Application    : No active profile set, falling back to 1 default profile: "default"
+2026-04-27T18:31:29.727Z  INFO 1 --- [spring-boot] [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat initialized with ports 8443 (https), 8080 (http), 8081 (https)
+2026-04-27T18:31:29.742Z  INFO 1 --- [spring-boot] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2026-04-27T18:31:29.742Z  INFO 1 --- [spring-boot] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/11.0.20]
+2026-04-27T18:31:29.762Z  INFO 1 --- [spring-boot] [           main] b.w.c.s.WebApplicationContextInitializer : Root WebApplicationContext: initialization completed in 917 ms
+2026-04-27T18:31:30.341Z  INFO 1 --- [spring-boot] [           main] o.a.t.util.net.NioEndpoint.certificate   : Connector [https-jsse-nio-8443], TLS virtual host [_default_], certificate type [UNDEFINED] configured from keystore [Set directly - location unknown] using alias [tomcat] with trust store [null]
+2026-04-27T18:31:30.356Z  INFO 1 --- [spring-boot] [           main] o.a.t.util.net.NioEndpoint.certificate   : Connector [https-jsse-nio-8081], TLS virtual host [_default_], certificate type [UNDEFINED] configured from key [/certs/server.key], certificate [/certs/server.crt] and certificate chain [null] with trust store [null]
+2026-04-27T18:31:30.360Z  INFO 1 --- [spring-boot] [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat started on ports 8443 (https), 8080 (http), 8081 (https) with context path '/'
+2026-04-27T18:31:30.373Z  INFO 1 --- [spring-boot] [           main] com.httparena.spring.boot.Application    : Started Application in 1.965 seconds (process running for 2.487)
+2026-04-27T18:31:31.001Z  INFO 1 --- [spring-boot] [nio-8081-exec-5] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
+2026-04-27T18:31:31.001Z  INFO 1 --- [spring-boot] [nio-8081-exec-5] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+2026-04-27T18:31:31.002Z  INFO 1 --- [spring-boot] [nio-8081-exec-5] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms


### PR DESCRIPTION
## Description

There seems to be no way to configure multiple endpoints via `application.yaml` so we use the same way as was already used by @asvanberg 

---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
