### PR TITLE
bump dogrider

### DIFF
--- a/frameworks/dogrider/Program.cs
+++ b/frameworks/dogrider/Program.cs
@@ -1,5 +1,6 @@
 using dogrider.Protocol;
 using dogrider.Server;
+using zerg.Engine.Configs;
 
 namespace riderdog;
 
@@ -7,11 +8,45 @@ internal static class Program
 {
     private static async Task Main()
     {
-        await using var server = new DogriderServer(
+        await using var server = new Dogrider(
+            new EngineOptions
+            {
+                Ip = "0.0.0.0",
+                Port = 8080,
+                Backlog = 65535,
+                ReactorCount = 16,
+                AcceptorConfig = new AcceptorConfig(
+                    RingFlags: 0,
+                    SqCpuThread: -1,
+                    SqThreadIdleMs: 100,
+                    RingEntries: 8 * 1024,
+                    BatchSqes: 4096,
+                    CqTimeout: 100_000_000,
+                    IPVersion: IPVersion.IPv4Only
+                ),
+                ReactorConfigs = Enumerable.Range(0, 16).Select(_ => new ReactorConfig(
+                    RingFlags: (1u << 12) | (1u << 13), // SINGLE_ISSUER | DEFER_TASKRUN
+                    SqCpuThread: -1,
+                    SqThreadIdleMs: 100,
+                    RingEntries: 1 * 1024,
+                    RecvBufferSize: 1 * 1024,
+                    BufferRingEntries: 16 * 1024,
+                    BatchCqes: 4096,
+                    MaxConnectionsPerReactor: 1 * 384,
+                    CqTimeout: 1_000_000,
+                    ConnectionBufferRingEntries: 32,
+                    IncrementalBufferConsumption: false
+                )).ToArray()
+            }, 
+            handler: new EchoHandlerPipelined());
+        
+        /*
+        await using var server = new Dogrider(
             ip: "0.0.0.0",
             port: 8080,
-            reactorCount: Math.Max(1, 64),
+            reactorCount: Math.Max(1, 16),
             handler: new EchoHandler());
+        */
 
         server.Start();
         
@@ -30,8 +65,11 @@ internal static class Program
     }
 }
 
-internal sealed class EchoHandler : Handler
+internal sealed class EchoHandlerPipelined : Handler
 {
+    
+    private static ReadOnlySpan<byte> _hello => "hello"u8;
+    
     public async ValueTask HandleAsync(IConnection connection)
     {
         while (true)
@@ -56,12 +94,14 @@ internal sealed class EchoHandler : Handler
                 {
                     case FrameType.Text:
                         
-                        connection.Write(frame.Data);
+                        //connection.Write(frame.Data);
+                        connection.Write(_hello);
                         break;
                     
                     case FrameType.Binary:
                         
-                        connection.Write(frame.Data, FrameType.Binary);
+                        //connection.Write(frame.Data, FrameType.Binary);
+                        connection.Write(_hello, FrameType.Binary);
                         break;
                     
                     case FrameType.Ping:

--- a/frameworks/dogrider/riderdog.csproj
+++ b/frameworks/dogrider/riderdog.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="dogrider" Version="1.0.0" />
+      <PackageReference Include="dogrider" Version="10.0.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
