### PR TITLE
[true-async] bump base image to v0.7.0-rc.6 (restore HTTP/1+H2 perf)

### DIFF
--- a/frameworks/true-async-server/Dockerfile
+++ b/frameworks/true-async-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM trueasync/php-true-async:0.7.0-rc.4-php8.6
+FROM trueasync/php-true-async:0.7.0-rc.6-php8.6
 
 RUN printf '%s\n' \
       'opcache.jit=1255' \


### PR DESCRIPTION
## What

Bumps `frameworks/true-async-server` base image `0.7.0-rc.4` → **`0.7.0-rc.6-php8.6`**.

## Why

rc.6 **reverts the experimental 1ms reactor-poll throttle back to the original `CLOCK_MONOTONIC_COARSE` jiffy (~10ms)**. The fine 1ms tick (introduced for an H3 PTO fix) regressed HTTP/1 (pipelined/baseline) and HTTP/2, which benefit from coarse batching. This restores H1/H2 to their prior numbers.

The **H3 stream-credit fix stays in** (server v0.7.1 — `ngtcp2_conn_extend_max_streams_bidi` on stream close, the fix that took baseline-h3/static-h3 c=64 from ~1277 req/s back to normal).

Supersedes rc.5 (#775 — used an *adaptive* throttle that shifted the regression onto h2c at scale).

## Image

`trueasync/php-true-async:0.7.0-rc.6-php8.6` (on Docker Hub, php 8.6).