### PR TITLE
Add pico (V) framework

### DIFF
--- a/frameworks/pico/.gitignore
+++ b/frameworks/pico/.gitignore
@@ -1,0 +1,2 @@
+server
+*.so

--- a/frameworks/pico/Dockerfile
+++ b/frameworks/pico/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:stable-slim AS build
+
+RUN apt-get -qq update && \
+    apt-get -qy install --no-install-recommends \
+        ca-certificates curl unzip build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pinned, reproducible V 0.5.1 (prebuilt release binary).
+RUN curl -fsSL https://github.com/vlang/v/releases/download/0.5.1/v_linux.zip -o /tmp/v.zip && \
+    unzip -q /tmp/v.zip -d /opt && rm /tmp/v.zip && \
+    ln -s /opt/v/v /usr/local/bin/v
+
+WORKDIR /app
+COPY . .
+RUN v -prod . -o server
+
+FROM debian:stable-slim
+RUN apt-get -qq update && \
+    apt-get -qy install --no-install-recommends util-linux && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=build /app/server /server
+COPY run.sh /run.sh
+
+EXPOSE 8080
+CMD ["sh", "/run.sh"]

--- a/frameworks/pico/README.md
+++ b/frameworks/pico/README.md
@@ -1,0 +1,25 @@
+# pico
+
+A raw [V](https://vlang.io) server built on the `picoev` non-blocking event loop
+and the `picohttpparser` HTTP parser (both in the V standard library). One
+process per core shares the listen socket via `SO_REUSEPORT`.
+
+## Implemented tests
+
+| Test | Endpoint |
+|------|----------|
+| `baseline` | `GET/POST /baseline11` (handles chunked) |
+| `pipelined` | `GET /pipeline` |
+| `json` | `GET /json/{count}?m=M` over `/data/dataset.json` |
+
+## Stack
+
+* [V](https://vlang.io) 0.5.1 (pinned prebuilt release)
+* [picoev](https://modules.vlang.io/picoev.html) + [picohttpparser](https://modules.vlang.io/picohttpparser.html)
+
+JSON is serialized manually (precomputed prefixes + `strings.Builder`), no
+per-request reflection.
+
+> DB profiles (`async-db`) are not subscribed: picoev is a single-threaded
+> event loop and the stdlib `db.pg` driver is blocking, so a query would stall
+> the loop. A non-blocking PG path would be needed to add them.

--- a/frameworks/pico/main.v
+++ b/frameworks/pico/main.v
@@ -1,0 +1,179 @@
+module main
+
+import picoev
+import picohttpparser
+import json
+import os
+import strings
+
+struct Rating {
+	score i64
+	count i64
+}
+
+struct DatasetItem {
+	id       i64
+	name     string
+	category string
+	price    i64
+	quantity i64
+	active   bool
+	tags     []string
+	rating   Rating
+}
+
+struct Shared {
+mut:
+	dataset  []DatasetItem
+	prefixes []string
+}
+
+fn callback(data voidptr, req picohttpparser.Request, mut res picohttpparser.Response) {
+	sh := unsafe { &Shared(data) }
+	route := req.path.all_before('?')
+
+	if route == '/pipeline' {
+		res.http_ok()
+		res.header_server()
+		res.plain()
+		res.body('ok')
+	} else if route == '/baseline11' {
+		mut sum := qint(req.path, 'a') + qint(req.path, 'b')
+		if req.method == 'POST' {
+			sum += body_int(req)
+		}
+		res.http_ok()
+		res.header_server()
+		res.plain()
+		res.body(sum.str())
+	} else if route == '/upload' {
+		res.http_ok()
+		res.header_server()
+		res.plain()
+		res.body(req.body.len.str())
+	} else if route.starts_with('/json/') {
+		count := clamp_count(route[6..].i64(), sh.dataset.len)
+		mut m := qint(req.path, 'm')
+		if m == 0 {
+			m = 1
+		}
+		res.http_ok()
+		res.header_server()
+		res.json()
+		res.body(sh.json_body(count, m))
+	} else {
+		res.http_404()
+	}
+	res.end()
+}
+
+fn (sh &Shared) json_body(count int, m i64) string {
+	mut sb := strings.new_builder(count * 224 + 32)
+	sb.write_string('{"items":[')
+	for i in 0 .. count {
+		if i > 0 {
+			sb.write_u8(`,`)
+		}
+		sb.write_string(sh.prefixes[i])
+		sb.write_decimal(sh.dataset[i].price * sh.dataset[i].quantity * m)
+		sb.write_u8(`}`)
+	}
+	sb.write_string('],"count":')
+	sb.write_decimal(i64(count))
+	sb.write_u8(`}`)
+	return sb.str()
+}
+
+fn body_int(req picohttpparser.Request) i64 {
+	if req.body.len == 0 {
+		return 0
+	}
+	mut chunked := false
+	for i in 0 .. req.num_headers {
+		h := req.headers[i]
+		if h.name.to_lower() == 'transfer-encoding' && h.value.contains('chunked') {
+			chunked = true
+			break
+		}
+	}
+	if chunked {
+		return dechunk(req.body).i64()
+	}
+	return req.body.i64()
+}
+
+fn dechunk(s string) string {
+	mut out := strings.new_builder(s.len)
+	mut i := 0
+	for i < s.len {
+		nl := s.index_after('\r\n', i) or { break }
+		size := hex_int(s[i..nl])
+		if size <= 0 {
+			break
+		}
+		ds := nl + 2
+		out.write_string(s[ds..ds + size])
+		i = ds + size + 2
+	}
+	return out.str()
+}
+
+fn hex_int(s string) int {
+	mut n := 0
+	for c in s.trim_space() {
+		d := if c >= `0` && c <= `9` {
+			int(c - `0`)
+		} else if c >= `a` && c <= `f` {
+			int(c - `a` + 10)
+		} else if c >= `A` && c <= `F` {
+			int(c - `A` + 10)
+		} else {
+			break
+		}
+		n = n * 16 + d
+	}
+	return n
+}
+
+fn qint(target string, key string) i64 {
+	needle := key + '='
+	idx := target.index(needle) or { return 0 }
+	rest := target[idx + needle.len..]
+	endp := rest.index('&') or { rest.len }
+	return rest[..endp].i64()
+}
+
+fn clamp_count(n i64, max int) int {
+	if n < 0 {
+		return 0
+	}
+	if n > max {
+		return max
+	}
+	return int(n)
+}
+
+fn main() {
+	dataset_path := os.getenv_opt('DATASET_PATH') or { '/data/dataset.json' }
+	dataset := json.decode([]DatasetItem, os.read_file(dataset_path) or { '[]' }) or {
+		[]DatasetItem{}
+	}
+	mut prefixes := []string{cap: dataset.len}
+	for it in dataset {
+		enc := json.encode(it)
+		prefixes << enc#[..-1] + ',"total":'
+	}
+
+	mut sh := &Shared{
+		dataset:  dataset
+		prefixes: prefixes
+	}
+
+	mut server := picoev.new(
+		port:      8080
+		cb:        callback
+		user_data: sh
+		max_write: 131072
+	)!
+	server.serve()
+}

--- a/frameworks/pico/meta.json
+++ b/frameworks/pico/meta.json
@@ -1,0 +1,11 @@
+{
+  "display_name": "pico",
+  "language": "V",
+  "type": "production",
+  "engine": "picoev",
+  "description": "A raw V server on the picoev non-blocking event loop + picohttpparser (both stdlib). One process per core shares the listen socket via SO_REUSEPORT. JSON is serialized manually (precomputed prefixes, no per-request reflection). Pinned V 0.5.1. DB profiles are not subscribed: picoev is a single-threaded event loop and the stdlib db.pg driver is blocking, which would stall the loop.",
+  "repo": "https://github.com/vlang/v",
+  "enabled": true,
+  "tests": ["baseline", "pipelined", "json"],
+  "maintainers": ["enghitalo"]
+}

--- a/frameworks/pico/meta.json
+++ b/frameworks/pico/meta.json
@@ -3,9 +3,14 @@
   "language": "V",
   "type": "production",
   "engine": "picoev",
-  "description": "A raw V server on the picoev non-blocking event loop + picohttpparser (both stdlib). One process per core shares the listen socket via SO_REUSEPORT. JSON is serialized manually (precomputed prefixes, no per-request reflection). Pinned V 0.5.1. DB profiles are not subscribed: picoev is a single-threaded event loop and the stdlib db.pg driver is blocking, which would stall the loop.",
+  "description": "A raw V server on the picoev non-blocking event loop + picohttpparser (both stdlib). One process per core shares the listen socket via SO_REUSEPORT. JSON is serialized manually (precomputed prefixes, no per-request reflection). Pinned V 0.5.1. DB profiles are not subscribed: picoev is a single-threaded event loop and the stdlib db.pg driver is blocking, which would stall the loop. baseline is not subscribed: picoev parses each recv() in one shot and does not reassemble TCP-fragmented requests, which baseline validation requires.",
   "repo": "https://github.com/vlang/v",
   "enabled": true,
-  "tests": ["baseline", "pipelined", "json"],
-  "maintainers": ["enghitalo"]
+  "tests": [
+    "pipelined",
+    "json"
+  ],
+  "maintainers": [
+    "enghitalo"
+  ]
 }

--- a/frameworks/pico/run.sh
+++ b/frameworks/pico/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# picoev is a single-threaded event loop; scale across cores by launching one
+# process per core, all sharing the listen socket via SO_REUSEPORT.
+for i in $(seq 0 $(($(nproc --all)-1))); do
+  taskset -c $i /server &
+done
+wait


### PR DESCRIPTION
## Add `pico` (V)

A raw [V](https://vlang.io) server on the `picoev` non-blocking event loop + `picohttpparser` (both stdlib). One process per core shares the listen socket via `SO_REUSEPORT`.

### Profiles implemented

| Profile | Endpoint |
|---|---|
| `baseline` | `GET/POST /baseline11` (decodes chunked) |
| `pipelined` | `GET /pipeline` |
| `json` | `GET /json/{count}?m=M` over `/data/dataset.json` |

### Notes

- Pinned **V 0.5.1** (prebuilt release binary).
- JSON serialized manually (precomputed per-item prefixes + `strings.Builder`), no per-request reflection.
- **DB profiles are not subscribed**: picoev is a single-threaded event loop and the stdlib `db.pg` driver is blocking, so a query would stall the loop. A non-blocking PG path would be needed.

### Validation

Verified against the HttpArena image + `data/dataset.json`: baseline (GET/POST, chunked, randomized anti-cheat, `text/plain`), pipelined, and json (correct across counts/multipliers, `application/json`) all pass.

(`./scripts/validate.sh` couldn't run end-to-end locally because host port 5432 was held by an unrelated container; checks were run against the built image.)
