### PR TITLE
Add bananabread (TypeScript/Bun GenHTTP port)

### DIFF
--- a/frameworks/bananabread/.dockerignore
+++ b/frameworks/bananabread/.dockerignore
@@ -1,0 +1,3 @@
+seagreen/
+node_modules/
+bun.lockb

--- a/frameworks/bananabread/.gitignore
+++ b/frameworks/bananabread/.gitignore
@@ -1,0 +1,4 @@
+seagreen/
+node_modules/
+bun.lockb
+.DS_Store

--- a/frameworks/bananabread/Dockerfile
+++ b/frameworks/bananabread/Dockerfile
@@ -1,0 +1,18 @@
+FROM oven/bun:1-alpine
+RUN apk add --no-cache git
+WORKDIR /app
+
+# App deps (reflect-metadata powers the decorator-based webservice routing).
+COPY package.json ./
+RUN bun install
+
+COPY tsconfig.json ./
+COPY src ./src
+
+# Seagreen (the TypeScript GenHTTP port) is consumed by relative import from ./seagreen.
+# Cloned at build time from its public repo; bare imports (reflect-metadata) resolve from /app.
+RUN git clone --depth 1 https://github.com/dotnet-web-stack/Seagreen.git seagreen
+
+EXPOSE 8080
+# Bun runs the TypeScript directly (no build step); main.ts forks one worker per core.
+ENTRYPOINT ["bun", "run", "src/main.ts"]

--- a/frameworks/bananabread/Dockerfile
+++ b/frameworks/bananabread/Dockerfile
@@ -1,5 +1,19 @@
-FROM oven/bun:1-alpine
-RUN apk add --no-cache git
+# The oven/bun x64 images ship the "baseline" (non-AVX2) Bun build for CPU portability. In Bun
+# 1.3.x that baseline build has a code-generation bug that miscompiles Seagreen's layout router:
+# request dispatch for routes past roughly the fifth entry in a layout 404s even though the
+# handlers are registered (/async-db and the deeper /crud routes break). The AVX2 build — the
+# flavor `bun.sh/install` selects on an AVX2 CPU, and the one that runs correctly on the host —
+# routes them correctly and is faster besides. So we take the Debian (glibc) image for its
+# tooling and replace bun with the AVX2 build. glibc, not alpine/musl, because the prebuilt
+# AVX2 binary the installer fetches here is glibc-linked.
+FROM oven/bun:1
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates curl unzip \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14" \
+ && cp -f /root/.bun/bin/bun "$(command -v bun)" \
+ && rm -rf /root/.bun \
+ && echo "bun build flavor: $(bun -e 'throw 0' 2>&1 | grep -o 'Linux x64[^)]*')"
 WORKDIR /app
 
 # App deps (reflect-metadata powers the decorator-based webservice routing).

--- a/frameworks/bananabread/README.md
+++ b/frameworks/bananabread/README.md
@@ -1,0 +1,41 @@
+# bananabread
+
+A HttpArena entry for **Seagreen** — a TypeScript port of [GenHTTP](https://github.com/Kaliumhexacyanoferrat/GenHTTP)
+on the [Bun](https://bun.sh) runtime (the TypeScript sibling of the Kotlin port, `fishcake`/CodeGreen).
+It runs GenHTTP's own internal HTTP/1.1 engine, built on `Bun.listen` raw TCP (not `Bun.serve`).
+
+## Stack
+
+- **Language:** TypeScript / Bun
+- **Framework:** Seagreen (TypeScript port of GenHTTP)
+- **Engine:** Seagreen internal engine (raw TCP via `Bun.listen`)
+- **Database:** Bun's built-in SQL client (`Bun.SQL`) for PostgreSQL
+- **Multi-core:** one worker process per core, sharing the port via `SO_REUSEPORT`
+- **Build:** none — Bun runs the TypeScript directly; Seagreen is cloned at image build time
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/pipeline` | GET | Returns `ok` |
+| `/baseline11` | GET / POST | Sums `a` + `b` (POST adds a body value) |
+| `/baseline2` | GET | Sums `a` + `b` |
+| `/json/{count}` | GET | Processes `count` dataset items; `?m=` scales the total (default 1) |
+| `/upload` | POST | Streams the body, returns the byte count |
+| `/async-db` | GET | `price BETWEEN min AND max` range query |
+| `/crud/items` | GET | Paged listing by category |
+| `/crud/items/{id}` | GET | Cached read (`X-Cache: HIT\|MISS`) |
+| `/crud/items` | POST | Upsert → `201 Created` |
+| `/crud/items/{id}` | PUT | Update, `404` when unknown |
+
+Declared profiles (`meta.json`): `baseline`, `pipelined`, `limited-conn`, `json`, `upload`,
+`async-db`, `crud`, `api-4`, `api-16`. TLS/HTTP-2, compression, static files, websockets and
+gRPC are omitted (those Seagreen modules are not ported yet).
+
+## Notes
+
+- The single-item CRUD read uses an in-process 200 ms TTL cache (mirrors GenHTTP's `MemoryCache`).
+- `DATABASE_URL`, `DATASET_PATH` follow the standard HttpArena contract; without `DATABASE_URL`
+  the database-backed endpoints degrade gracefully (empty results / `404`).
+- The image clones Seagreen from `main` (public repo `dotnet-web-stack/Seagreen`), so that branch
+  must contain the current engine (including the `workers()` API and the multi-worker spawn fix).

--- a/frameworks/bananabread/bun.lock
+++ b/frameworks/bananabread/bun.lock
@@ -1,0 +1,18 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bananabread",
+      "dependencies": {
+        "reflect-metadata": "^0.2.2",
+        "zod": "^3.24.0",
+      },
+    },
+  },
+  "packages": {
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/frameworks/bananabread/meta.json
+++ b/frameworks/bananabread/meta.json
@@ -1,0 +1,21 @@
+{
+  "display_name": "bananabread",
+  "language": "TypeScript",
+  "type": "production",
+  "engine": "seagreen",
+  "description": "Seagreen — a TypeScript port of GenHTTP — on Bun's raw-TCP engine, with kotlinx-style decorators and Bun's built-in SQL.",
+  "repo": "https://github.com/dotnet-web-stack/Seagreen",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "upload",
+    "async-db",
+    "crud",
+    "api-4",
+    "api-16"
+  ],
+  "maintainers": []
+}

--- a/frameworks/bananabread/package.json
+++ b/frameworks/bananabread/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bananabread",
+  "private": true,
+  "type": "module",
+  "description": "HttpArena entry: Seagreen (TypeScript GenHTTP port) on Bun.",
+  "dependencies": {
+    "reflect-metadata": "^0.2.2",
+    "zod": "^3.24.0"
+  }
+}

--- a/frameworks/bananabread/seagreen
+++ b/frameworks/bananabread/seagreen
@@ -1,0 +1,1 @@
+/home/diogo/Desktop/Socket/Seagreen

--- a/frameworks/bananabread/src/data.ts
+++ b/frameworks/bananabread/src/data.ts
@@ -1,0 +1,67 @@
+/**
+ * Data layer: the `/json` dataset (from DATASET_PATH) and PostgreSQL access via Bun's built-in
+ * SQL client (Bun.SQL). When DATABASE_URL is unset, the DB queries return empty so the
+ * database-backed endpoints degrade gracefully.
+ */
+import { SQL } from "bun";
+import type { CrudCreateRequest, CrudUpdateRequest, DatasetItem, DbItem } from "./model.ts";
+
+const datasetFile = Bun.file(process.env.DATASET_PATH ?? "/data/dataset.json");
+export const dataset: DatasetItem[] = (await datasetFile.exists()) ? ((await datasetFile.json()) as DatasetItem[]) : [];
+
+const sql = process.env.DATABASE_URL ? new SQL(process.env.DATABASE_URL) : null;
+export const dbAvailable = sql !== null;
+
+// biome-ignore lint/suspicious/noExplicitAny: Bun.SQL rows are untyped records
+function toDbItem(r: any): DbItem {
+  return {
+    id: r.id,
+    name: r.name,
+    category: r.category,
+    price: r.price,
+    quantity: r.quantity,
+    active: r.active,
+    tags: r.tags ?? [],
+    rating: { score: r.rating_score, count: r.rating_count },
+  };
+}
+
+export async function rangeByPrice(min: number, max: number, limit: number): Promise<DbItem[]> {
+  if (!sql) return [];
+  const rows = await sql`SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count
+                         FROM items WHERE price BETWEEN ${min} AND ${max} LIMIT ${limit}`;
+  return rows.map(toDbItem);
+}
+
+export async function listByCategory(category: string, limit: number, offset: number): Promise<DbItem[]> {
+  if (!sql) return [];
+  const rows = await sql`SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count
+                         FROM items WHERE category = ${category} ORDER BY id LIMIT ${limit} OFFSET ${offset}`;
+  return rows.map(toDbItem);
+}
+
+export async function findById(id: number): Promise<DbItem | null> {
+  if (!sql) return null;
+  const rows = await sql`SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count
+                         FROM items WHERE id = ${id} LIMIT 1`;
+  return rows.length ? toDbItem(rows[0]) : null;
+}
+
+export async function upsert(req: CrudCreateRequest): Promise<void> {
+  if (!sql) return;
+  const tags = JSON.stringify(req.tags ?? ["bench"]);
+  await sql`INSERT INTO items (id, name, category, price, quantity, active, tags, rating_score, rating_count)
+            VALUES (${req.id}, ${req.name}, ${req.category}, ${req.price}, ${req.quantity}, ${req.active ?? true}, ${tags}::jsonb, 0, 0)
+            ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, category = EXCLUDED.category,
+              price = EXCLUDED.price, quantity = EXCLUDED.quantity, active = EXCLUDED.active, tags = EXCLUDED.tags`;
+}
+
+export async function update(id: number, req: CrudUpdateRequest): Promise<boolean> {
+  if (!sql) return false;
+  const rows = await sql`UPDATE items SET
+              name = COALESCE(${req.name ?? null}, name),
+              price = COALESCE(${req.price ?? null}, price),
+              quantity = COALESCE(${req.quantity ?? null}, quantity)
+            WHERE id = ${id} RETURNING id`;
+  return rows.length > 0;
+}

--- a/frameworks/bananabread/src/data.ts
+++ b/frameworks/bananabread/src/data.ts
@@ -9,7 +9,15 @@ import type { CrudCreateRequest, CrudUpdateRequest, DatasetItem, DbItem } from "
 const datasetFile = Bun.file(process.env.DATASET_PATH ?? "/data/dataset.json");
 export const dataset: DatasetItem[] = (await datasetFile.exists()) ? ((await datasetFile.json()) as DatasetItem[]) : [];
 
-const sql = process.env.DATABASE_URL ? new SQL(process.env.DATABASE_URL) : null;
+// One Bun.SQL pool lives per worker process (Seagreen forks one worker per core), and the pools
+// must collectively stay under PostgreSQL's max_connections (the harness caps it at 256). The
+// default per-pool size (~10) × ~64 workers ≈ 640 connections blows past that, and the overflow
+// fails to open under load — surfacing as 5xx (and reconnect storms that wreck throughput). Size
+// each worker's pool so workers × poolMax stays well under 256 (~200, leaving headroom for
+// reserved/health connections); this matches the worker count main.ts derives.
+const workerCount = Number(process.env.WORKERS) || navigator.hardwareConcurrency || 1;
+const poolMax = Math.max(1, Math.floor(200 / workerCount));
+const sql = process.env.DATABASE_URL ? new SQL(process.env.DATABASE_URL, { max: poolMax }) : null;
 export const dbAvailable = sql !== null;
 
 // biome-ignore lint/suspicious/noExplicitAny: Bun.SQL rows are untyped records

--- a/frameworks/bananabread/src/main.ts
+++ b/frameworks/bananabread/src/main.ts
@@ -1,0 +1,12 @@
+import { Host } from "../seagreen/src/engine/internal/index.ts";
+import { dbAvailable } from "./data.ts";
+import { createApp } from "./project.ts";
+
+const port = Number(process.env.PORT ?? 8080);
+const workers = Number(process.env.WORKERS) || navigator.hardwareConcurrency || 1;
+
+if (!process.env.SEAGREEN_WORKER) {
+  console.log(`bananabread (Seagreen) → :${port}, ${workers} workers, database: ${dbAvailable ? "connected" : "disabled"}`);
+}
+
+await Host.create().handler(createApp()).port(port).workers(workers).run();

--- a/frameworks/bananabread/src/model.ts
+++ b/frameworks/bananabread/src/model.ts
@@ -1,0 +1,54 @@
+export interface RatingInfo {
+  score: number;
+  count: number;
+}
+
+export interface DatasetItem {
+  id: number;
+  name: string;
+  category: string;
+  price: number;
+  quantity: number;
+  active: boolean;
+  tags: string[];
+  rating: RatingInfo;
+}
+
+export interface ProcessedItem extends DatasetItem {
+  total: number;
+}
+
+export interface DbItem {
+  id: number;
+  name: string;
+  category: string;
+  price: number;
+  quantity: number;
+  active: boolean;
+  tags: string[];
+  rating: RatingInfo;
+}
+
+export interface CrudCreateRequest {
+  id: number;
+  name: string;
+  category: string;
+  price: number;
+  quantity: number;
+  active?: boolean;
+  tags?: string[];
+}
+
+export interface CrudUpdateRequest {
+  name?: string;
+  price?: number;
+  quantity?: number;
+}
+
+/** Serialized as `{ "items": [...], "count": N }`. */
+export class ListWithCount<T> {
+  readonly count: number;
+  constructor(readonly items: T[]) {
+    this.count = items.length;
+  }
+}

--- a/frameworks/bananabread/src/project.ts
+++ b/frameworks/bananabread/src/project.ts
@@ -1,0 +1,15 @@
+import { Content, Resource } from "../seagreen/src/modules/io/index.ts";
+import { Layout, type LayoutBuilder } from "../seagreen/src/modules/layouting/index.ts";
+import { Service } from "../seagreen/src/modules/webservices/index.ts";
+import { AsyncDatabase, Baseline, Crud, JsonService, Upload } from "./services.ts";
+
+export function createApp(): LayoutBuilder {
+  return Layout.create()
+    .add("pipeline", Content.from(Resource.fromString("ok")))
+    .add("baseline11", Service.from(Baseline))
+    .add("baseline2", Service.from(Baseline))
+    .add("upload", Service.from(Upload))
+    .add("json", Service.from(JsonService))
+    .add("async-db", Service.from(AsyncDatabase))
+    .add("crud", Layout.create().add("items", Service.from(Crud)));
+}

--- a/frameworks/bananabread/src/services.ts
+++ b/frameworks/bananabread/src/services.ts
@@ -1,6 +1,7 @@
 /**
  * Webservices for the HttpArena workloads, on Seagreen's decorator-based reflection stack.
  */
+import { RedisClient } from "bun";
 import {
   ContentType,
   ProviderException,
@@ -23,11 +24,23 @@ import {
 import * as Data from "./data.ts";
 import { type CrudCreateRequest, type CrudUpdateRequest, type DbItem, ListWithCount, type ProcessedItem } from "./model.ts";
 
-/** In-process 200 ms TTL cache for the cached single-item read. */
-class TtlCache {
+/**
+ * Single-item read cache for the cache-aside workload. The validation harness fires its two
+ * cache probes on separate connections, which `SO_REUSEPORT` may route to different worker
+ * processes — so a per-process map would report MISS twice. When REDIS_URL is provided the cache
+ * is backed by Redis (Bun's built-in client) and therefore shared across workers; otherwise it
+ * falls back to an in-process TTL map (correct for a single worker).
+ */
+interface ItemCache {
+  get(id: number): Promise<string | undefined>;
+  set(id: number, body: string): Promise<void>;
+  invalidate(id: number): Promise<void>;
+}
+
+class InProcessCache implements ItemCache {
   private readonly map = new Map<number, { body: string; expiresAt: number }>();
-  constructor(private readonly ttlMs = 200) {}
-  get(id: number): string | undefined {
+  constructor(private readonly ttlMs: number) {}
+  async get(id: number): Promise<string | undefined> {
     const e = this.map.get(id);
     if (!e) return undefined;
     if (e.expiresAt <= performance.now()) {
@@ -36,14 +49,40 @@ class TtlCache {
     }
     return e.body;
   }
-  set(id: number, body: string): void {
+  async set(id: number, body: string): Promise<void> {
     this.map.set(id, { body, expiresAt: performance.now() + this.ttlMs });
   }
-  invalidate(id: number): void {
+  async invalidate(id: number): Promise<void> {
     this.map.delete(id);
   }
 }
-const cache = new TtlCache(200);
+
+class RedisCache implements ItemCache {
+  private readonly client: RedisClient;
+  constructor(
+    url: string,
+    private readonly ttlMs: number,
+  ) {
+    this.client = new RedisClient(url);
+  }
+  private key(id: number): string {
+    return `crud:item:${id}`;
+  }
+  async get(id: number): Promise<string | undefined> {
+    return (await this.client.get(this.key(id))) ?? undefined;
+  }
+  async set(id: number, body: string): Promise<void> {
+    await this.client.send("SET", [this.key(id), body, "PX", String(this.ttlMs)]);
+  }
+  async invalidate(id: number): Promise<void> {
+    await this.client.del(this.key(id));
+  }
+}
+
+const CACHE_TTL_MS = 1000;
+const cache: ItemCache = process.env.REDIS_URL
+  ? new RedisCache(process.env.REDIS_URL, CACHE_TTL_MS)
+  : new InProcessCache(CACHE_TTL_MS);
 
 export class Baseline {
   @ResourceMethod("GET")
@@ -94,21 +133,21 @@ export class Crud {
 
   @ResourceMethod("GET", ":id")
   async get(@FromPath("id") id: number, @Inject() request: Request): Promise<Response> {
-    const cached = cache.get(id);
+    const cached = await cache.get(id);
     if (cached !== undefined) {
       return request.respond().content(new StringContent(cached, ContentType.ApplicationJson)).header("X-Cache", "HIT").build();
     }
     const item = await Data.findById(id);
     if (!item) throw new ProviderException(ResponseStatus.NotFound, `Item with ID ${id} does not exist`);
     const json = JSON.stringify(item);
-    cache.set(id, json);
+    await cache.set(id, json);
     return request.respond().content(new StringContent(json, ContentType.ApplicationJson)).header("X-Cache", "MISS").build();
   }
 
   @ResourceMethod("POST")
   async create(@FromContent() item: CrudCreateRequest): Promise<Result<DbItem>> {
     await Data.upsert(item);
-    cache.invalidate(item.id);
+    await cache.invalidate(item.id);
     const created: DbItem = {
       id: item.id,
       name: item.name,
@@ -125,7 +164,7 @@ export class Crud {
   @ResourceMethod("PUT", ":id")
   async update(@FromPath("id") id: number, @FromContent() item: CrudUpdateRequest): Promise<DbItem> {
     const ok = await Data.update(id, item);
-    cache.invalidate(id);
+    await cache.invalidate(id);
     if (!ok) throw new ProviderException(ResponseStatus.NotFound, `Item with ID ${id} does not exist`);
     const updated = await Data.findById(id);
     if (!updated) throw new ProviderException(ResponseStatus.NotFound, `Item with ID ${id} does not exist`);

--- a/frameworks/bananabread/src/services.ts
+++ b/frameworks/bananabread/src/services.ts
@@ -1,0 +1,134 @@
+/**
+ * Webservices for the HttpArena workloads, on Seagreen's decorator-based reflection stack.
+ */
+import {
+  ContentType,
+  ProviderException,
+  type Request,
+  type RequestBody,
+  type Response,
+  ResponseStatus,
+} from "../seagreen/src/api/index.ts";
+import { StringContent } from "../seagreen/src/modules/io/index.ts";
+import {
+  FromBody,
+  FromContent,
+  FromPath,
+  FromQuery,
+  FromStream,
+  Inject,
+  ResourceMethod,
+  Result,
+} from "../seagreen/src/modules/webservices/index.ts";
+import * as Data from "./data.ts";
+import { type CrudCreateRequest, type CrudUpdateRequest, type DbItem, ListWithCount, type ProcessedItem } from "./model.ts";
+
+/** In-process 200 ms TTL cache for the cached single-item read. */
+class TtlCache {
+  private readonly map = new Map<number, { body: string; expiresAt: number }>();
+  constructor(private readonly ttlMs = 200) {}
+  get(id: number): string | undefined {
+    const e = this.map.get(id);
+    if (!e) return undefined;
+    if (e.expiresAt <= performance.now()) {
+      this.map.delete(id);
+      return undefined;
+    }
+    return e.body;
+  }
+  set(id: number, body: string): void {
+    this.map.set(id, { body, expiresAt: performance.now() + this.ttlMs });
+  }
+  invalidate(id: number): void {
+    this.map.delete(id);
+  }
+}
+const cache = new TtlCache(200);
+
+export class Baseline {
+  @ResourceMethod("GET")
+  sum(@FromQuery("a") a: number, @FromQuery("b") b: number): number {
+    return a + b;
+  }
+
+  @ResourceMethod("POST")
+  sumBody(@FromQuery("a") a: number, @FromQuery("b") b: number, @FromBody() c: number): number {
+    return a + b + c;
+  }
+}
+
+export class Upload {
+  @ResourceMethod("POST")
+  async compute(@FromStream() body: RequestBody): Promise<number> {
+    let total = 0;
+    for await (const chunk of body.chunks()) total += chunk.length;
+    return total;
+  }
+}
+
+export class JsonService {
+  @ResourceMethod("GET", ":count")
+  compute(@FromPath("count") count: number, @FromQuery("m") m = 1): ListWithCount<ProcessedItem> {
+    if (Data.dataset.length === 0) throw new ProviderException(ResponseStatus.InternalServerError, "No dataset");
+    const take = Math.max(0, Math.min(count, Data.dataset.length));
+    const items = Data.dataset.slice(0, take).map((d) => ({ ...d, total: d.price * d.quantity * m }));
+    return new ListWithCount(items);
+  }
+}
+
+export class AsyncDatabase {
+  @ResourceMethod("GET")
+  async compute(@FromQuery("min") min = 10, @FromQuery("max") max = 50, @FromQuery("limit") limit = 50): Promise<ListWithCount<DbItem>> {
+    return new ListWithCount(await Data.rangeByPrice(min, max, Math.min(50, Math.max(1, limit))));
+  }
+}
+
+export class Crud {
+  @ResourceMethod("GET")
+  async list(@FromQuery("category") category = "electronics", @FromQuery("page") page = 1, @FromQuery("limit") limit = 10) {
+    const p = Math.max(1, page);
+    const l = Math.min(50, Math.max(1, limit));
+    const items = await Data.listByCategory(category, l, (p - 1) * l);
+    return { items, total: items.length, page: p, limit: l };
+  }
+
+  @ResourceMethod("GET", ":id")
+  async get(@FromPath("id") id: number, @Inject() request: Request): Promise<Response> {
+    const cached = cache.get(id);
+    if (cached !== undefined) {
+      return request.respond().content(new StringContent(cached, ContentType.ApplicationJson)).header("X-Cache", "HIT").build();
+    }
+    const item = await Data.findById(id);
+    if (!item) throw new ProviderException(ResponseStatus.NotFound, `Item with ID ${id} does not exist`);
+    const json = JSON.stringify(item);
+    cache.set(id, json);
+    return request.respond().content(new StringContent(json, ContentType.ApplicationJson)).header("X-Cache", "MISS").build();
+  }
+
+  @ResourceMethod("POST")
+  async create(@FromContent() item: CrudCreateRequest): Promise<Result<DbItem>> {
+    await Data.upsert(item);
+    cache.invalidate(item.id);
+    const created: DbItem = {
+      id: item.id,
+      name: item.name,
+      category: item.category,
+      price: item.price,
+      quantity: item.quantity,
+      active: item.active ?? true,
+      tags: item.tags ?? ["bench"],
+      rating: { score: 0, count: 0 },
+    };
+    return new Result(created).status(ResponseStatus.Created);
+  }
+
+  @ResourceMethod("PUT", ":id")
+  async update(@FromPath("id") id: number, @FromContent() item: CrudUpdateRequest): Promise<DbItem> {
+    const ok = await Data.update(id, item);
+    cache.invalidate(id);
+    if (!ok) throw new ProviderException(ResponseStatus.NotFound, `Item with ID ${id} does not exist`);
+    const updated = await Data.findById(id);
+    if (!updated) throw new ProviderException(ResponseStatus.NotFound, `Item with ID ${id} does not exist`);
+    return updated;
+  }
+}

--- a/frameworks/bananabread/tsconfig.json
+++ b/frameworks/bananabread/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "types": ["bun"],
+    "strict": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
TypeScript/Bun sibling of `fishcake` — runs **Seagreen**, a port of GenHTTP, on its own internal HTTP/1.1 engine built on `Bun.listen` raw TCP (not `Bun.serve`).

- **Engine:** Seagreen internal engine; one worker process per core sharing the port via `SO_REUSEPORT`.
- **Database:** Bun's built-in `Bun.SQL` for `async-db`/`crud` (degrades gracefully when `DATABASE_URL` is unset).
- **Build:** none — Bun runs the TypeScript directly; the Dockerfile clones Seagreen from its public repo (`dotnet-web-stack/Seagreen@main`).
- **Profiles:** `baseline`, `pipelined`, `limited-conn`, `json`, `upload`, `async-db`, `crud`, `api-4`, `api-16`. TLS/HTTP-2, compression, static files, websockets and gRPC are omitted (those Seagreen modules aren't ported yet).

Endpoints: `/pipeline`, `/baseline11` (GET+POST), `/baseline2`, `/json/:count?m=`, `/upload`, `/async-db`, `/crud/items` (list, cached read with `X-Cache`, upsert → 201, update → 404).

Validated locally (non-DB endpoints): pipeline/baseline/json/streamed-upload work, async-db/crud degrade gracefully, multi-worker confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
