### PR TITLE
Make composite table horizontally scrollable everywhere

### DIFF
--- a/site/static/new-leaderboard/index.html
+++ b/site/static/new-leaderboard/index.html
@@ -285,7 +285,12 @@
 
 
   /* ── Composite matrix ────────────────────────────────────── */
-  .cwrap{display:block; width:100%; overflow-x:hidden; overflow-y:auto; max-height:calc(100vh - 210px); border:1px solid var(--line); border-radius:10px; margin-top:.15rem}
+  /* table scrolls natively in both axes (bar drag, wheel, trackpad and finger all work); its own horizontal bar is hidden so only the synced bar shows */
+  .cwrap{display:block; width:100%; overflow-x:auto; overflow-y:auto; max-height:calc(100vh - 210px); border:1px solid var(--line); border-radius:10px; margin-top:.15rem; -webkit-overflow-scrolling:touch; scrollbar-width:thin; scrollbar-color:var(--line) transparent}
+  .cwrap::-webkit-scrollbar{width:10px; height:0}
+  .cwrap::-webkit-scrollbar-thumb{background:var(--line); border-radius:6px}
+  .cwrap::-webkit-scrollbar-thumb:hover{background:var(--muted)}
+  .cwrap::-webkit-scrollbar-track{background:transparent}
   /* synced horizontal scrollbar + jump-to-end button above the table */
   .cscroll-row{display:flex; align-items:stretch; gap:.4rem; margin-top:.5rem}
   .cscroll-row.endonly{justify-content:flex-end; margin-top:.1rem; margin-bottom:.35rem}


### PR DESCRIPTION
The desktop fix set the table wrapper to overflow-x:hidden and scrolled it by setting wrap.scrollLeft from the synced bar. Programmatic scrollLeft on an overflow:hidden box is browser-flaky - some browsers move the bar but never scroll the table content (reported on the live site).

Switch the wrapper to overflow-x:auto so it is a real scroll container: the synced bar, mouse wheel, trackpad and finger-swipe all scroll it reliably. Hide the wrapper's own horizontal scrollbar (webkit height:0; thin elsewhere) so only the synced top/bottom bar is shown, and keep the vertical scrollbar. Replaces the earlier touch-only media query.