### PR TITLE
validate: always run framework containers with seccomp=unconfined

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -93,7 +93,7 @@ if has_test "async-db" || has_test "crud" || has_test "api-4" || has_test "api-1
     docker_args=(-d --name "$CONTAINER_NAME" --network host --security-opt seccomp=unconfined
         --ulimit memlock=-1:-1 --ulimit nofile="$HARD_NOFILE:$HARD_NOFILE")
 else
-    docker_args=(-d --name "$CONTAINER_NAME" -p "$PORT:8080"
+    docker_args=(-d --name "$CONTAINER_NAME" -p "$PORT:8080" --security-opt seccomp=unconfined
         --ulimit memlock=-1:-1 --ulimit nofile="$HARD_NOFILE:$HARD_NOFILE")
 fi
 docker_args+=(-v "$DATA_DIR/dataset.json:/data/dataset.json:ro")
@@ -130,12 +130,12 @@ if has_test "static" || has_test "static-h2" || has_test "static-h3" || has_test
     docker_args+=(-v "$DATA_DIR/static:/data/static:ro")
 fi
 
-# Allow io_uring syscalls for frameworks that need them (blocked by default seccomp)
-ENGINE=$(python3 -c "import json; print(json.load(open('$META_FILE')).get('engine',''))" 2>/dev/null || true)
-if [ "$ENGINE" = "io_uring" ]; then
-    docker_args+=(--security-opt seccomp=unconfined)
-    docker_args+=(--ulimit memlock=-1:-1)
-fi
+# Note: --security-opt seccomp=unconfined is applied unconditionally in both
+# container-launch branches above. io_uring (and other syscalls some runtimes
+# rely on) are blocked by Docker's default seccomp profile, and a framework
+# shouldn't have to advertise engine=="io_uring" to be testable — many need it
+# transitively (e.g. an engine built on io_uring under another name). This
+# mirrors benchmark.sh, which always runs framework containers unconfined.
 
 # Start Postgres sidecar if async-db is needed
 if has_test "async-db" || has_test "crud" || has_test "api-4" || has_test "api-16" || has_test "gateway-64" || has_test "gateway-h3" || has_test "production-stack" || has_test "fortunes"; then


### PR DESCRIPTION
## Description

`validate.sh` only added `--security-opt seccomp=unconfined` to the framework container when `meta.json` `engine == "io_uring"`. That gate is too narrow — a framework can need io_uring (or other syscalls blocked by Docker's default seccomp profile) **without** advertising it as its engine:

- an engine built on io_uring under another name (its `engine` field is the engine's name, not `"io_uring"`),
- or a runtime/library that uses io_uring transitively.

Such frameworks crash at startup *only during validation* — `io_uring_setup` → `EPERM` → the server exits → `Connection refused` — while passing `/benchmark`, because `benchmark.sh` already runs every framework container with `seccomp=unconfined`.

## Fix

Apply `--security-opt seccomp=unconfined` unconditionally in **both** container-launch branches (the `memlock` unlimited ulimit was already present), and drop the `engine == "io_uring"` special-case. This makes validation consistent with benchmarking.
