### PR TITLE
[true-async] bump base image to v0.7.0-rc.5 (adaptive throttle — HTTP/1 pipelined fix)

### DIFF
--- a/frameworks/true-async-server/Dockerfile
+++ b/frameworks/true-async-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM trueasync/php-true-async:0.7.0-rc.4-php8.6
+FROM trueasync/php-true-async:0.7.0-rc.5-php8.6
 
 RUN printf '%s\n' \
       'opcache.jit=1255' \


### PR DESCRIPTION
## What
Bumps true-async-server base image **rc.4 → rc.5**.

### rc.5 = rc.4 +
**Adaptive reactor-poll throttle** (true-async/php-async): the fixed 1ms throttle (added to fix HTTP/3 PTO collapse) regressed pipelined/keep-alive HTTP/1 ~29% at high concurrency. rc.5 makes the poll window adaptive — **1ms when a QUIC ACK/PTO timer is imminent**, **batch up to 10ms otherwise** (so HTTP/1 amortises the poll), via a new `uv_next_timer_timeout()` in the TrueAsync libuv fork (graceful fallback to fixed 1ms on stock libuv).

Local A/B (-c512): pipelined **2.23M → 2.88M (+29%)**.

### Validating
- **H1 (baseline/pipelined/static)** should recover toward the pre-rc.3 levels.
- **HTTP/3** must NOT regress (the adaptive keeps QUIC timers on time; this run confirms it at scale).

Carries all rc.4 fixes (H3 bidi stream-credit replenish #79, patched libuv skip-redundant-EPOLL_CTL_MOD).