### PR TITLE
Update simplew-tuned

### DIFF
--- a/frameworks/simplew-tuned/Program.cs
+++ b/frameworks/simplew-tuned/Program.cs
@@ -82,6 +82,7 @@ void ConfigureRoutes(SimpleWServer server)
             options.Path = "/data/static";
             options.Prefix = "/static/";
             options.AutoIndex = false;
+            options.CompressedDiskCache = true; // read compressed files in disk (created them if they don't exists)
         });
     }
 

--- a/frameworks/simplew-tuned/simplew-arena.csproj
+++ b/frameworks/simplew-tuned/simplew-arena.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260601-1868" />
+    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260606-1878" />
   </ItemGroup>
 </Project>

--- a/frameworks/simplew-tuned/simplew-arena.csproj
+++ b/frameworks/simplew-tuned/simplew-arena.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="SimpleW" Version="26.0.0" />
+    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260530-1860" />
   </ItemGroup>
 </Project>

--- a/frameworks/simplew-tuned/simplew-arena.csproj
+++ b/frameworks/simplew-tuned/simplew-arena.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260531-1864" />
+    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260601-1868" />
   </ItemGroup>
 </Project>

--- a/frameworks/simplew-tuned/simplew-arena.csproj
+++ b/frameworks/simplew-tuned/simplew-arena.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260530-1860" />
+    <PackageReference Include="SimpleW" Version="26.0.1-alpha.20260531-1864" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

update simplew-tuned to 26.0.1-alpha.20260530-1860
this fixes a stackoverflow under heavy load !!

---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
