### PR TITLE
[roda] Mark async-db call as io bound

### DIFF
--- a/frameworks/roda/app.rb
+++ b/frameworks/roda/app.rb
@@ -246,7 +246,7 @@ class App < Roda
   def self.redis
     @redis ||= begin
       return unless ENV['REDIS_URL']
-      max_connections = ENV.fetch('MAX_THREADS', 4).to_i
+      max_connections = ENV.fetch('MAX_THREADS', 4).to_i + ENV.fetch("MAX_IO_THREADS", 10).to_i
       ConnectionPool::Wrapper.new(size: max_connections, timeout: 10) do
         Redis.new(url: ENV['REDIS_URL'])
       end

--- a/frameworks/roda/config.ru
+++ b/frameworks/roda/config.ru
@@ -2,12 +2,14 @@ require_relative 'app'
 
 # Threads marked as IO bound are allowed to go over Puma's max thread limit.
 class MarkAsIOBoundThreads
+  IOBoundPaths = %w[/baseline11 /baseline2 /async-db].map { [_1, nil] }.to_h.freeze
+
   def initialize(app)
     @app = app
   end
 
   def call(env)
-    if env['PATH_INFO'].start_with? '/baseline'
+    if IOBoundPaths.has_key? env['PATH_INFO']
       env["puma.mark_as_io_bound"].call
     end
     @app.call(env)


### PR DESCRIPTION
Also increase connection pool to allow more connections for io bound
threads.