### PR TITLE
[rails] Mark as production

### DIFF
--- a/frameworks/rails/app/controllers/benchmark_controller.rb
+++ b/frameworks/rails/app/controllers/benchmark_controller.rb
@@ -40,24 +40,7 @@ class BenchmarkController < ActionController::API
       d.merge(total: d[:price] * d[:quantity] * m)
     end
 
-    result = JSON.generate(items: items, count: items.length)
-
-    if accept_encodings = request.headers['Accept-Encoding']
-      types = accept_encodings.split(',').map(&:strip)
-      if types.include? 'gzip'
-        sio = StringIO.new
-        gz = Zlib::GzipWriter.new(sio, 1)
-        gz.write(result)
-        gz.close
-        response.headers['content-type'] = 'application/json'
-        response.headers['content-encoding'] = 'gzip'
-        send_data sio.string, disposition: :inline
-      else
-        render json: result
-      end
-    else
-      render json: result
-    end
+    render json: JSON.generate(items: items, count: items.length)
   end
 
   def async_db

--- a/frameworks/rails/config/application.rb
+++ b/frameworks/rails/config/application.rb
@@ -20,14 +20,16 @@ class BenchmarkApp < Rails::Application
   # Disable all middleware we don't need
   config.middleware.delete ActionDispatch::HostAuthorization
   config.middleware.delete ActionDispatch::Callbacks
-  config.middleware.delete ActionDispatch::ActionableExceptions
   config.middleware.delete ActionDispatch::RemoteIp
   config.middleware.delete ActionDispatch::RequestId
   config.middleware.delete Rails::Rack::Logger
   config.middleware.delete ActionDispatch::ShowExceptions
 
+  # Add gzip support
+  config.middleware.insert 0, Rack::Deflater
+
   # Catch unknown HTTP methods, routing errors, and mark /upload as binary
-  config.middleware.insert_before 0, Class.new {
+  config.middleware.insert 0, Class.new {
     VALID_METHODS = %w[GET HEAD POST PUT DELETE PATCH OPTIONS TRACE].to_set.freeze
 
     def initialize(app)

--- a/frameworks/rails/meta.json
+++ b/frameworks/rails/meta.json
@@ -1,7 +1,7 @@
 {
   "display_name": "rails",
   "language": "Ruby",
-  "type": "tuned",
+  "type": "production",
   "engine": "puma",
   "description": "Ruby on Rails (API mode) on Puma, multi-worker with one worker per CPU core.",
   "repo": "https://github.com/rails/rails",


### PR DESCRIPTION
Rails uses standard framework configuration, so it can be marked as production.
Use Rack::Deflater middleware for gzip.