### PR TITLE
Composite table: full height on touch, single page scroll

### DIFF
--- a/site/static/new-leaderboard/index.html
+++ b/site/static/new-leaderboard/index.html
@@ -291,6 +291,8 @@
   .cwrap::-webkit-scrollbar-thumb{background:var(--line); border-radius:6px}
   .cwrap::-webkit-scrollbar-thumb:hover{background:var(--muted)}
   .cwrap::-webkit-scrollbar-track{background:transparent}
+  /* touch devices: let the table run full height so the PAGE gives the single vertical scroll (no nested scroll); horizontal finger-scroll stays */
+  @media (hover: none) and (pointer: coarse){ .cwrap{max-height:none} }
   /* synced horizontal scrollbar + jump-to-end button above the table */
   .cscroll-row{display:flex; align-items:stretch; gap:.4rem; margin-top:.5rem}
   .cscroll-row.endonly{justify-content:flex-end; margin-top:.1rem; margin-bottom:.35rem}


### PR DESCRIPTION
On touch / small screens, the composite table currently scrolls vertically inside its own capped box (nested scroll). This makes it stretch to full height instead, so the **page** provides one vertical scroll.

```css
@media (hover: none) and (pointer: coarse){ .cwrap{ max-height:none } }
```

Horizontal finger-scroll is unchanged. Desktop is untouched (capped box + sticky header). On touch the header scrolls with the page — the natural trade-off of a single page-level scroll.

Follow-up to #842 (that PR merged before this commit landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)