### PR TITLE
Add vanilla (V) framework

### DIFF
--- a/frameworks/vanilla/.gitignore
+++ b/frameworks/vanilla/.gitignore
@@ -1,0 +1,2 @@
+server
+*.so

--- a/frameworks/vanilla/Dockerfile
+++ b/frameworks/vanilla/Dockerfile
@@ -2,17 +2,17 @@ FROM debian:stable-slim AS build
 
 RUN apt-get -qq update && \
     apt-get -qy install --no-install-recommends \
-        ca-certificates build-essential git libpq-dev liburing-dev && \
+        ca-certificates curl unzip build-essential git libpq-dev liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Build V from the master branch (reports `V 0.5.1`). Pinning a tag with
-# `git checkout <tag> && make` is unreliable because make pulls the latest vc.
-RUN git clone --depth 1 https://github.com/vlang/v /opt/vlang && \
-    cd /opt/vlang && make && ln -s /opt/vlang/v /usr/local/bin/v
+# Pinned, reproducible V 0.5.1 (prebuilt release binary — no source build, and it
+# avoids the `git checkout <tag> && make` vc-mismatch problem).
+RUN curl -fsSL https://github.com/vlang/v/releases/download/0.5.1/v_linux.zip -o /tmp/v.zip && \
+    unzip -q /tmp/v.zip -d /opt && rm /tmp/v.zip && \
+    ln -s /opt/v/v /usr/local/bin/v
 
 # Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server).
-RUN mkdir -p /root/.vmodules && \
-    git clone --depth 1 https://github.com/enghitalo/vanilla /root/.vmodules/vanilla
+RUN git clone --depth 1 https://github.com/enghitalo/vanilla /root/.vmodules/vanilla
 
 WORKDIR /app
 COPY . .

--- a/frameworks/vanilla/Dockerfile
+++ b/frameworks/vanilla/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:stable-slim AS build
+
+RUN apt-get -qq update && \
+    apt-get -qy install --no-install-recommends \
+        ca-certificates build-essential git libpq-dev liburing-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build V from the master branch (reports `V 0.5.1`). Pinning a tag with
+# `git checkout <tag> && make` is unreliable because make pulls the latest vc.
+RUN git clone --depth 1 https://github.com/vlang/v /opt/vlang && \
+    cd /opt/vlang && make && ln -s /opt/vlang/v /usr/local/bin/v
+
+# Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server).
+RUN mkdir -p /root/.vmodules && \
+    git clone --depth 1 https://github.com/enghitalo/vanilla /root/.vmodules/vanilla
+
+WORKDIR /app
+COPY . .
+RUN v -prod . -o server
+
+FROM debian:stable-slim
+RUN apt-get -qq update && \
+    apt-get -qy install --no-install-recommends libpq5 liburing2 && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=build /app/server /server
+
+EXPOSE 8080
+CMD ["/server"]

--- a/frameworks/vanilla/README.md
+++ b/frameworks/vanilla/README.md
@@ -1,0 +1,30 @@
+# vanilla
+
+[vanilla](https://github.com/enghitalo/vanilla) is a minimalist, high-performance
+HTTP server written in [V](https://vlang.io) — multi-threaded, non-blocking
+epoll I/O, lock-free, copy-free, with `SO_REUSEPORT`.
+
+## Implemented tests
+
+| Test | Endpoint | Notes |
+|------|----------|-------|
+| `baseline` | `GET/POST /baseline11` | `a + b` (+ request body on POST); handles chunked + fragmented requests |
+| `pipelined` | `GET /pipeline` | returns `ok` |
+| `json` | `GET /json/{count}?m=M` | processes `/data/dataset.json`, adds `total = price*quantity*M` |
+| `async-db` | `GET /async-db?min&max&limit` | `SELECT … FROM items WHERE price BETWEEN min AND max LIMIT limit` via `db.pg` |
+
+> `POST /upload` is implemented too, but `vanilla` caps a single request at 8 MiB
+> (a built-in DoS guard), so the `upload` profile (20 MiB bodies) is not subscribed.
+
+## Stack
+
+* [V](https://vlang.io) standard toolchain (built from source)
+* [vanilla](https://github.com/enghitalo/vanilla) — raw epoll HTTP server
+* `db.pg` (stdlib) — pooled PostgreSQL driver, sized from `DATABASE_MAX_CONN`
+* `json` (stdlib) — dataset parsing + response serialization
+
+## Environment
+
+* `DATABASE_URL` — Postgres connection URI (async-db)
+* `DATABASE_MAX_CONN` — connection pool size
+* `DATASET_PATH` — dataset location (defaults to `/data/dataset.json`)

--- a/frameworks/vanilla/README.md
+++ b/frameworks/vanilla/README.md
@@ -4,27 +4,33 @@
 HTTP server written in [V](https://vlang.io) — multi-threaded, non-blocking
 epoll I/O, lock-free, copy-free, with `SO_REUSEPORT`.
 
-## Implemented tests
+## Implemented profiles
 
-| Test | Endpoint | Notes |
-|------|----------|-------|
-| `baseline` | `GET/POST /baseline11` | `a + b` (+ request body on POST); handles chunked + fragmented requests |
+| Profile | Endpoint | Notes |
+|---|---|---|
+| `baseline` | `GET/POST /baseline11` | `a + b` (+ body on POST); handles chunked + TCP-fragmented requests |
 | `pipelined` | `GET /pipeline` | returns `ok` |
-| `json` | `GET /json/{count}?m=M` | processes `/data/dataset.json`, adds `total = price*quantity*M` |
-| `async-db` | `GET /async-db?min&max&limit` | `SELECT … FROM items WHERE price BETWEEN min AND max LIMIT limit` via `db.pg` |
-
-> `POST /upload` is implemented too, but `vanilla` caps a single request at 8 MiB
-> (a built-in DoS guard), so the `upload` profile (20 MiB bodies) is not subscribed.
+| `limited-conn` | `GET /baseline11` | short-lived connections |
+| `json` | `GET /json/{count}?m=M` | single-allocation response, precomputed item prefixes |
+| `json-comp` | `GET /json/...` + `Accept-Encoding` | gzip-compressed response |
+| `static` | `GET /static/<file>` | assets preloaded into memory, MIME by extension, 404 on miss |
+| `async-db` | `GET /async-db?min&max&limit` | `db.pg` ConnectionPool |
+| `fortunes` | `GET /fortunes` | DB rows + runtime row, HTML-escaped |
+| `api-4`, `api-16` | mixed baseline + json + async-db | |
 
 ## Stack
 
 * [V](https://vlang.io) 0.5.1 (pinned prebuilt release)
 * [vanilla](https://github.com/enghitalo/vanilla) — raw epoll HTTP server
-* `db.pg` (stdlib) — pooled PostgreSQL driver, sized from `DATABASE_MAX_CONN`
-* `json` (stdlib) — dataset parsing + response serialization
+* `db.pg`, `json`, `compress.gzip` (stdlib)
 
 ## Environment
 
-* `DATABASE_URL` — Postgres connection URI (async-db)
-* `DATABASE_MAX_CONN` — connection pool size
-* `DATASET_PATH` — dataset location (defaults to `/data/dataset.json`)
+* `DATABASE_URL`, `DATABASE_MAX_CONN` — Postgres connection + pool size
+* `DATASET_PATH` (default `/data/dataset.json`), `STATIC_DIR` (default `/data/static`)
+
+> The `upload` profile (20 MiB bodies) lands once
+> [enghitalo/vanilla#17](https://github.com/enghitalo/vanilla/pull/17)
+> (configurable `max_request_bytes`) is merged; until then vanilla caps a single
+> request at 8 MiB. HTTP/2, HTTP/3 and gRPC profiles need protocol support
+> vanilla doesn't have yet (tracked upstream).

--- a/frameworks/vanilla/README.md
+++ b/frameworks/vanilla/README.md
@@ -16,6 +16,7 @@ epoll I/O, lock-free, copy-free, with `SO_REUSEPORT`.
 | `json-comp` | `GET /json/...` + `Accept-Encoding` | gzip-compressed response |
 | `static` | `GET /static/<file>` | assets preloaded into memory, MIME by extension, 404 on miss |
 | `async-db` | `GET /async-db?min&max&limit` | `db.pg` ConnectionPool |
+| `crud` | `GET/POST/PUT /crud/items[/id]` | list + read + create + update; in-memory cache-aside (`X-Cache` MISS/HIT, invalidated on update — no Redis) |
 | `fortunes` | `GET /fortunes` | DB rows + runtime row, HTML-escaped |
 | `api-4`, `api-16` | mixed baseline + json + async-db | |
 

--- a/frameworks/vanilla/README.md
+++ b/frameworks/vanilla/README.md
@@ -18,7 +18,7 @@ epoll I/O, lock-free, copy-free, with `SO_REUSEPORT`.
 
 ## Stack
 
-* [V](https://vlang.io) standard toolchain (built from source)
+* [V](https://vlang.io) 0.5.1 (pinned prebuilt release)
 * [vanilla](https://github.com/enghitalo/vanilla) — raw epoll HTTP server
 * `db.pg` (stdlib) — pooled PostgreSQL driver, sized from `DATABASE_MAX_CONN`
 * `json` (stdlib) — dataset parsing + response serialization

--- a/frameworks/vanilla/README.md
+++ b/frameworks/vanilla/README.md
@@ -10,6 +10,7 @@ epoll I/O, lock-free, copy-free, with `SO_REUSEPORT`.
 |---|---|---|
 | `baseline` | `GET/POST /baseline11` | `a + b` (+ body on POST); handles chunked + TCP-fragmented requests |
 | `pipelined` | `GET /pipeline` | returns `ok` |
+| `upload` | `POST /upload` | returns body byte count (up to 20+ MiB via `max_request_bytes`) |
 | `limited-conn` | `GET /baseline11` | short-lived connections |
 | `json` | `GET /json/{count}?m=M` | single-allocation response, precomputed item prefixes |
 | `json-comp` | `GET /json/...` + `Accept-Encoding` | gzip-compressed response |
@@ -29,8 +30,5 @@ epoll I/O, lock-free, copy-free, with `SO_REUSEPORT`.
 * `DATABASE_URL`, `DATABASE_MAX_CONN` — Postgres connection + pool size
 * `DATASET_PATH` (default `/data/dataset.json`), `STATIC_DIR` (default `/data/static`)
 
-> The `upload` profile (20 MiB bodies) lands once
-> [enghitalo/vanilla#17](https://github.com/enghitalo/vanilla/pull/17)
-> (configurable `max_request_bytes`) is merged; until then vanilla caps a single
-> request at 8 MiB. HTTP/2, HTTP/3 and gRPC profiles need protocol support
-> vanilla doesn't have yet (tracked upstream).
+> HTTP/2, HTTP/3 and gRPC profiles need protocol support vanilla doesn't have
+> yet — tracked in [enghitalo/vanilla#18](https://github.com/enghitalo/vanilla/issues/18).

--- a/frameworks/vanilla/main.v
+++ b/frameworks/vanilla/main.v
@@ -60,7 +60,7 @@ struct DbResp {
 
 struct Shared {
 mut:
-	db      &pg.DB
+	pool    pg.ConnectionPool
 	dataset []DatasetItem
 }
 
@@ -117,25 +117,42 @@ fn (mut sh Shared) async_db(min i64, max i64, limit i64) string {
 	if lim > 50 {
 		lim = 50
 	}
-	rows := sh.db.exec_param_many('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN \$1 AND \$2 LIMIT \$3',
-		[min.str(), max.str(), lim.str()]) or { return '{"items":[],"count":0}' }
+	mut conn := sh.pool.acquire() or { return '{"items":[],"count":0}' }
+	rows := conn.exec_param_many('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN \$1 AND \$2 LIMIT \$3',
+		[min.str(), max.str(), lim.str()]) or {
+		sh.pool.release(conn)
+		return '{"items":[],"count":0}'
+	}
+	sh.pool.release(conn)
 	mut items := []DbItem{cap: rows.len}
 	for row in rows {
 		items << DbItem{
-			id:       row.val(0).int()
-			name:     row.val(1)
-			category: row.val(2)
-			price:    row.val(3).int()
-			quantity: row.val(4).int()
-			active:   row.val(5) == 't'
-			tags:     json.decode([]string, row.val(6)) or { [] }
+			id:       nn(row.vals[0]).int()
+			name:     nn(row.vals[1])
+			category: nn(row.vals[2])
+			price:    nn(row.vals[3]).int()
+			quantity: nn(row.vals[4]).int()
+			active:   nn(row.vals[5]) == 't'
+			tags:     json.decode([]string, nn3(row.vals[6], '[]')) or { [] }
 			rating:   Rating{
-				score: row.val(7).i64()
-				count: row.val(8).i64()
+				score: nn(row.vals[7]).i64()
+				count: nn(row.vals[8]).i64()
 			}
 		}
 	}
 	return json.encode(DbResp{ items: items, count: items.len })
+}
+
+// nn unwraps a nullable column value to a plain string ('' for NULL).
+@[inline]
+fn nn(v ?string) string {
+	return v or { '' }
+}
+
+// nn3 unwraps a nullable column value with a custom default.
+@[inline]
+fn nn3(v ?string, d string) string {
+	return v or { d }
 }
 
 // qint reads a query parameter as an integer (0 if absent / non-numeric).
@@ -216,19 +233,45 @@ fn ok(ctype string, body string) []u8 {
 	return sb
 }
 
-fn main() {
-	conninfo := os.getenv_opt('DATABASE_URL') or { 'postgres://bench:bench@localhost:5432/benchmark' }
-	mut db := pg.connect_with_conninfo(conninfo, pg.PoolConfig{})!
-	if mc := os.getenv_opt('DATABASE_MAX_CONN') {
-		db.set_max_open_conns(mc.int())
+// parse_db_url turns postgres://user:pass@host:port/dbname into a pg.Config.
+fn parse_db_url(u string) pg.Config {
+	mut s := u
+	if s.contains('://') {
+		s = s.all_after('://')
 	}
+	creds := s.all_before('@')
+	rest := s.all_after('@')
+	host_port := rest.all_before('/')
+	mut port := 5432
+	if host_port.contains(':') {
+		port = host_port.all_after(':').int()
+	}
+	return pg.Config{
+		host:     host_port.all_before(':')
+		port:     port
+		user:     creds.all_before(':')
+		password: creds.all_after(':')
+		dbname:   rest.all_after('/')
+	}
+}
+
+fn main() {
+	url := os.getenv_opt('DATABASE_URL') or { 'postgres://bench:bench@localhost:5432/benchmark' }
+	mut size := (os.getenv_opt('DATABASE_MAX_CONN') or { '64' }).int()
+	if size < 1 {
+		size = 64
+	}
+	if size > 200 {
+		size = 200 // leave headroom under Postgres max_connections
+	}
+	mut pool := pg.new_connection_pool(parse_db_url(url), size)!
 
 	dataset_path := os.getenv_opt('DATASET_PATH') or { '/data/dataset.json' }
 	dataset_raw := os.read_file(dataset_path) or { '[]' }
 	dataset := json.decode([]DatasetItem, dataset_raw) or { []DatasetItem{} }
 
 	mut sh := Shared{
-		db:      db
+		pool:    pool
 		dataset: dataset
 	}
 

--- a/frameworks/vanilla/main.v
+++ b/frameworks/vanilla/main.v
@@ -1,0 +1,243 @@
+module main
+
+import vanilla.http_server
+import vanilla.http_server.http1_1.request_parser
+import db.pg
+import json
+import os
+import strings
+
+struct Rating {
+	score i64
+	count i64
+}
+
+// Dataset item as stored in /data/dataset.json.
+struct DatasetItem {
+	id       i64
+	name     string
+	category string
+	price    i64
+	quantity i64
+	active   bool
+	tags     []string
+	rating   Rating
+}
+
+// Item returned by /json — the dataset item plus the computed `total`.
+struct OutItem {
+	id       i64
+	name     string
+	category string
+	price    i64
+	quantity i64
+	active   bool
+	tags     []string
+	rating   Rating
+	total    i64
+}
+
+struct JsonResp {
+	items []OutItem
+	count int
+}
+
+struct DbItem {
+	id       int
+	name     string
+	category string
+	price    int
+	quantity int
+	active   bool
+	tags     []string
+	rating   Rating
+}
+
+struct DbResp {
+	items []DbItem
+	count int
+}
+
+struct Shared {
+mut:
+	db      &pg.DB
+	dataset []DatasetItem
+}
+
+fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
+	req := request_parser.decode_http_request(req_buffer)!
+	method := unsafe { tos(&req.buffer[req.method.start], req.method.len) }
+	target := unsafe { tos(&req.buffer[req.path.start], req.path.len) }
+	route := target.all_before('?')
+
+	if route == '/pipeline' {
+		return ok('text/plain', 'ok')
+	} else if route == '/baseline11' {
+		mut sum := qint(req, 'a') + qint(req, 'b')
+		if method == 'POST' {
+			sum += body_int(req)
+		}
+		return ok('text/plain', sum.str())
+	} else if route == '/upload' {
+		return ok('text/plain', req.body.len.str())
+	} else if route.starts_with('/json/') {
+		count := clamp_count(route[6..].i64(), sh.dataset.len)
+		mut m := qint(req, 'm')
+		if m == 0 {
+			m = 1
+		}
+		mut items := []OutItem{cap: count}
+		for i in 0 .. count {
+			d := sh.dataset[i]
+			items << OutItem{
+				id:       d.id
+				name:     d.name
+				category: d.category
+				price:    d.price
+				quantity: d.quantity
+				active:   d.active
+				tags:     d.tags
+				rating:   d.rating
+				total:    d.price * d.quantity * m
+			}
+		}
+		return ok('application/json', json.encode(JsonResp{ items: items, count: items.len }))
+	} else if route == '/async-db' {
+		return ok('application/json', sh.async_db(qint(req, 'min'), qint(req, 'max'),
+			qint(req, 'limit')))
+	}
+	return ok('text/plain', 'not found')
+}
+
+fn (mut sh Shared) async_db(min i64, max i64, limit i64) string {
+	mut lim := limit
+	if lim < 1 {
+		lim = 1
+	}
+	if lim > 50 {
+		lim = 50
+	}
+	rows := sh.db.exec_param_many('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE price BETWEEN \$1 AND \$2 LIMIT \$3',
+		[min.str(), max.str(), lim.str()]) or { return '{"items":[],"count":0}' }
+	mut items := []DbItem{cap: rows.len}
+	for row in rows {
+		items << DbItem{
+			id:       row.val(0).int()
+			name:     row.val(1)
+			category: row.val(2)
+			price:    row.val(3).int()
+			quantity: row.val(4).int()
+			active:   row.val(5) == 't'
+			tags:     json.decode([]string, row.val(6)) or { [] }
+			rating:   Rating{
+				score: row.val(7).i64()
+				count: row.val(8).i64()
+			}
+		}
+	}
+	return json.encode(DbResp{ items: items, count: items.len })
+}
+
+// qint reads a query parameter as an integer (0 if absent / non-numeric).
+fn qint(req request_parser.HttpRequest, key string) i64 {
+	s := req.get_query_slice(key.bytes()) or { return 0 }
+	return unsafe { tos(&req.buffer[s.start], s.len) }.i64()
+}
+
+fn clamp_count(n i64, max int) int {
+	if n < 0 {
+		return 0
+	}
+	if n > max {
+		return max
+	}
+	return int(n)
+}
+
+// body_int parses the request body as an integer, decoding chunked transfer
+// encoding when present.
+fn body_int(req request_parser.HttpRequest) i64 {
+	if req.body.len == 0 {
+		return 0
+	}
+	raw := unsafe { tos(&req.buffer[req.body.start], req.body.len) }
+	if te := req.get_header_value_slice('Transfer-Encoding') {
+		val := unsafe { tos(&req.buffer[te.start], te.len) }
+		if val.contains('chunked') {
+			return dechunk(raw).i64()
+		}
+	}
+	return raw.i64()
+}
+
+// dechunk decodes an HTTP/1.1 chunked body into its payload.
+fn dechunk(s string) string {
+	mut out := strings.new_builder(s.len)
+	mut i := 0
+	for i < s.len {
+		nl := s.index_after('\r\n', i) or { break }
+		size := strconv_hex(s[i..nl])
+		if size <= 0 {
+			break
+		}
+		data_start := nl + 2
+		out.write_string(s[data_start..data_start + size])
+		i = data_start + size + 2 // skip data + trailing CRLF
+	}
+	return out.str()
+}
+
+fn strconv_hex(s string) int {
+	mut n := 0
+	for c in s.trim_space() {
+		d := if c >= `0` && c <= `9` {
+			int(c - `0`)
+		} else if c >= `a` && c <= `f` {
+			int(c - `a` + 10)
+		} else if c >= `A` && c <= `F` {
+			int(c - `A` + 10)
+		} else {
+			break
+		}
+		n = n * 16 + d
+	}
+	return n
+}
+
+// ok builds a complete HTTP/1.1 response with the given content type.
+fn ok(ctype string, body string) []u8 {
+	mut sb := strings.new_builder(body.len + 96)
+	sb.write_string('HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Type: ')
+	sb.write_string(ctype)
+	sb.write_string('\r\nContent-Length: ')
+	sb.write_decimal(i64(body.len))
+	sb.write_string('\r\nConnection: keep-alive\r\n\r\n')
+	sb.write_string(body)
+	return sb
+}
+
+fn main() {
+	conninfo := os.getenv_opt('DATABASE_URL') or { 'postgres://bench:bench@localhost:5432/benchmark' }
+	mut db := pg.connect_with_conninfo(conninfo, pg.PoolConfig{})!
+	if mc := os.getenv_opt('DATABASE_MAX_CONN') {
+		db.set_max_open_conns(mc.int())
+	}
+
+	dataset_path := os.getenv_opt('DATASET_PATH') or { '/data/dataset.json' }
+	dataset_raw := os.read_file(dataset_path) or { '[]' }
+	dataset := json.decode([]DatasetItem, dataset_raw) or { []DatasetItem{} }
+
+	mut sh := Shared{
+		db:      db
+		dataset: dataset
+	}
+
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8080
+		io_multiplexing: .epoll
+		request_handler: fn [mut sh] (req_buffer []u8, fd int) ![]u8 {
+			return handle(req_buffer, fd, mut sh)
+		}
+	})!
+	server.run()
+}

--- a/frameworks/vanilla/main.v
+++ b/frameworks/vanilla/main.v
@@ -6,6 +6,7 @@ import db.pg
 import json
 import os
 import strings
+import sync
 import compress.gzip
 
 struct Rating {
@@ -57,6 +58,16 @@ mut:
 	dataset  []DatasetItem
 	prefixes []string // per item: `{…,"total":` (everything but the request-dependent total)
 	assets   map[string]StaticFile // /static/<name> -> prebuilt response
+	cache    map[int]string        // crud cache-aside: id -> item JSON
+	cache_mu &sync.RwMutex = unsafe { nil }
+}
+
+struct CrudCreate {
+	id       int
+	name     string
+	category string
+	price    int
+	quantity int
 }
 
 fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
@@ -96,11 +107,139 @@ fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
 			return f.response
 		}
 		return not_found
+	} else if route == '/crud/items' {
+		if method == 'POST' {
+			return sh.crud_create(req)
+		}
+		return sh.crud_list(qstr(req, 'category'), qint(req, 'page'), qint(req, 'limit'))
+	} else if route.starts_with('/crud/items/') {
+		id := route[12..].int()
+		if method == 'PUT' {
+			return sh.crud_update(id, req)
+		}
+		return sh.crud_get(id)
 	}
 	return not_found
 }
 
+// crud_list returns a paginated, category-filtered page of items.
+fn (mut sh Shared) crud_list(category string, page i64, limit i64) []u8 {
+	mut p := page
+	if p < 1 {
+		p = 1
+	}
+	mut lim := limit
+	if lim < 1 {
+		lim = 10
+	}
+	if lim > 100 {
+		lim = 100
+	}
+	offset := (p - 1) * lim
+	mut conn := sh.pool.acquire() or { return ok('application/json', '{"items":[],"total":0,"page":1}') }
+	rows := conn.exec_param_many('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE category = \$1 ORDER BY id LIMIT \$2 OFFSET \$3',
+		[category, lim.str(), offset.str()]) or {
+		sh.pool.release(conn)
+		return ok('application/json', '{"items":[],"total":0,"page":1}')
+	}
+	trows := conn.exec_param_many('SELECT count(*) FROM items WHERE category = \$1', [category]) or {
+		[]
+	}
+	sh.pool.release(conn)
+	total := if trows.len > 0 { nn(trows[0].vals[0]).int() } else { 0 }
+	mut items := []DbItem{cap: rows.len}
+	for row in rows {
+		items << row_to_item(row)
+	}
+	mut sb := strings.new_builder(items.len * 200 + 64)
+	sb.write_string('{"items":')
+	sb.write_string(json.encode(items))
+	sb.write_string(',"total":')
+	sb.write_decimal(i64(total))
+	sb.write_string(',"page":')
+	sb.write_decimal(p)
+	sb.write_u8(`}`)
+	return ok('application/json', sb.str())
+}
+
+// crud_get returns a single item, using a cache-aside in-memory cache and
+// reporting the result via the X-Cache header (MISS on first read, HIT after).
+fn (mut sh Shared) crud_get(id int) []u8 {
+	sh.cache_mu.@rlock()
+	cached := sh.cache[id] or { '' }
+	sh.cache_mu.runlock()
+	if cached.len > 0 {
+		return ok_xcache('application/json', cached, 'HIT')
+	}
+	mut conn := sh.pool.acquire() or { return not_found }
+	rows := conn.exec_param_many('SELECT id, name, category, price, quantity, active, tags, rating_score, rating_count FROM items WHERE id = \$1',
+		[id.str()]) or {
+		sh.pool.release(conn)
+		return not_found
+	}
+	sh.pool.release(conn)
+	if rows.len == 0 {
+		return not_found
+	}
+	body := json.encode(row_to_item(rows[0]))
+	sh.cache_mu.@lock()
+	sh.cache[id] = body
+	sh.cache_mu.unlock()
+	return ok_xcache('application/json', body, 'MISS')
+}
+
+// crud_create inserts a new item from the JSON body and returns 201.
+fn (mut sh Shared) crud_create(req request_parser.HttpRequest) []u8 {
+	raw := unsafe { tos(&req.buffer[req.body.start], req.body.len) }
+	c := json.decode(CrudCreate, raw) or { return bad_request }
+	mut conn := sh.pool.acquire() or { return bad_request }
+	conn.exec_param_many("INSERT INTO items (id, name, category, price, quantity, active, tags, rating_score, rating_count) VALUES (\$1, \$2, \$3, \$4, \$5, true, '[]', 0, 0) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, category = EXCLUDED.category, price = EXCLUDED.price, quantity = EXCLUDED.quantity",
+		[c.id.str(), c.name, c.category, c.price.str(), c.quantity.str()]) or {
+		sh.pool.release(conn)
+		return bad_request
+	}
+	sh.pool.release(conn)
+	return created
+}
+
+// crud_update updates an item and invalidates its cache entry.
+fn (mut sh Shared) crud_update(id int, req request_parser.HttpRequest) []u8 {
+	raw := unsafe { tos(&req.buffer[req.body.start], req.body.len) }
+	c := json.decode(CrudCreate, raw) or { return bad_request }
+	mut conn := sh.pool.acquire() or { return bad_request }
+	conn.exec_param_many('UPDATE items SET name = \$2, category = \$3, price = \$4, quantity = \$5 WHERE id = \$1',
+		[id.str(), c.name, c.category, c.price.str(), c.quantity.str()]) or {
+		sh.pool.release(conn)
+		return bad_request
+	}
+	sh.pool.release(conn)
+	sh.cache_mu.@lock()
+	sh.cache.delete(id)
+	sh.cache_mu.unlock()
+	return ok('application/json', '{"status":"ok"}')
+}
+
+fn row_to_item(row pg.Row) DbItem {
+	return DbItem{
+		id:       nn(row.vals[0]).int()
+		name:     nn(row.vals[1])
+		category: nn(row.vals[2])
+		price:    nn(row.vals[3]).int()
+		quantity: nn(row.vals[4]).int()
+		active:   nn(row.vals[5]) == 't'
+		tags:     json.decode([]string, nn3(row.vals[6], '[]')) or { [] }
+		rating:   Rating{
+			score: nn(row.vals[7]).i64()
+			count: nn(row.vals[8]).i64()
+		}
+	}
+}
+
 const not_found = 'HTTP/1.1 404 Not Found\r\nServer: vanilla\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const created = 'HTTP/1.1 201 Created\r\nServer: vanilla\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const bad_request = 'HTTP/1.1 400 Bad Request\r\nServer: vanilla\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 
 // json_response builds the FULL HTTP response (headers + body) for /json in a
 // single allocation — no per-request reflection and no body→response copy.
@@ -254,6 +393,13 @@ fn qint(req request_parser.HttpRequest, key string) i64 {
 	return unsafe { tos(&req.buffer[s.start], s.len) }.i64()
 }
 
+// qstr reads a query parameter as a string ('' if absent). Clones so the value
+// outlives the request buffer (it is passed to the DB driver).
+fn qstr(req request_parser.HttpRequest, key string) string {
+	s := req.get_query_slice(key.bytes()) or { return '' }
+	return unsafe { tos(&req.buffer[s.start], s.len) }.clone()
+}
+
 fn clamp_count(n i64, max int) int {
 	if n < 0 {
 		return 0
@@ -318,6 +464,20 @@ fn strconv_hex(s string) int {
 fn ok(ctype string, body string) []u8 {
 	mut sb := strings.new_builder(body.len + 96)
 	sb.write_string('HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Type: ')
+	sb.write_string(ctype)
+	sb.write_string('\r\nContent-Length: ')
+	sb.write_decimal(i64(body.len))
+	sb.write_string('\r\nConnection: keep-alive\r\n\r\n')
+	sb.write_string(body)
+	return sb
+}
+
+// ok_xcache builds a JSON response carrying an X-Cache: HIT|MISS header.
+fn ok_xcache(ctype string, body string, cache string) []u8 {
+	mut sb := strings.new_builder(body.len + 96)
+	sb.write_string('HTTP/1.1 200 OK\r\nServer: vanilla\r\nX-Cache: ')
+	sb.write_string(cache)
+	sb.write_string('\r\nContent-Type: ')
 	sb.write_string(ctype)
 	sb.write_string('\r\nContent-Length: ')
 	sb.write_decimal(i64(body.len))
@@ -425,6 +585,8 @@ fn main() {
 		dataset:  dataset
 		prefixes: prefixes
 		assets:   assets
+		cache:    map[int]string{}
+		cache_mu: sync.new_rwmutex()
 	}
 
 	mut server := http_server.new_server(http_server.ServerConfig{

--- a/frameworks/vanilla/main.v
+++ b/frameworks/vanilla/main.v
@@ -6,6 +6,7 @@ import db.pg
 import json
 import os
 import strings
+import compress.gzip
 
 struct Rating {
 	score i64
@@ -40,11 +41,22 @@ struct DbResp {
 	count int
 }
 
+struct Fortune {
+	id      int
+	message string
+}
+
+// A static asset preloaded into memory with its full HTTP response.
+struct StaticFile {
+	response []u8
+}
+
 struct Shared {
 mut:
 	pool     pg.ConnectionPool
 	dataset  []DatasetItem
 	prefixes []string // per item: `{…,"total":` (everything but the request-dependent total)
+	assets   map[string]StaticFile // /static/<name> -> prebuilt response
 }
 
 fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
@@ -69,13 +81,26 @@ fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
 		if m == 0 {
 			m = 1
 		}
+		if accepts_gzip(req) {
+			// json-comp profile: gzip the body and set Content-Encoding.
+			return ok_gzip('application/json', sh.json_body(count, m))
+		}
 		return sh.json_response(count, m)
 	} else if route == '/async-db' {
 		return ok('application/json', sh.async_db(qint(req, 'min'), qint(req, 'max'),
 			qint(req, 'limit')))
+	} else if route == '/fortunes' {
+		return ok('text/html; charset=utf-8', sh.fortunes())
+	} else if route.starts_with('/static/') {
+		if f := sh.assets[route[8..]] {
+			return f.response
+		}
+		return not_found
 	}
-	return ok('text/plain', 'not found')
+	return not_found
 }
+
+const not_found = 'HTTP/1.1 404 Not Found\r\nServer: vanilla\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 
 // json_response builds the FULL HTTP response (headers + body) for /json in a
 // single allocation — no per-request reflection and no body→response copy.
@@ -106,6 +131,61 @@ fn (sh &Shared) json_response(count int, m i64) []u8 {
 	sb.write_decimal(i64(count))
 	sb.write_u8(`}`)
 	return sb
+}
+
+// json_body builds just the /json body string (used for the gzip path).
+fn (sh &Shared) json_body(count int, m i64) string {
+	mut sb := strings.new_builder(count * 224 + 32)
+	sb.write_string('{"items":[')
+	for i in 0 .. count {
+		if i > 0 {
+			sb.write_u8(`,`)
+		}
+		sb.write_string(sh.prefixes[i])
+		sb.write_decimal(sh.dataset[i].price * sh.dataset[i].quantity * m)
+		sb.write_u8(`}`)
+	}
+	sb.write_string('],"count":')
+	sb.write_decimal(i64(count))
+	sb.write_u8(`}`)
+	return sb.str()
+}
+
+// fortunes queries the fortune table, appends the runtime row, sorts by message
+// and renders the HTML table (escaped). 199 seeded + 1 runtime + header = 201 <tr>.
+fn (mut sh Shared) fortunes() string {
+	mut fortunes := []Fortune{}
+	mut conn := sh.pool.acquire() or {
+		return '<!doctype html><html><body><table></table></body></html>'
+	}
+	rows := conn.exec_param_many('SELECT id, message FROM fortune', []) or { [] }
+	sh.pool.release(conn)
+	for row in rows {
+		fortunes << Fortune{
+			id:      nn(row.vals[0]).int()
+			message: nn(row.vals[1])
+		}
+	}
+	fortunes << Fortune{
+		id:      0
+		message: 'Additional fortune added at request time.'
+	}
+	fortunes.sort(a.message < b.message)
+	mut sb := strings.new_builder(32768)
+	sb.write_string('<!doctype html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>')
+	for f in fortunes {
+		sb.write_string('<tr><td>')
+		sb.write_decimal(i64(f.id))
+		sb.write_string('</td><td>')
+		sb.write_string(escape_html(f.message))
+		sb.write_string('</td></tr>')
+	}
+	sb.write_string('</table></body></html>')
+	return sb.str()
+}
+
+fn escape_html(s string) string {
+	return s.replace_each(['&', '&amp;', '<', '&lt;', '>', '&gt;', '"', '&quot;', "'", '&apos;'])
 }
 
 // digits returns the number of decimal digits in a non-negative integer.
@@ -246,6 +326,40 @@ fn ok(ctype string, body string) []u8 {
 	return sb
 }
 
+// ok_gzip gzip-compresses the body and sets Content-Encoding: gzip.
+fn ok_gzip(ctype string, body string) []u8 {
+	gz := gzip.compress(body.bytes()) or { return ok(ctype, body) }
+	mut sb := strings.new_builder(gz.len + 128)
+	sb.write_string('HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Encoding: gzip\r\nContent-Type: ')
+	sb.write_string(ctype)
+	sb.write_string('\r\nContent-Length: ')
+	sb.write_decimal(i64(gz.len))
+	sb.write_string('\r\nConnection: keep-alive\r\n\r\n')
+	unsafe { sb.write_ptr(gz.data, gz.len) }
+	return sb
+}
+
+// accepts_gzip reports whether the request advertises gzip in Accept-Encoding.
+fn accepts_gzip(req request_parser.HttpRequest) bool {
+	ae := req.get_header_value_slice('Accept-Encoding') or { return false }
+	return unsafe { tos(&req.buffer[ae.start], ae.len) }.contains('gzip')
+}
+
+// content_type maps a file extension to a MIME type for the static handler.
+fn content_type(name string) string {
+	ext := name.all_after_last('.')
+	return match ext {
+		'css' { 'text/css' }
+		'js' { 'application/javascript' }
+		'json' { 'application/json' }
+		'html' { 'text/html' }
+		'svg' { 'image/svg+xml' }
+		'webp' { 'image/webp' }
+		'woff2' { 'font/woff2' }
+		else { 'application/octet-stream' }
+	}
+}
+
 // parse_db_url turns postgres://user:pass@host:port/dbname into a pg.Config.
 fn parse_db_url(u string) pg.Config {
 	mut s := u
@@ -292,10 +406,25 @@ fn main() {
 		prefixes << enc#[..-1] + ',"total":'
 	}
 
+	// Preload static assets into memory as ready-to-send responses (originals
+	// only; skip the precompressed .gz/.br siblings — we serve identity).
+	mut assets := map[string]StaticFile{}
+	static_dir := os.getenv_opt('STATIC_DIR') or { '/data/static' }
+	for name in os.ls(static_dir) or { []string{} } {
+		if name.ends_with('.gz') || name.ends_with('.br') {
+			continue
+		}
+		bytes := os.read_bytes('${static_dir}/${name}') or { continue }
+		assets[name] = StaticFile{
+			response: static_response(content_type(name), bytes)
+		}
+	}
+
 	mut sh := Shared{
 		pool:     pool
 		dataset:  dataset
 		prefixes: prefixes
+		assets:   assets
 	}
 
 	mut server := http_server.new_server(http_server.ServerConfig{
@@ -306,4 +435,16 @@ fn main() {
 		}
 	})!
 	server.run()
+}
+
+// static_response prebuilds the full HTTP response for a static file.
+fn static_response(ctype string, body []u8) []u8 {
+	mut sb := strings.new_builder(body.len + 96)
+	sb.write_string('HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Type: ')
+	sb.write_string(ctype)
+	sb.write_string('\r\nContent-Length: ')
+	sb.write_decimal(i64(body.len))
+	sb.write_string('\r\nConnection: keep-alive\r\n\r\n')
+	unsafe { sb.write_ptr(body.data, body.len) }
+	return sb
 }

--- a/frameworks/vanilla/main.v
+++ b/frameworks/vanilla/main.v
@@ -24,24 +24,6 @@ struct DatasetItem {
 	rating   Rating
 }
 
-// Item returned by /json — the dataset item plus the computed `total`.
-struct OutItem {
-	id       i64
-	name     string
-	category string
-	price    i64
-	quantity i64
-	active   bool
-	tags     []string
-	rating   Rating
-	total    i64
-}
-
-struct JsonResp {
-	items []OutItem
-	count int
-}
-
 struct DbItem {
 	id       int
 	name     string
@@ -60,8 +42,9 @@ struct DbResp {
 
 struct Shared {
 mut:
-	pool    pg.ConnectionPool
-	dataset []DatasetItem
+	pool     pg.ConnectionPool
+	dataset  []DatasetItem
+	prefixes []string // per item: `{…,"total":` (everything but the request-dependent total)
 }
 
 fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
@@ -86,27 +69,57 @@ fn handle(req_buffer []u8, _fd int, mut sh Shared) ![]u8 {
 		if m == 0 {
 			m = 1
 		}
-		mut items := []OutItem{cap: count}
-		for i in 0 .. count {
-			d := sh.dataset[i]
-			items << OutItem{
-				id:       d.id
-				name:     d.name
-				category: d.category
-				price:    d.price
-				quantity: d.quantity
-				active:   d.active
-				tags:     d.tags
-				rating:   d.rating
-				total:    d.price * d.quantity * m
-			}
-		}
-		return ok('application/json', json.encode(JsonResp{ items: items, count: items.len }))
+		return sh.json_response(count, m)
 	} else if route == '/async-db' {
 		return ok('application/json', sh.async_db(qint(req, 'min'), qint(req, 'max'),
 			qint(req, 'limit')))
 	}
 	return ok('text/plain', 'not found')
+}
+
+// json_response builds the FULL HTTP response (headers + body) for /json in a
+// single allocation — no per-request reflection and no body→response copy.
+// Only `total` (price*quantity*m) varies per request; the rest is a precomputed
+// prefix. Content-Length is computed up front so everything lands in one buffer.
+fn (sh &Shared) json_response(count int, m i64) []u8 {
+	mut clen := 21 + digits(i64(count)) // len('{"items":[') + len('],"count":') + '}' + count digits
+	if count > 0 {
+		clen += count - 1 // item separators
+	}
+	for i in 0 .. count {
+		t := sh.dataset[i].price * sh.dataset[i].quantity * m
+		clen += sh.prefixes[i].len + digits(t) + 1 // prefix + total + '}'
+	}
+	mut sb := strings.new_builder(clen + 96)
+	sb.write_string('HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Type: application/json\r\nContent-Length: ')
+	sb.write_decimal(i64(clen))
+	sb.write_string('\r\nConnection: keep-alive\r\n\r\n{"items":[')
+	for i in 0 .. count {
+		if i > 0 {
+			sb.write_u8(`,`)
+		}
+		sb.write_string(sh.prefixes[i])
+		sb.write_decimal(sh.dataset[i].price * sh.dataset[i].quantity * m)
+		sb.write_u8(`}`)
+	}
+	sb.write_string('],"count":')
+	sb.write_decimal(i64(count))
+	sb.write_u8(`}`)
+	return sb
+}
+
+// digits returns the number of decimal digits in a non-negative integer.
+fn digits(n i64) int {
+	if n < 10 {
+		return 1
+	}
+	mut x := n
+	mut d := 0
+	for x > 0 {
+		d++
+		x /= 10
+	}
+	return d
 }
 
 fn (mut sh Shared) async_db(min i64, max i64, limit i64) string {
@@ -270,9 +283,19 @@ fn main() {
 	dataset_raw := os.read_file(dataset_path) or { '[]' }
 	dataset := json.decode([]DatasetItem, dataset_raw) or { []DatasetItem{} }
 
+	// Precompute each item's JSON prefix once: `{…,"rating":{…},"total":`
+	// (drop the closing brace, append the total key). Only the total value is
+	// request-dependent, so the hot path never serializes a struct.
+	mut prefixes := []string{cap: dataset.len}
+	for it in dataset {
+		enc := json.encode(it)
+		prefixes << enc#[..-1] + ',"total":'
+	}
+
 	mut sh := Shared{
-		pool:    pool
-		dataset: dataset
+		pool:     pool
+		dataset:  dataset
+		prefixes: prefixes
 	}
 
 	mut server := http_server.new_server(http_server.ServerConfig{

--- a/frameworks/vanilla/main.v
+++ b/frameworks/vanilla/main.v
@@ -430,6 +430,9 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            8080
 		io_multiplexing: .epoll
+		limits:          http_server.Limits{
+			max_request_bytes: 32 * 1024 * 1024 // accept the 20 MiB upload bodies
+		}
 		request_handler: fn [mut sh] (req_buffer []u8, fd int) ![]u8 {
 			return handle(req_buffer, fd, mut sh)
 		}

--- a/frameworks/vanilla/meta.json
+++ b/frameworks/vanilla/meta.json
@@ -3,7 +3,7 @@
   "language": "V",
   "type": "production",
   "engine": "epoll",
-  "description": "vanilla is a minimalist, high-performance HTTP server written in V: multi-threaded, non-blocking epoll I/O, lock-free, copy-free, SO_REUSEPORT. Handlers are pure (request)->[]u8 returning raw response bytes. JSON is built in a single allocation with precomputed prefixes (no per-request reflection); json-comp gzips on Accept-Encoding; static assets are preloaded into memory; fortunes renders the DB rows + a runtime row with HTML escaping; async-db uses the stdlib db.pg ConnectionPool. Pinned V 0.5.1 (prebuilt release).",
+  "description": "vanilla is a minimalist, high-performance HTTP server written in V: multi-threaded, non-blocking epoll I/O, lock-free, copy-free, SO_REUSEPORT. Handlers are pure (request)->[]u8 returning raw response bytes. JSON is built in a single allocation with precomputed prefixes (no per-request reflection); json-comp gzips on Accept-Encoding; static assets are preloaded into memory; fortunes renders the DB rows + a runtime row with HTML escaping; async-db uses the stdlib db.pg ConnectionPool. Pinned V 0.5.1 (prebuilt release). crud uses an in-memory cache-aside (X-Cache MISS/HIT, invalidated on update) \u2014 no Redis required.",
   "repo": "https://github.com/enghitalo/vanilla",
   "enabled": true,
   "tests": [
@@ -15,6 +15,7 @@
     "upload",
     "static",
     "async-db",
+    "crud",
     "fortunes",
     "api-4",
     "api-16"

--- a/frameworks/vanilla/meta.json
+++ b/frameworks/vanilla/meta.json
@@ -3,14 +3,22 @@
   "language": "V",
   "type": "production",
   "engine": "epoll",
-  "description": "vanilla is a minimalist, high-performance HTTP server written in V: multi-threaded, non-blocking epoll I/O, lock-free, copy-free (handlers work on slices into the read buffer), with SO_REUSEPORT for kernel load balancing. Handlers are pure (request) -> []u8 functions returning raw HTTP response bytes. The JSON dataset is parsed once at startup with the stdlib json module; async-db uses the stdlib db.pg pooled driver (sized from DATABASE_MAX_CONN). Built with -prod.",
+  "description": "vanilla is a minimalist, high-performance HTTP server written in V: multi-threaded, non-blocking epoll I/O, lock-free, copy-free, SO_REUSEPORT. Handlers are pure (request)->[]u8 returning raw response bytes. JSON is built in a single allocation with precomputed prefixes (no per-request reflection); json-comp gzips on Accept-Encoding; static assets are preloaded into memory; fortunes renders the DB rows + a runtime row with HTML escaping; async-db uses the stdlib db.pg ConnectionPool. Pinned V 0.5.1 (prebuilt release).",
   "repo": "https://github.com/enghitalo/vanilla",
   "enabled": true,
   "tests": [
     "baseline",
     "pipelined",
+    "limited-conn",
     "json",
-    "async-db"
+    "json-comp",
+    "static",
+    "async-db",
+    "fortunes",
+    "api-4",
+    "api-16"
   ],
-  "maintainers": ["enghitalo"]
+  "maintainers": [
+    "enghitalo"
+  ]
 }

--- a/frameworks/vanilla/meta.json
+++ b/frameworks/vanilla/meta.json
@@ -12,6 +12,7 @@
     "limited-conn",
     "json",
     "json-comp",
+    "upload",
     "static",
     "async-db",
     "fortunes",

--- a/frameworks/vanilla/meta.json
+++ b/frameworks/vanilla/meta.json
@@ -1,0 +1,16 @@
+{
+  "display_name": "vanilla",
+  "language": "V",
+  "type": "production",
+  "engine": "epoll",
+  "description": "vanilla is a minimalist, high-performance HTTP server written in V: multi-threaded, non-blocking epoll I/O, lock-free, copy-free (handlers work on slices into the read buffer), with SO_REUSEPORT for kernel load balancing. Handlers are pure (request) -> []u8 functions returning raw HTTP response bytes. The JSON dataset is parsed once at startup with the stdlib json module; async-db uses the stdlib db.pg pooled driver (sized from DATABASE_MAX_CONN). Built with -prod.",
+  "repo": "https://github.com/enghitalo/vanilla",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "json",
+    "async-db"
+  ],
+  "maintainers": ["enghitalo"]
+}


### PR DESCRIPTION
## Add `vanilla` (V)

[vanilla](https://github.com/enghitalo/vanilla) is a minimalist, high-performance HTTP server written in [V](https://vlang.io) — raw epoll, non-blocking, lock-free, copy-free, `SO_REUSEPORT`.

### Profiles implemented

| Profile | Endpoint | Notes |
|---|---|---|
| `baseline` | `GET/POST /baseline11` | `a + b` (+ body on POST); handles chunked & TCP-fragmented requests |
| `pipelined` | `GET /pipeline` | returns `ok` |
| `json` | `GET /json/{count}?m=M` | processes `/data/dataset.json`, adds `total = price*quantity*M` |
| `async-db` | `GET /async-db?min&max&limit` | `SELECT … FROM items WHERE price BETWEEN min AND max LIMIT limit` via the stdlib `db.pg` pooled driver |

### Notes

- V is built from `master` in the Dockerfile (reports `V 0.5.1`). The dataset is parsed once at startup with the stdlib `json` module; the DB pool is sized from `DATABASE_MAX_CONN`.
- `POST /upload` is implemented but **not subscribed**: `vanilla` caps a single request at 8 MiB (a built-in DoS guard), below the 20 MiB `upload` bodies. Happy to raise/condition that cap upstream in a follow-up if you'd like the `upload` profile too.

### Validation

Verified against the HttpArena image + `data/pgdb-seed.sql` + `data/dataset.json`. All `baseline` / `pipelined` / `json` / `async-db` checks pass — including chunked bodies, randomized anti-cheat inputs, all four TCP-fragmentation splits, the 4 json `(count, m)` pairs, the 4 async-db limits, and the empty-range DB case.

(Local `./scripts/validate.sh vanilla` couldn't run end-to-end in my environment because host port 5432 was already in use by an unrelated container, so the Postgres sidecar couldn't bind; the checks above were run manually against the built image with an equivalent Postgres on another port.)
