### PR TITLE
Use a group per PR so benchmark requests do not interfer with each other

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -23,8 +23,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: benchmark
-  cancel-in-progress: false
+  group: benchmark-pr-${{ inputs.pr }}
+  cancel-in-progress: true
 
 jobs:
   runner-busy:


### PR DESCRIPTION
Currently, benchmark requests (workflow `Benchmark PR`) are globally synchronized, which means that GitHub will cancel pending ones as soon as a new one arrives. Contributors are not notified about this, so they will just wonder when the benchmark results will arrive.

As the custom runner is limited to one concurrent job anyway (I guess?), we can attribute the benchmark requests to a PR, so each PR will have it's own queue. Triggering multiple benchmark requests from the same PR will then cancel the older requests which is desired behavior.

Cannot test this locally, but this should be quite straight forward.

@MDA2AV can you affirm the limit of one concurrent job on the runner?