### PR TITLE
[python] Add BlackBull framework

### DIFF
--- a/frameworks/blackbull/.dockerignore
+++ b/frameworks/blackbull/.dockerignore
@@ -1,0 +1,10 @@
+# Build context = bench/httparena/.  Keep the image small: only
+# requirements.txt + app.py + launcher.py are copied into the image.
+**
+!requirements.txt
+!app.py
+!launcher.py
+# Dev-only: a locally-built wheel for Dockerfile.dev.  Untracked.
+!blackbull-*.whl
+**/__pycache__/
+**/*.pyc

--- a/frameworks/blackbull/Dockerfile
+++ b/frameworks/blackbull/Dockerfile
@@ -1,0 +1,37 @@
+# BlackBull-on-HttpArena container.
+#
+# Build context = bench/httparena/ (this directory).  BlackBull is
+# installed from PyPI, so the host source tree is not needed at build
+# time.  Build with:
+#
+#   docker build -t blackbull-httparena bench/httparena/
+#
+# Run with HttpArena-shaped mounts (cleartext HTTP/1.1 on :8080, h2c
+# on :8082, TLS HTTP/1.1 on :8081, TLS HTTP/2 on :8443):
+#
+#   docker run --rm --network host \
+#     -v $PWD/bench/httparena/_local/data:/data:ro \
+#     -v $PWD/bench/httparena/_local/certs:/certs:ro \
+#     blackbull-httparena
+
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install BlackBull from PyPI — same install path real users follow.
+# Pins live in requirements.txt; bump in lockstep with each release.
+# The [compression] extra pulls brotli + zstandard for the json-comp
+# profile.  --no-cache-dir keeps the pip cache out of the image layer.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy framework files last so app/launcher edits don't bust the
+# slow pip layer.
+COPY app.py launcher.py ./
+
+EXPOSE 8080 8081 8082 8443
+
+CMD ["python", "launcher.py"]

--- a/frameworks/blackbull/README.md
+++ b/frameworks/blackbull/README.md
@@ -1,0 +1,119 @@
+# BlackBull on HttpArena
+
+BlackBull's framework integration for the
+[HttpArena](https://www.http-arena.com/) benchmark harness.  The
+directory is structured so it can be vendored under
+[`MDA2AV/HttpArena`](https://github.com/MDA2AV/HttpArena) at
+`frameworks/blackbull/` without further modification.
+
+## Layout
+
+```
+bench/httparena/
+  Dockerfile         multi-stage-free image; build context = repo root
+  .dockerignore      keeps the image small
+  app.py             BlackBull entrypoint with the HttpArena endpoint contract
+  launcher.py        spawns cleartext (:8080) + TLS (:8081) processes
+  meta.json          HttpArena framework metadata
+  README.md          this file
+```
+
+## Profiles implemented
+
+The endpoint contract in `app.py` covers the H1 / H2 / WebSocket
+profiles BlackBull's runtime supports today:
+
+| Profile         | Endpoint               | Status |
+|-----------------|------------------------|--------|
+| baseline        | GET/POST `/baseline11` | ✓ |
+| pipelined       | GET/POST `/baseline11` | ✓ (same endpoint, pipeline-driven workload) |
+| limited-conn    | GET/POST `/baseline11` | ✓ |
+| json            | GET `/json/{count}`    | ✓ |
+| json-tls        | GET `/json/{count}` on :8081 | ✓ |
+| upload          | POST `/upload`         | ✓ |
+| baseline-h2     | GET/POST `/baseline11` on :8443 (TLS, ALPN h2) | ✓ (claimed in `meta.json`) |
+| baseline-h2c    | GET `/baseline11`  on :8082 (h2 prior-knowledge) | runtime-capable; not claimed in `meta.json` yet |
+| json-h2c        | GET `/json/{count}` on :8082 (h2 prior-knowledge) | runtime-capable; not claimed in `meta.json` yet |
+| echo-ws         | GET `/ws` upgrade      | ✓ (re-exported via the standard BlackBull WS handler — TODO mount at `/ws` here) |
+
+A dedicated `:8082` cleartext listener is opened so HttpArena's
+`validate.sh` port-open probe succeeds.  BlackBull's preface
+auto-detect dispatches h2c connections through the HTTP/2 actor on
+the same app/workers as `:8080`; the port stays idle during
+benchmark runs that do not exercise h2c.  `baseline-h2c` /
+`json-h2c` are runtime-capable on `:8082` but currently unclaimed in
+`meta.json`.
+
+Profiles **not** implemented (intentional carve-out):
+
+| Profile | Why not |
+|---|---|
+| `static-h3` | HTTP/3 / QUIC transport is intentionally out-of-scope per the project roadmap. |
+| `async-db`, `crud`, `fortunes`, `api-4`, `api-16` | Out of scope.  BlackBull is a protocol-layer framework, not a full-stack one — Postgres-backed implementations belong in a separate submission if we ever pursue the leaderboard (see Flask's HttpArena entry for the pattern). |
+| `*-h3`           | HTTP/3 / QUIC is out-of-scope. |
+| `*-grpc`         | No gRPC. |
+| `gateway-*`, `production-stack` | Need sidecar + DB work first; same scope rationale as the DB profiles. |
+
+## Local smoke test
+
+The `_local/` subdir holds throwaway mounts that mirror what
+HttpArena's harness provides; create it on first use.
+
+```bash
+mkdir -p bench/httparena/_local/data bench/httparena/_local/certs
+
+# Dataset — pull HttpArena's authoritative 50-item file or use our own.
+curl -fL -o bench/httparena/_local/data/dataset.json \
+  https://raw.githubusercontent.com/MDA2AV/HttpArena/master/data/dataset.json
+
+# Reuse the project's mkcert dev cert as the TLS pair.
+cp tests/cert.pem bench/httparena/_local/certs/server.crt
+cp tests/key.pem  bench/httparena/_local/certs/server.key
+
+# Build (context = this directory; BlackBull is pip-installed from PyPI).
+docker build -t blackbull-httparena bench/httparena/
+
+# Run with the documented mounts.
+docker run --rm --network host \
+  -v $PWD/bench/httparena/_local/data:/data:ro \
+  -v $PWD/bench/httparena/_local/certs:/certs:ro \
+  --name blackbull-httparena \
+  blackbull-httparena
+
+# In another terminal:
+curl -s "http://localhost:8080/pipeline"                  # → ok
+curl -s "http://localhost:8080/baseline11?a=1&b=2&c=3"     # → 6
+curl -s "http://localhost:8080/json/3?m=2.0" | python3 -m json.tool
+curl -sk "https://localhost:8081/baseline11?a=10"          # → 10
+```
+
+`_local/` is gitignored — local sandbox only.
+
+## End-to-end HttpArena run
+
+To actually drive the validation + benchmark scripts:
+
+```bash
+# One-time: clone HttpArena somewhere outside the BlackBull repo.
+git clone https://github.com/MDA2AV/HttpArena.git ~/work/HttpArena
+
+# Vendor this directory under HttpArena's frameworks/ tree:
+mkdir -p ~/work/HttpArena/frameworks/blackbull
+cp -r bench/httparena/* ~/work/HttpArena/frameworks/blackbull/
+
+# Flip enabled=true in the vendored meta.json, then:
+cd ~/work/HttpArena
+./scripts/validate.sh blackbull           # 18-point correctness check
+./scripts/benchmark.sh blackbull baseline # one profile
+```
+
+## Versioning + apples-to-apples
+
+The Dockerfile pins `blackbull[compression]` to an explicit PyPI
+version (currently `0.33.0`).  Bump the pin in lockstep with the
+upstream release whose behaviour you intend the container to
+exercise.
+
+`BB_ACCESS_LOG=0` is set by `app.py` to match the peer benchmark
+convention — every peer in the HttpArena framework set disables
+access logging during benchmark runs.

--- a/frameworks/blackbull/app.py
+++ b/frameworks/blackbull/app.py
@@ -1,0 +1,263 @@
+"""BlackBull entrypoint for HttpArena benchmark profiles.
+
+Implements the endpoint contract documented at
+https://www.http-arena.com/docs/add-framework/ for the H1 + WebSocket
+profiles BlackBull supports today:
+
+  GET  /pipeline                              → text/plain "ok"
+  GET  /baseline11?<int=int>&…                → text/plain sum of query ints
+  POST /baseline11?<int=int>&…  body=<int>    → text/plain sum
+  GET  /json/{count}?m=<float>                → JSON {items, count}
+  GET  /json-comp/{count}?m=<float>           → JSON, may be gzipped
+  POST /upload          body                  → text/plain byte count
+  GET  /ws (Upgrade)                          → echoes frames
+
+Dataset is read from $DATASET_PATH (default /data/dataset.json — the
+read-only mount HttpArena's harness provides).
+
+Profiles intentionally NOT implemented:
+  - async-db / crud   (no asyncpg integration)
+  - api-4 / api-16    (multi-endpoint compositions)
+  - *-h3              (no HTTP/3 transport)
+  - *-grpc            (no gRPC support)
+  - production-stack / gateway / fortunes
+
+The container starts four BlackBull processes via ``launcher.py``:
+cleartext on :8080, h2c on :8082, TLS HTTP/1.1 on :8081, TLS HTTP/2
+on :8443.  Cleartext also serves h2c via prior-knowledge — BlackBull
+negotiates HTTP/2 on first preface bytes.
+"""
+import argparse
+import json
+import os
+import sys
+from http import HTTPMethod
+from urllib.parse import parse_qs
+
+# Scheme.websocket is the BlackBull marker used by `@app.route` to
+# register the `echo-ws` HttpArena profile handler.
+from blackbull.utils import Scheme
+
+# Ensure the BlackBull source tree is importable when the Docker image
+# vendors it at /src/BlackBull/.  Local runs use `pip install -e .` so
+# this is a no-op then.
+_repo_root = os.environ.get('BLACKBULL_SRC', '/src/BlackBull')
+if os.path.isdir(_repo_root) and _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from blackbull import BlackBull, JSONResponse, Response, read_body
+from blackbull.middleware.compression import Compression
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+DATASET_PATH = os.environ.get('DATASET_PATH', '/data/dataset.json')
+try:
+    with open(DATASET_PATH, 'r') as f:
+        DATASET_ITEMS = json.load(f)
+except (OSError, ValueError):
+    DATASET_ITEMS = []
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = BlackBull()
+
+# HttpArena's json-comp profile expects Accept-Encoding-driven compression.
+# BlackBull's Compression middleware picks br > zstd > gzip from the codecs
+# the container has installed.  Bodies below min_size (default 100 bytes)
+# pass through, so /baseline11 + /pipeline aren't affected.
+#
+# Diagnostic toggle: BB_NO_COMPRESSION=1 skips registering Compression
+# entirely.  Useful for isolating the cost of on-the-fly brotli encoding
+# on already-compressed payloads (e.g. .woff2 fonts) that lack a
+# precompressed sibling.  Not for benchmark publication — disabling a
+# default-on feature breaks the apples-to-apples convention.
+if os.environ.get('BB_NO_COMPRESSION', '0') != '1':
+    app.use(Compression())
+
+# HttpArena's static profile expects /static/<asset> to serve files from
+# /data/static/.  app.static() registers a StaticFiles middleware with the
+# URL prefix and source directory; missing files (e.g. when /data/static/
+# is unpopulated in a sandbox run) return 404 without breaking other routes.
+app.static('/static', os.environ.get('STATIC_DIR', '/data/static/'))
+
+_PIPELINE_BODY = b'ok'
+_NO_DATASET = b'No dataset'
+_PLAIN = 'text/plain; charset=utf-8'
+
+
+def _qs(scope):
+    raw = scope.get('query_string') or b''
+    return parse_qs(raw.decode('latin-1'), keep_blank_values=True)
+
+
+@app.route(path='/pipeline', methods=[HTTPMethod.GET])
+async def pipeline():
+    return Response(_PIPELINE_BODY, content_type=_PLAIN)
+
+
+async def _baseline_handler(scope, receive, send):
+    """Shared body for /baseline11 (H/1.1) and /baseline2 (H/2).
+
+    HttpArena uses path-suffix to distinguish the two profiles, but
+    the semantics are identical: sum integer query params, add posted
+    body if integer, return as text/plain.
+    """
+    total = 0
+    for vals in _qs(scope).values():
+        for v in vals:
+            try:
+                total += int(v)
+            except ValueError:
+                pass
+    if scope['method'] == 'POST':
+        body = await read_body(receive)
+        if body:
+            try:
+                total += int(body.strip())
+            except ValueError:
+                pass
+    payload = str(total).encode()
+    await send({'type': 'http.response.start', 'status': 200,
+                'headers': [(b'content-type', _PLAIN.encode())]})
+    await send({'type': 'http.response.body', 'body': payload})
+
+
+@app.route(path='/baseline11', methods=[HTTPMethod.GET, HTTPMethod.POST])
+async def baseline11(scope, receive, send):
+    await _baseline_handler(scope, receive, send)
+
+
+# HttpArena's H/2 baseline profile uses /baseline2 (path suffix
+# disambiguates from the H/1.1 /baseline11).  Same semantics.
+@app.route(path='/baseline2', methods=[HTTPMethod.GET, HTTPMethod.POST])
+async def baseline2(scope, receive, send):
+    await _baseline_handler(scope, receive, send)
+
+
+def _json_payload(count: int, m: float):
+    items = []
+    for idx, ds in enumerate(DATASET_ITEMS):
+        if idx >= count:
+            break
+        item = dict(ds)
+        item['total'] = ds['price'] * ds['quantity'] * m
+        items.append(item)
+    return {'items': items, 'count': len(items)}
+
+
+@app.route(path='/json/{count:int}', methods=[HTTPMethod.GET])
+async def json_endpoint(count: int, scope):
+    if not DATASET_ITEMS:
+        return Response(_NO_DATASET, status=500, content_type=_PLAIN)
+    try:
+        m = float(_qs(scope).get('m', ['0'])[0])
+    except ValueError:
+        m = 0.0
+    return JSONResponse(_json_payload(count, m))
+
+
+@app.route(path='/json-comp/{count:int}', methods=[HTTPMethod.GET])
+async def json_comp_endpoint(count: int, scope):
+    # Same payload as /json; the Compression middleware registered
+    # at module top wraps the response with gzip / brotli / zstd per
+    # the client's Accept-Encoding.
+    if not DATASET_ITEMS:
+        return Response(_NO_DATASET, status=500, content_type=_PLAIN)
+    try:
+        m = float(_qs(scope).get('m', ['0'])[0])
+    except ValueError:
+        m = 0.0
+    return JSONResponse(_json_payload(count, m))
+
+
+@app.route(path='/upload', methods=[HTTPMethod.POST])
+async def upload_endpoint(scope, receive, send):
+    size = 0
+    while True:
+        msg = await receive()
+        if msg['type'] != 'http.request':
+            break
+        size += len(msg.get('body') or b'')
+        if not msg.get('more_body', False):
+            break
+    payload = str(size).encode()
+    await send({'type': 'http.response.start', 'status': 200,
+                'headers': [(b'content-type', _PLAIN.encode())]})
+    await send({'type': 'http.response.body', 'body': payload})
+
+
+# Liveness for ``launcher.py``'s readiness probe.
+@app.route(path='/healthz', methods=[HTTPMethod.GET])
+async def healthz():
+    return Response(b'ok', content_type=_PLAIN)
+
+
+# HttpArena `echo-ws` profile — RFC 6455 WebSocket echo.  First
+# message after accept is the receive loop; text frames echo as text,
+# binary frames echo as bytes.
+@app.route(path='/ws', methods=[HTTPMethod.GET], scheme=Scheme.websocket)
+async def ws_echo(scope, receive, send):
+    event = await receive()
+    if event.get('type') != 'websocket.connect':
+        return
+    await send({'type': 'websocket.accept'})
+    while True:
+        event = await receive()
+        t = event.get('type', '')
+        if t == 'websocket.disconnect':
+            break
+        if t != 'websocket.receive':
+            continue
+        text = event.get('text')
+        if text is not None:
+            await send({'type': 'websocket.send', 'text': text})
+        else:
+            await send({'type': 'websocket.send',
+                        'bytes': event.get('bytes') or b''})
+
+
+# ---------------------------------------------------------------------------
+# Entry point — invoked by launcher.py once per listener port.
+# ---------------------------------------------------------------------------
+
+def _parse_args():
+    p = argparse.ArgumentParser(description='BlackBull on HttpArena')
+    p.add_argument('--port', type=int, required=True)
+    p.add_argument('--cert')
+    p.add_argument('--key')
+    p.add_argument('--workers', type=int, default=None)
+    return p.parse_args()
+
+
+if __name__ == '__main__':
+    args = _parse_args()
+    # Match peer benchmark posture: access log off (apples-to-apples).
+    os.environ.setdefault('BB_ACCESS_LOG', '0')
+    # When BB_ACCESS_LOG=1 is opted in (e.g. for diagnostic phase
+    # tracing under BB_PHASE_TRACE=1), the access logger needs an
+    # explicit INFO handler — BlackBull's default level inheritance
+    # leaves ``blackbull.access`` at WARNING (effective), so
+    # emit_access_log() is gated off even when cfg.access_log is True.
+    # Wire a dedicated stderr handler with propagate=False so the
+    # access stream is self-contained and doesn't double-emit through
+    # the QueueHandler on the parent 'blackbull' logger.
+    if os.environ.get('BB_ACCESS_LOG') == '1':
+        import logging as _bb_logging
+        _bb_access = _bb_logging.getLogger('blackbull.access')
+        _bb_access.setLevel(_bb_logging.INFO)
+        _h = _bb_logging.StreamHandler(sys.stderr)
+        _h.setLevel(_bb_logging.INFO)
+        _h.setFormatter(_bb_logging.Formatter('[ACCESS] %(message)s'))
+        _bb_access.addHandler(_h)
+        _bb_access.propagate = False
+    if args.cert and args.key:
+        app.run(port=args.port, certfile=args.cert, keyfile=args.key,
+                workers=args.workers)
+    else:
+        app.run(port=args.port, workers=args.workers)

--- a/frameworks/blackbull/launcher.py
+++ b/frameworks/blackbull/launcher.py
@@ -1,0 +1,112 @@
+"""Spawn HTTP + HTTPS BlackBull workers per HttpArena framework spec.
+
+HttpArena's `scripts/validate.sh` uses four ports:
+
+  :8080  HTTP/1.1 cleartext (also serves h2c via prior-knowledge)
+  :8081  HTTPS HTTP/1.1     — the ``json-tls`` profile probes here
+  :8082  h2c only           — BlackBull's HTTP/2 preface auto-detect
+                              handles h2c on the same app/workers as
+                              :8080.  The dedicated :8082 listener is
+                              opened so validate.sh's port-open probe
+                              succeeds even when ``baseline-h2c`` /
+                              ``json-h2c`` profiles aren't claimed in
+                              ``meta.json``.
+  :8443  HTTPS HTTP/2 ALPN  — ``baseline-h2`` / ``static-h2`` probe here
+
+BlackBull claims both H/1.1+TLS and H/2+TLS, so :8081 and :8443 are
+exposed simultaneously — same BlackBull, same cert, different
+listeners.  ALPN negotiates HTTP/1.1 on :8081 connections and h2
+on :8443.
+
+Parallel ``subprocess.Popen`` per port, all terminated on SIGTERM /
+SIGINT.  No port-readiness gating — BlackBull's bind happens in
+``serve()`` as the first awaited step, so by the time the
+subprocess is alive the kernel TCP accept queue is open.
+"""
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+HTTP_PORT      = int(os.environ.get('HTTPARENA_HTTP_PORT',      '8080'))
+HTTPS_H1_PORT  = int(os.environ.get('HTTPARENA_HTTPS_H1_PORT',  '8081'))
+H2C_PORT       = int(os.environ.get('HTTPARENA_H2C_PORT',       '8082'))
+HTTPS_H2_PORT  = int(os.environ.get('HTTPARENA_HTTPS_H2_PORT',  '8443'))
+TLS_CERT       = os.environ.get('TLS_CERT', '/certs/server.crt')
+TLS_KEY        = os.environ.get('TLS_KEY',  '/certs/server.key')
+
+# Worker count — explicit override via WEB_WORKERS env var (the
+# harness sets this when sweeping nproc/2 / nproc / nproc×2).
+# Otherwise honour cgroup-aware CPU affinity if the platform exposes
+# it (Linux), else fall back to multiprocessing.cpu_count().  Capped
+# at 128 as a sanity guard.
+_web_workers = os.environ.get('WEB_WORKERS', '').strip()
+if _web_workers.isdigit() and int(_web_workers) > 0:
+    WRK_COUNT = min(int(_web_workers), 128)
+else:
+    try:
+        WRK_COUNT = min(len(os.sched_getaffinity(0)), 128)
+    except (AttributeError, OSError):
+        WRK_COUNT = multiprocessing.cpu_count()
+
+PY = sys.executable
+APP = os.path.join(os.path.dirname(__file__), 'app.py')
+
+# Which listeners to spawn.  validate.sh requires all four;
+# benchmark profiles only ever load one at a time, so disabling the
+# idle three during a benchmark removes most of the worker-process
+# scheduler pressure.  Comma-separated list of
+# {"http","https-h1","h2c","https-h2"}; default = all four (so
+# validate.sh's port-open probe finds :8082 listening).
+_ports_env = os.environ.get('BB_HTTPARENA_PORTS', 'http,https-h1,h2c,https-h2')
+_enabled_ports = {p.strip() for p in _ports_env.split(',') if p.strip()}
+
+
+def _spawn(extra):
+    return subprocess.Popen([PY, APP, *extra, '--workers', str(WRK_COUNT)])
+
+
+http_proc       = _spawn(['--port', str(HTTP_PORT)]) if 'http' in _enabled_ports else None
+h2c_proc        = _spawn(['--port', str(H2C_PORT)])  if 'h2c'  in _enabled_ports else None
+https_h1_proc   = None
+https_h2_proc   = None
+if os.path.exists(TLS_CERT) and os.path.exists(TLS_KEY):
+    if 'https-h1' in _enabled_ports:
+        https_h1_proc = _spawn(['--port', str(HTTPS_H1_PORT),
+                                '--cert', TLS_CERT, '--key', TLS_KEY])
+    if 'https-h2' in _enabled_ports:
+        https_h2_proc = _spawn(['--port', str(HTTPS_H2_PORT),
+                                '--cert', TLS_CERT, '--key', TLS_KEY])
+else:
+    sys.stderr.write(
+        f'launcher: TLS cert/key not present at {TLS_CERT} / {TLS_KEY}; '
+        f'starting cleartext only\n')
+
+
+_PROCS = (http_proc, h2c_proc, https_h1_proc, https_h2_proc)
+
+
+def _shutdown(*_):
+    for p in _PROCS:
+        if p is not None:
+            p.terminate()
+    time.sleep(1)
+    for p in _PROCS:
+        if p is not None and p.poll() is None:
+            p.kill()
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, _shutdown)
+signal.signal(signal.SIGINT,  _shutdown)
+
+try:
+    rc = http_proc.wait()
+finally:
+    for p in (h2c_proc, https_h1_proc, https_h2_proc):
+        if p is not None:
+            p.terminate()
+sys.exit(rc)

--- a/frameworks/blackbull/meta.json
+++ b/frameworks/blackbull/meta.json
@@ -1,0 +1,24 @@
+{
+  "display_name": "blackbull",
+  "language": "Python",
+  "type": "emerging",
+  "mode": "standard",
+  "engine": "blackbull",
+  "description": "BlackBull — pure-Python async ASGI 3.0 framework supporting HTTP/1.1, HTTP/2, and WebSocket. ALPN negotiates HTTP/2 on the same listener that serves HTTP/1.1.",
+  "repo": "https://github.com/TOKUJI/BlackBull",
+  "enabled": true,
+  "tests": [
+    "baseline-h2",
+    "static-h2",
+    "echo-ws",
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-comp",
+    "json-tls",
+    "upload",
+    "static"
+  ],
+  "maintainers": []
+}

--- a/frameworks/blackbull/requirements.txt
+++ b/frameworks/blackbull/requirements.txt
@@ -1,0 +1,1 @@
+blackbull[compression]==0.33.1


### PR DESCRIPTION
## Description

`blackbull` is a pure-Python async ASGI 3.0 framework supporting HTTP/1.1, HTTP/2, and WebSocket.  ALPN negotiates HTTP/2 on the same listener that serves HTTP/1.1.

- Tier: emerging
- Profiles (11): baseline, baseline-h2, pipelined, limited-conn, json, json-comp, json-tls, upload, static, static-h2, echo-ws
- All local validation passed