### PR TITLE
Add CRUD, H2C, and fortunes to Ktor

### DIFF
--- a/frameworks/ktor/build.gradle.kts
+++ b/frameworks/ktor/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(ktorLibs.server.contentNegotiation)
     implementation(ktorLibs.serialization.kotlinx.json)
     implementation(ktorLibs.server.websockets)
+    implementation(ktorLibs.server.htmlBuilder)
 
     implementation(libs.exposed.core)
     implementation(libs.exposed.r2dbc)

--- a/frameworks/ktor/build.gradle.kts
+++ b/frameworks/ktor/build.gradle.kts
@@ -1,19 +1,14 @@
 plugins {
-    kotlin("jvm") version "2.3.0"
-    kotlin("plugin.serialization") version "2.3.0"
-    id("io.ktor.plugin") version "3.4.1"
-    application
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(ktorLibs.plugins.ktor)
 }
 
 group = "com.httparena"
 version = "1.0.0"
 
 application {
-    mainClass.set("com.httparena.ApplicationKt")
-}
-
-repositories {
-    mavenCentral()
+    mainClass = "com.httparena.ApplicationKt"
 }
 
 dependencies {
@@ -29,9 +24,9 @@ dependencies {
     implementation(libs.exposed.core)
     implementation(libs.exposed.r2dbc)
     implementation(libs.exposed.json)
+    implementation(libs.logback.classic)
     implementation(libs.postgresql)
     implementation(libs.r2dbc.pool)
-    implementation(libs.logback.classic)
 }
 
 ktor {

--- a/frameworks/ktor/gradle/libs.versions.toml
+++ b/frameworks/ktor/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 exposed = "1.2.0"
+kotlin = "2.3.21"
 
 [libraries]
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.15" }
@@ -10,3 +11,7 @@ exposed-r2dbc = { module = "org.jetbrains.exposed:exposed-r2dbc", version.ref = 
 exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
 postgresql = { module = "org.postgresql:r2dbc-postgresql", version = "1.1.1.RELEASE" }
 r2dbc-pool = { module = "io.r2dbc:r2dbc-pool", version = "1.0.2.RELEASE" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/frameworks/ktor/gradle/libs.versions.toml
+++ b/frameworks/ktor/gradle/libs.versions.toml
@@ -4,6 +4,9 @@ exposed = "1.2.0"
 [libraries]
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.15" }
 
+# Templating
+kotlinx-kotlinxHtml = { module = "org.jetbrains.kotlinx:kotlinx-html", version = "0.12.0" }
+
 # Database
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposed-r2dbc = { module = "org.jetbrains.exposed:exposed-r2dbc", version.ref = "exposed" }

--- a/frameworks/ktor/gradle/libs.versions.toml
+++ b/frameworks/ktor/gradle/libs.versions.toml
@@ -4,9 +4,6 @@ exposed = "1.2.0"
 [libraries]
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.15" }
 
-# Templating
-kotlinx-kotlinxHtml = { module = "org.jetbrains.kotlinx:kotlinx-html", version = "0.12.0" }
-
 # Database
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposed-r2dbc = { module = "org.jetbrains.exposed:exposed-r2dbc", version.ref = "exposed" }

--- a/frameworks/ktor/meta.json
+++ b/frameworks/ktor/meta.json
@@ -21,7 +21,11 @@
     "baseline-h2",
     "static-h2",
     "echo-ws",
-    "echo-ws-pipeline"
+    "echo-ws-pipeline",
+    "crud",
+    "crud-pipeline",
+    "crud-h2",
+    "crud-pipeline-h2"
   ],
   "maintainers": [
     "bjhham"

--- a/frameworks/ktor/meta.json
+++ b/frameworks/ktor/meta.json
@@ -20,12 +20,11 @@
     "api-16",
     "baseline-h2",
     "static-h2",
+    "baseline-h2c",
+    "json-h2c",
     "echo-ws",
     "echo-ws-pipeline",
-    "crud",
-    "crud-pipeline",
-    "crud-h2",
-    "crud-pipeline-h2"
+    "crud"
   ],
   "maintainers": [
     "bjhham"

--- a/frameworks/ktor/meta.json
+++ b/frameworks/ktor/meta.json
@@ -24,7 +24,8 @@
     "json-h2c",
     "echo-ws",
     "echo-ws-pipeline",
-    "crud"
+    "crud",
+    "fortunes"
   ],
   "maintainers": [
     "bjhham"

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -1,4 +1,9 @@
-rootProject.name = "ktor-httparena"
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
 dependencyResolutionManagement {
     repositories {
@@ -8,3 +13,5 @@ dependencyResolutionManagement {
         create("ktorLibs").from("io.ktor:ktor-version-catalog:3.5.0")
     }
 }
+
+rootProject.name = "ktor-httparena"

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -16,23 +16,11 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
-import kotlinx.html.body
-import kotlinx.html.head
-import kotlinx.html.table
-import kotlinx.html.td
-import kotlinx.html.th
-import kotlinx.html.title
-import kotlinx.html.tr
-import org.jetbrains.exposed.v1.core.SortOrder
-import org.jetbrains.exposed.v1.core.between
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.r2dbc.selectAll
+import kotlinx.coroutines.flow.*
+import kotlinx.html.*
+import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
-import org.jetbrains.exposed.v1.r2dbc.update
-import org.jetbrains.exposed.v1.r2dbc.upsert
+import org.jetbrains.exposed.v1.r2dbc.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -295,11 +283,6 @@ private fun Application.configureRouting(appData: AppData) {
 
     }
 }
-
-private val RUNTIME_FORTUNE = Fortune(
-    id = 0,
-    message = "Additional fortune added at request time."
-)
 
 fun Route.crudEndpoints(appData: AppData, log: Logger = LoggerFactory.getLogger("crudRoutes")): Route =
     route("/crud/items") {

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -34,6 +34,20 @@ fun main() {
     println("Ktor HttpArena server starting on :8080 (HTTP/1.1) and :8443 (HTTPS/HTTP+2)")
 
     val environment = applicationEnvironment {}
+    val module: Application.() -> Unit = {
+        install(DefaultHeaders) {
+            header("Server", "ktor")
+        }
+        install(Compression) {
+            gzip()
+        }
+        install(ContentNegotiation) {
+            json(appData.json)
+        }
+        install(WebSockets)
+
+        configureRouting(appData)
+    }
     val server = embeddedServer(Netty, environment, {
         enableHttp2 = true
 
@@ -61,20 +75,33 @@ fun main() {
                 host = "0.0.0.0"
             }
         }
-    }) {
-        install(DefaultHeaders) {
-            header("Server", "ktor")
-        }
-        install(Compression) {
-            gzip()
-        }
-        install(ContentNegotiation) {
-            json(appData.json)
-        }
-        install(WebSockets)
+    }, module)
 
-        configureRouting(appData)
-    }
+    // Spin up a second server for H2C
+    embeddedServer(Netty, environment, {
+        enableH2c = true
+
+        connector {
+            port = 8082
+            host = "0.0.0.0"
+        }
+    }) {
+        // Reject any non-HTTP/2 request hitting the H2C connector
+        intercept(ApplicationCallPipeline.Plugins) {
+            val version = call.request.httpVersion
+            if (!version.startsWith("HTTP/2")) {
+                call.response.headers.append(HttpHeaders.Upgrade, "h2c")
+                call.response.headers.append(HttpHeaders.Connection, "Upgrade")
+                call.respond(HttpStatusCode.UpgradeRequired, "HTTP/2 (h2c) required")
+                finish()
+                return@intercept
+            }
+        }
+        // Import the same endpoints for this server
+        module()
+
+    }.start(wait = false)
+
     server.start(wait = true)
 }
 

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -1,7 +1,7 @@
 package com.httparena
 
+import com.httparena.DbResponse.Companion.toResponse
 import io.ktor.http.*
-import io.ktor.network.util.DefaultByteBufferPool
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -15,13 +15,18 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
-import io.ktor.utils.io.pool.useInstance
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import kotlinx.io.Buffer
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.between
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.jetbrains.exposed.v1.r2dbc.update
+import org.jetbrains.exposed.v1.r2dbc.upsert
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.File
 
 fun main() {
@@ -162,7 +167,7 @@ private fun Application.configureRouting(appData: AppData) {
             val max = call.request.queryParameters["max"]?.toIntOrNull() ?: 50
             val limit = (call.request.queryParameters["limit"]?.toIntOrNull() ?: 50).coerceIn(1, 50)
             try {
-                val items = suspendTransaction(appData.postgres) {
+                val items = suspendTransaction(appData.postgres, readOnly = true) {
                     with(ItemTable) {
                         selectAll()
                             .where { price.between(min, max) }
@@ -171,12 +176,7 @@ private fun Application.configureRouting(appData: AppData) {
                             .toList()
                     }
                 }
-                call.respond(
-                    DbResponse(
-                        items = items,
-                        count = items.size
-                    )
-                )
+                call.respond(items.toResponse())
             } catch (e: Exception) {
                 log.error("Failed to load items from DB", e)
                 call.respondBytes("{\"items\":[],\"count\":0}".toByteArray(), ContentType.Application.Json)
@@ -213,5 +213,148 @@ private fun Application.configureRouting(appData: AppData) {
                 send(message)
         }
 
+        /**
+         * CRUD (REST API) — paginated list, cached single-item read, upsert create, partial update.
+         * https://www.http-arena.com/docs/test-profiles/h1/isolated/crud/
+         */
+        crudEndpoints(appData)
+
     }
 }
+
+fun Route.crudEndpoints(appData: AppData, log: Logger = LoggerFactory.getLogger("crudRoutes")): Route =
+    route("/crud/items") {
+        get {
+            val categoryParam = call.request.queryParameters["category"] ?: "electronics"
+            val page = (call.request.queryParameters["page"]?.toIntOrNull() ?: 1).coerceAtLeast(1)
+            val limit = (call.request.queryParameters["limit"]?.toIntOrNull() ?: 10).coerceIn(1, 50)
+            val offset = (page - 1).toLong() * limit
+
+            try {
+                val items = suspendTransaction(appData.postgres, readOnly = true) {
+                    ItemTable.selectAll()
+                        .where { ItemTable.category eq categoryParam }
+                        .orderBy(ItemTable.id, SortOrder.ASC)
+                        .limit(limit).offset(offset)
+                        .map(ItemTable::toDbItem)
+                        .toList()
+                }
+                call.respond(CrudListResponse(items = items, total = items.size, page = page, limit = limit))
+            } catch (e: Exception) {
+                log.error("CRUD list failed", e)
+                call.respond(HttpStatusCode.InternalServerError, "list failed")
+            }
+        }
+
+        get("{id}") {
+            val id = call.pathParameters["id"]?.toUIntOrNull() ?: run {
+                call.respondText("bad id", status = HttpStatusCode.BadRequest)
+                return@get
+            }
+
+            val cached = appData.crudCache.get(id)
+            if (cached != null) {
+                call.response.headers.append("X-Cache", "HIT")
+                call.respondBytes(cached, ContentType.Application.Json)
+                return@get
+            }
+
+            try {
+                val row = suspendTransaction(appData.postgres, readOnly = true) {
+                    ItemTable.selectAll()
+                        .where { ItemTable.id eq id }
+                        .limit(1)
+                        .map(ItemTable::toDbItem)
+                        .firstOrNull()
+                }
+                if (row == null) {
+                    call.respondText("not found", status = HttpStatusCode.NotFound)
+                    return@get
+                }
+                val body = appData.json.encodeToString(row).toByteArray()
+                appData.crudCache.put(id, body)
+                call.response.headers.append("X-Cache", "MISS")
+                call.respondBytes(body, ContentType.Application.Json)
+            } catch (e: Exception) {
+                log.error("CRUD read failed", e)
+                call.respond(HttpStatusCode.InternalServerError, "read failed")
+            }
+        }
+
+        post {
+            val req = try {
+                call.receive<CrudCreateRequest>()
+            } catch (_: Exception) {
+                call.respondText("invalid body", status = HttpStatusCode.UnprocessableEntity)
+                return@post
+            }
+            try {
+                suspendTransaction(appData.postgres) {
+                    ItemTable.upsert(
+                        keys = arrayOf(ItemTable.id),
+                        onUpdateExclude = listOf(ItemTable.ratingScore, ItemTable.ratingCount),
+                    ) {
+                        it[id] = req.id
+                        it[name] = req.name
+                        it[category] = req.category
+                        it[price] = req.price
+                        it[quantity] = req.quantity
+                        it[active] = req.active
+                        it[tags] = req.tags
+                        it[ratingScore] = 0
+                        it[ratingCount] = 0
+                    }
+                }
+                appData.crudCache.invalidate(req.id)
+                val response = DbItem(
+                    id = req.id, name = req.name, category = req.category,
+                    price = req.price, quantity = req.quantity, active = req.active,
+                    tags = req.tags, rating = RatingInfo(0, 0)
+                )
+                call.respond(HttpStatusCode.Created, response)
+            } catch (e: Exception) {
+                log.error("CRUD create failed", e)
+                call.respond(HttpStatusCode.InternalServerError, "create failed")
+            }
+        }
+
+        put("{id}") {
+            val id = call.pathParameters["id"]?.toUIntOrNull() ?: run {
+                call.respondText("bad id", status = HttpStatusCode.BadRequest)
+                return@put
+            }
+            val req = try {
+                call.receive<CrudUpdateRequest>()
+            } catch (_: Exception) {
+                call.respondText("invalid body", status = HttpStatusCode.UnprocessableEntity)
+                return@put
+            }
+            try {
+                val updated = suspendTransaction(appData.postgres, readOnly = false) {
+                    val rows = ItemTable.update({ ItemTable.id eq id }) { stmt ->
+                        req.name?.let { v -> stmt[ItemTable.name] = v }
+                        req.price?.let { v -> stmt[ItemTable.price] = v }
+                        req.quantity?.let { v -> stmt[ItemTable.quantity] = v }
+                    }
+                    if (rows == 0) {
+                        null
+                    } else {
+                        ItemTable.selectAll()
+                            .where { ItemTable.id eq id }
+                            .limit(1)
+                            .map(ItemTable::toDbItem)
+                            .firstOrNull()
+                    }
+                }
+                appData.crudCache.invalidate(id)
+                if (updated == null) {
+                    call.respondText("not found", status = HttpStatusCode.NotFound)
+                } else {
+                    call.respond(HttpStatusCode.OK, updated)
+                }
+            } catch (e: Exception) {
+                log.error("CRUD update failed", e)
+                call.respond(HttpStatusCode.InternalServerError, "update failed")
+            }
+        }
+    }

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -5,6 +5,7 @@ import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
+import io.ktor.server.html.*
 import io.ktor.server.http.content.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.compression.*
@@ -18,6 +19,13 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import kotlinx.html.body
+import kotlinx.html.head
+import kotlinx.html.table
+import kotlinx.html.td
+import kotlinx.html.th
+import kotlinx.html.title
+import kotlinx.html.tr
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.between
 import org.jetbrains.exposed.v1.core.eq
@@ -246,8 +254,52 @@ private fun Application.configureRouting(appData: AppData) {
          */
         crudEndpoints(appData)
 
+        /**
+         * Fortunes (template-engine benchmark) — kotlinx.html DSL.
+         * https://www.http-arena.com/docs/test-profiles/h1/isolated/fortunes/
+         */
+        get("/fortunes") {
+            val fortunes = mutableListOf<Fortune>()
+            try {
+                suspendTransaction(appData.postgres, readOnly = true) {
+                    FortuneTable.selectAll()
+                        .map(FortuneTable::toFortune)
+                        .toList(fortunes)
+                }
+            } catch (e: Exception) {
+                log.error("Failed to load fortunes from DB", e)
+                call.respond(HttpStatusCode.InternalServerError, "fortunes failed")
+                return@get
+            }
+            fortunes.add(RUNTIME_FORTUNE)
+            fortunes.sortBy { it.message }
+
+            call.respondHtml(HttpStatusCode.OK) {
+                head { title { +"Fortunes" } }
+                body {
+                    table {
+                        tr {
+                            th { +"id" }
+                            th { +"message" }
+                        }
+                        for ((id, message) in fortunes) {
+                            tr {
+                                td { +id.toString() }
+                                td { +message }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
     }
 }
+
+private val RUNTIME_FORTUNE = Fortune(
+    id = 0,
+    message = "Additional fortune added at request time."
+)
 
 fun Route.crudEndpoints(appData: AppData, log: Logger = LoggerFactory.getLogger("crudRoutes")): Route =
     route("/crud/items") {

--- a/frameworks/ktor/src/main/kotlin/com/httparena/DBSchema.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/DBSchema.kt
@@ -16,7 +16,7 @@ object ItemTable: UIntIdTable("items") {
     val ratingCount = integer("rating_count")
 
     fun toDbItem(row: ResultRow) = DbItem(
-        id = row[id].value.toInt(),
+        id = row[id].value,
         name = row[name],
         category = row[category],
         price = row[price],

--- a/frameworks/ktor/src/main/kotlin/com/httparena/DBSchema.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/DBSchema.kt
@@ -2,6 +2,7 @@ package com.httparena
 
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.UIntIdTable
 import org.jetbrains.exposed.v1.json.jsonb
 
@@ -27,5 +28,15 @@ object ItemTable: UIntIdTable("items") {
             row[ratingScore],
             row[ratingCount]
         )
+    )
+}
+
+object FortuneTable : Table("fortune") {
+    val id = integer("id")
+    val message = text("message")
+
+    fun toFortune(row: ResultRow) = Fortune(
+        id = row[id],
+        message = row[message]
     )
 }

--- a/frameworks/ktor/src/main/kotlin/com/httparena/DataTypes.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/DataTypes.kt
@@ -41,7 +41,7 @@ data class JsonResponse(
 
 @Serializable
 data class DbItem(
-    val id: Int,
+    val id: UInt,
     val name: String,
     val category: String,
     val price: Int,
@@ -55,4 +55,34 @@ data class DbItem(
 data class DbResponse(
     val items: List<DbItem>,
     val count: Int
+) {
+    companion object {
+        fun List<DbItem>.toResponse() = DbResponse(this, size)
+    }
+}
+
+@Serializable
+data class CrudListResponse(
+    val items: List<DbItem>,
+    val total: Int,
+    val page: Int,
+    val limit: Int
+)
+
+@Serializable
+data class CrudCreateRequest(
+    val id: UInt,
+    val name: String,
+    val category: String,
+    val price: Int,
+    val quantity: Int,
+    val active: Boolean = false,
+    val tags: List<String> = emptyList()
+)
+
+@Serializable
+data class CrudUpdateRequest(
+    val name: String? = null,
+    val price: Int? = null,
+    val quantity: Int? = null
 )

--- a/frameworks/ktor/src/main/kotlin/com/httparena/DataTypes.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/DataTypes.kt
@@ -86,3 +86,8 @@ data class CrudUpdateRequest(
     val price: Int? = null,
     val quantity: Int? = null
 )
+
+data class Fortune(
+    val id: Int,
+    val message: String
+)

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Utils.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Utils.kt
@@ -64,6 +64,11 @@ object DevNull : RawSink {
     }
 }
 
+val RUNTIME_FORTUNE = Fortune(
+    id = 0,
+    message = "Additional fortune added at request time."
+)
+
 const val CERT_PATH = "/certs/server.crt"
 const val KEY_PATH = "/certs/server.key"
 const val KEY_ALIAS = "server"

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Utils.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Utils.kt
@@ -22,6 +22,39 @@ import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Cache entry holding pre-serialized JSON bytes and an absolute expiration time
+ * (in nanos from [System.nanoTime]).  Used by the CRUD single-item read endpoint.
+ */
+class CacheEntry(val body: ByteArray, val expiresAt: Long)
+
+/**
+ * Simple in-process cache-aside with 200 ms absolute TTL for CRUD single-item reads.
+ * Stale entries are removed lazily on access.
+ */
+class CrudCache(private val ttlMillis: Long = 200) {
+    private val map = ConcurrentHashMap<UInt, CacheEntry>()
+
+    fun get(id: UInt): ByteArray? {
+        val entry = map[id] ?: return null
+        if (entry.expiresAt <= System.nanoTime()) {
+            map.remove(id, entry)
+            return null
+        }
+        return entry.body
+    }
+
+    fun put(id: UInt, body: ByteArray) {
+        val expiresAt = System.nanoTime() + ttlMillis * 1_000_000L
+        map[id] = CacheEntry(body, expiresAt)
+    }
+
+    fun invalidate(id: UInt) {
+        map.remove(id)
+    }
+}
 
 object DevNull : RawSink {
     override fun close() {}
@@ -43,6 +76,12 @@ class AppData {
     private val datasetFile = File(System.getenv("DATASET_PATH") ?: "/data/dataset.json")
 
     val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Cache-aside store used by the CRUD single-item read endpoint
+     * (200 ms absolute TTL, in-process).
+     */
+    val crudCache = CrudCache(ttlMillis = 200)
 
     /**
      * Dataset from file.  Used in JSON endpoints.
@@ -71,10 +110,11 @@ class AppData {
                     .password(if (userInfo.size > 1) userInfo[1] else "")
                     .build()
             )
+            val maxConn = System.getenv("DATABASE_MAX_CONN")?.toIntOrNull() ?: (cpuCores * 2)
             val pool = ConnectionPool(
                 ConnectionPoolConfiguration.builder(factory)
-                    .initialSize(cpuCores * 2)
-                    .maxSize(cpuCores * 2)
+                    .initialSize(maxConn)
+                    .maxSize(maxConn)
                     .validationQuery("")
                     .validationDepth(ValidationDepth.LOCAL)
                     .acquireRetry(0)
@@ -85,7 +125,6 @@ class AppData {
                 databaseConfig = R2dbcDatabaseConfig.Builder().apply {
                     explicitDialect = PostgreSQLDialect()
                     defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
-                    defaultReadOnly = true
                 }
             )
         }


### PR DESCRIPTION
## Description
- Add CRUD test using Exposed / r2dbc
- Add H2C embedded server
- Add fortunes endpoint

H2C doesn't work in conjunction with secure HTTP/2 in Ktor, so I just added a second server.  I'm not sure if this will have an impact on other benchmarks due to resource contention, so if the results take a dip I can migrate it to another module.

I also tried including gRPC using [Kotlin/kotlinx-rpc](https://github.com/Kotlin/kotlinx-rpc), but it doesn't seem to be possible to attach it to the same ports atm.  I'll ask the maintainers of this library for some help next week.

HTTP/3 should come at the end of August with Ktor 3.6.0, but I'll try it out ahead of time on an EAP build.