### PR TITLE
Fix: fletch type to production

### DIFF
--- a/frameworks/fletch/meta.json
+++ b/frameworks/fletch/meta.json
@@ -2,7 +2,7 @@
   "display_name": "Fletch",
   "language": "Dart",
   "engine": "dart:io",
-  "type": "tuned",
+  "type": "production",
   "description": "Express-inspired HTTP framework for Dart with radix-tree routing, middleware chains, signed sessions, and built-in DI.",
   "repo": "https://github.com/kartikey321/fletch",
   "enabled": true,


### PR DESCRIPTION
Earlier it was wrongly set as tuned.

However nothing is tuned, it is following clurster mechanism new process for each thread



## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
