### PR TITLE
Add dogrider

### DIFF
--- a/frameworks/dogrider/Dockerfile
+++ b/frameworks/dogrider/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /source
+
+COPY riderdog.csproj ./
+RUN dotnet restore
+
+COPY . .
+RUN dotnet publish -c Release --no-self-contained -o /app
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0
+WORKDIR /app
+COPY --from=build /app .
+
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "riderdog.dll"]

--- a/frameworks/dogrider/Program.cs
+++ b/frameworks/dogrider/Program.cs
@@ -10,7 +10,7 @@ internal static class Program
         await using var server = new DogriderServer(
             ip: "0.0.0.0",
             port: 8080,
-            reactorCount: Math.Max(1, 16),
+            reactorCount: Math.Max(1, 64),
             handler: new EchoHandler());
 
         server.Start();

--- a/frameworks/dogrider/Program.cs
+++ b/frameworks/dogrider/Program.cs
@@ -1,0 +1,86 @@
+using dogrider.Protocol;
+using dogrider.Server;
+
+namespace riderdog;
+
+internal static class Program
+{
+    private static async Task Main()
+    {
+        await using var server = new DogriderServer(
+            ip: "0.0.0.0",
+            port: 8080,
+            reactorCount: Math.Max(1, 16),
+            handler: new EchoHandler());
+
+        server.Start();
+        
+        Console.WriteLine("dogrider listening on ws://0.0.0.0:8080/");
+
+        var stop = new TaskCompletionSource();
+        
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true; stop.TrySetResult(); 
+        };
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => stop.TrySetResult();
+        
+        await stop.Task;
+        await server.StopAsync();
+    }
+}
+
+internal sealed class EchoHandler : Handler
+{
+    public async ValueTask HandleAsync(IConnection connection)
+    {
+        while (true)
+        {
+            var frames = await connection.ReadFramesAsync();
+
+            foreach (var frame in frames)
+            {
+                if (frame.IsError(out var err))
+                {
+                    if (err.ErrorType is FrameErrorType.ConnectionClosed)
+                    {
+                        return;
+                    }
+                    
+                    await connection.CloseAsync(reason: err.Message, statusCode: 1002);
+                    
+                    return;
+                }
+
+                switch (frame.Type)
+                {
+                    case FrameType.Text:
+                        
+                        connection.Write(frame.Data);
+                        break;
+                    
+                    case FrameType.Binary:
+                        
+                        connection.Write(frame.Data, FrameType.Binary);
+                        break;
+                    
+                    case FrameType.Ping:
+                        
+                        connection.Pong(frame.Data);
+                        break;
+                    
+                    case FrameType.Close:
+                        
+                        await connection.CloseAsync();
+                        return;
+                    
+                    case FrameType.Pong:
+                    case FrameType.Continue:
+                        break;
+                }
+            }
+
+            await connection.FlushAsync();
+        }
+    }
+}

--- a/frameworks/dogrider/README.md
+++ b/frameworks/dogrider/README.md
@@ -1,0 +1,9 @@
+# dogrider
+
+A man riding a dog
+
+## Stack
+
+- **Language:** C# / .NET 10 
+- **Framework:** dogrider
+- **Engine:** zerg

--- a/frameworks/dogrider/meta.json
+++ b/frameworks/dogrider/meta.json
@@ -1,0 +1,15 @@
+{
+  "display_name": "dogrider",
+  "language": "C#",
+  "type": "production",
+  "engine": "zerg",
+  "description": "GenHTTP websockets with zerg backend",
+  "repo": "https://github.com/MDA2AV/dogrider",
+  "enabled": true,
+  "tests": [
+    "echo-ws"
+  ],
+  "maintainers": [
+    "MDA2AV"
+  ]
+}

--- a/frameworks/dogrider/riderdog.csproj
+++ b/frameworks/dogrider/riderdog.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <RootNamespace>riderdog</RootNamespace>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="dogrider" Version="1.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/site/data/echo-ws-16384.json
+++ b/site/data/echo-ws-16384.json
@@ -79,6 +79,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "dogrider",
+    "language": "C#",
+    "rps": 3159374,
+    "avg_latency": "5.08ms",
+    "p99_latency": "12.10ms",
+    "cpu": "5660.7%",
+    "memory": "3.4GiB",
+    "connections": 16384,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "21.48MB/s",
+    "reconnects": 4,
+    "status_2xx": 15796872,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "genhttp",
     "language": "C#",
     "rps": 2060810,

--- a/site/data/echo-ws-4096.json
+++ b/site/data/echo-ws-4096.json
@@ -79,6 +79,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "dogrider",
+    "language": "C#",
+    "rps": 3351721,
+    "avg_latency": "1.22ms",
+    "p99_latency": "4.26ms",
+    "cpu": "5859.4%",
+    "memory": "2.5GiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "22.37MB/s",
+    "reconnects": 0,
+    "status_2xx": 16758607,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "genhttp",
     "language": "C#",
     "rps": 2209207,

--- a/site/data/echo-ws-512.json
+++ b/site/data/echo-ws-512.json
@@ -79,6 +79,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "dogrider",
+    "language": "C#",
+    "rps": 3268792,
+    "avg_latency": "156us",
+    "p99_latency": "864us",
+    "cpu": "5860.9%",
+    "memory": "2.3GiB",
+    "connections": 512,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "21.82MB/s",
+    "reconnects": 0,
+    "status_2xx": 16343961,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "genhttp",
     "language": "C#",
     "rps": 2290988,

--- a/site/data/frameworks.json
+++ b/site/data/frameworks.json
@@ -129,6 +129,13 @@
     "type": "tuned",
     "engine": "deno"
   },
+  "dogrider": {
+    "dir": "dogrider",
+    "description": "GenHTTP websockets with zerg backend",
+    "repo": "https://github.com/MDA2AV/dogrider",
+    "type": "production",
+    "engine": "zerg"
+  },
   "elysia": {
     "dir": "elysia",
     "description": "An ergonomic framework for Humans",

--- a/site/static/logs/echo-ws/16384/dogrider.log
+++ b/site/static/logs/echo-ws/16384/dogrider.log
@@ -1,0 +1,198 @@
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w7] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w8] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w6] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w1] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w0] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w5] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w9] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w3] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w4] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w2] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w10] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w11] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w12] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w29] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w13] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w14] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w32] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w15] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w16] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w17] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w18] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w19] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w20] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w21] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w22] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w23] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w24] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w25] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w26] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w27] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w28] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w30] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w31] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w33] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w34] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+[w35] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+params: p.flags=0x3000 p.wq_fd=0
+[w36] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w37] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w38] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w39] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w40] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w42] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w43] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w44] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w45] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w46] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w47] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w48] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w49] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w50] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w51] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w52] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w53] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w54] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w55] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w41] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w56] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w57] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w58] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w59] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w60] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w61] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w62] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w63] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+Server started with 64 reactors + 1 acceptor
+[acceptor] ring flags = 0x10000 (SQPOLL=False, SQ_AFF=False)
+[acceptor] Multishot accept armed
+dogrider listening on ws://0.0.0.0:8080/
+[acceptor] Load balancing across 64 reactors
+[dogrider] Connection 118 failed: Operation is not valid due to the current state of the object.

--- a/site/static/logs/echo-ws/4096/dogrider.log
+++ b/site/static/logs/echo-ws/4096/dogrider.log
@@ -1,0 +1,198 @@
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w10] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w2] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w0] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w32] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+[w5] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+params: p.flags=0x3000 p.wq_fd=0
+[w6] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w11] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w36] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w1] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w3] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w8] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+[w9] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w7] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+params: p.flags=0x3000 p.wq_fd=0
+[w4] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w37] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w12] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w33] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w13] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w14] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w15] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w16] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w17] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w18] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w38] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w19] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w20] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w21] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w22] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w23] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+[w24] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+params: p.flags=0x3000 p.wq_fd=0
+[w25] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w26] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w27] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w28] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w29] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w31] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w30] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w34] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w35] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w40] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w39] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w41] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w42] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w43] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w44] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w45] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w46] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w47] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w48] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w49] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w50] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w51] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w52] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w53] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w54] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w55] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w56] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w57] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w58] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w59] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w60] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w61] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w62] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w63] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+Server started with 64 reactors + 1 acceptor
+[acceptor] ring flags = 0x10000 (SQPOLL=False, SQ_AFF=False)
+[acceptor] Multishot accept armed
+dogrider listening on ws://0.0.0.0:8080/
+[acceptor] Load balancing across 64 reactors
+[dogrider] Connection 118 failed: Operation is not valid due to the current state of the object.

--- a/site/static/logs/echo-ws/512/dogrider.log
+++ b/site/static/logs/echo-ws/512/dogrider.log
@@ -1,0 +1,197 @@
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+[w6] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+params: p.flags=0x3000 p.wq_fd=0
+[w37] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w5] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w8] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w2] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w1] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w7] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w45] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w9] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w44] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w0] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w38] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w3] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w4] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w10] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w11] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w12] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w13] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w14] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w15] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w16] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w17] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w18] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w19] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w20] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w21] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w22] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w23] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w24] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w25] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w39] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w26] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w27] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w28] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w29] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w30] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w31] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w32] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w33] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w34] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w35] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w36] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w40] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w41] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w42] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w43] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w47] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w46] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w48] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+[w49] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w50] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w51] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w52] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w53] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w54] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w55] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w56] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w57] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w58] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w59] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w60] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w61] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w62] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+shim_create_ring_ex: flags=0x3000 sq_cpu=-1 idle=100
+params: p.flags=0x3000 p.wq_fd=0
+[w63] ring flags = 0x13000 (SQPOLL=False, SQ_AFF=False)
+Server started with 64 reactors + 1 acceptor
+[acceptor] ring flags = 0x10000 (SQPOLL=False, SQ_AFF=False)
+[acceptor] Multishot accept armed
+[acceptor] Load balancing across 64 reactors
+dogrider listening on ws://0.0.0.0:8080/


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
