### PR TITLE
Enable finger-slide horizontal scroll on composite table (mobile)

### DIFF
--- a/site/static/new-leaderboard/index.html
+++ b/site/static/new-leaderboard/index.html
@@ -286,6 +286,8 @@
 
   /* ── Composite matrix ────────────────────────────────────── */
   .cwrap{display:block; width:100%; overflow-x:hidden; overflow-y:auto; max-height:calc(100vh - 210px); border:1px solid var(--line); border-radius:10px; margin-top:.15rem}
+  /* touch devices: allow finger-slide horizontal scrolling of the table (desktop keeps overflow-x hidden + the synced bars) */
+  @media (hover: none) and (pointer: coarse){ .cwrap{overflow-x:auto; -webkit-overflow-scrolling:touch} }
   /* synced horizontal scrollbar + jump-to-end button above the table */
   .cscroll-row{display:flex; align-items:stretch; gap:.4rem; margin-top:.5rem}
   .cscroll-row.endonly{justify-content:flex-end; margin-top:.1rem; margin-bottom:.35rem}


### PR DESCRIPTION
## Problem

On touch devices the composite table can't be scrolled horizontally with a finger swipe.

## Cause

The table wrapper was set to `overflow-x:hidden` (desktop scrolls via the synced top/bottom scrollbar + jump buttons, so the persistent native bottom bar was removed). `overflow-x:hidden` also disables touch panning, so there's no way to scroll the table sideways on a phone.

## Fix

Re-enable horizontal overflow on touch devices only:

```css
@media (hover: none) and (pointer: coarse){
  .cwrap{ overflow-x:auto; -webkit-overflow-scrolling:touch }
}
```

Desktop (mouse) is unchanged — still `overflow-x:hidden` with the synced bars. Touch devices get native finger-swipe with momentum; the synced bars still track the scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)