### PR TITLE
Add hical C++20/26 framework

### DIFF
--- a/frameworks/hical/Dockerfile
+++ b/frameworks/hical/Dockerfile
@@ -1,0 +1,46 @@
+# HttpArena — Hical C++20/26 Web Framework
+# 多阶段 Docker 构建
+#
+# 第一阶段：编译 Hical 框架 + HttpArena benchmark 服务器
+# 第二阶段：精简运行镜像
+
+# --- 构建阶段 ---
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates gcc-14 g++-14 cmake ninja-build git \
+        libboost-all-dev libssl-dev libgtest-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone Hical 项目源码（包含 HttpArena benchmark 文件在 docker/HttpArena/ 下）
+ARG HICAL_REPO=https://github.com/Hical61/Hical.git
+ARG HICAL_REF=main
+
+WORKDIR /src
+RUN git clone --depth 1 --branch ${HICAL_REF} ${HICAL_REPO} .
+
+RUN cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=gcc-14 \
+        -DCMAKE_CXX_COMPILER=g++-14 \
+        -DCMAKE_CXX_FLAGS="-march=native -mtune=native" \
+        -DHICAL_BUILD_HTTPARENA=ON \
+        -DHICAL_BUILD_TESTS=OFF \
+        -DHICAL_BUILD_EXAMPLES=OFF \
+    && cmake --build build --target httparena_server -j$(nproc) \
+    && strip build/httparena_server
+
+# --- 运行阶段（最小镜像） ---
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libboost-json1.83.0 libssl3t64 zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/build/httparena_server /server
+
+EXPOSE 8080
+
+CMD ["/server"]

--- a/frameworks/hical/README.md
+++ b/frameworks/hical/README.md
@@ -1,0 +1,28 @@
+# Hical
+
+[Hical](https://github.com/Hical61/Hical) is a modern C++20/26 high-performance
+web framework built on Boost.Asio.
+
+## Features
+
+- Coroutine-based async I/O (`boost::asio::awaitable<T>`)
+- Three-tier PMR memory pool (global / thread-local / request-level)
+- Zero-copy HTTP parsing (picohttpparser + stack-allocated `phr_header[64]`)
+- SO_REUSEPORT multi-acceptor model on Linux
+- Self-developed WebSocket stack (RFC 6455, permessage-deflate)
+- Dual-track C++26 reflection layer (native P2996 / C++20 macro fallback)
+
+## Test Types
+
+- baseline, pipelined, limited-conn
+- json
+- upload
+- static
+- echo-ws
+
+## Dependencies
+
+- C++20 (GCC 14+)
+- Boost (Asio, JSON, System)
+- OpenSSL
+- zlib

--- a/frameworks/hical/meta.json
+++ b/frameworks/hical/meta.json
@@ -1,0 +1,19 @@
+{
+  "display_name": "hical",
+  "language": "C++",
+  "type": "engine",
+  "engine": "hical",
+  "description": "Hical is a modern C++20/26 high-performance web framework built on Boost.Asio, featuring coroutine-based async I/O (boost::asio::awaitable<T>), three-tier PMR memory pools, zero-copy HTTP parsing via picohttpparser, and a self-developed WebSocket stack (RFC 6455 with permessage-deflate). SO_REUSEPORT multi-acceptor model on Linux. Dual-track C++26 reflection layer (P2996 / C++20 macro fallback).",
+  "repo": "https://github.com/Hical61/Hical",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "upload",
+    "static",
+    "echo-ws"
+  ],
+  "maintainers": ["Hical61"]
+}


### PR DESCRIPTION
## Description

Add [hical](https://github.com/Hical61/hical) — a modern C++20/26 high-performance
web framework built on Boost.Asio, featuring coroutine-based async I/O,
three-tier PMR memory pools, zero-copy HTTP parsing via picohttpparser,
and a self-developed WebSocket stack (RFC 6455, permessage-deflate).

SO_REUSEPORT multi-acceptor model on Linux (one `io_context` per core, kernel-sharded accept).
Dual-track C++26 reflection layer (native P2996 / C++20 macro fallback).

### Profiles implemented

| Profile | Endpoint | Notes |
|---|---|---|
| `baseline` | `GET/POST /baseline11?a=&b=` | Handles chunked & TCP-fragmented requests |
| `pipelined` | `GET /pipeline` | Returns `ok` |
| `limited-conn` | `GET /baseline11?a=&b=` | Short-lived connections |
| `json` | `GET /json/{count}?m=M` | Reads `/data/dataset.json`, calculates `total = price * quantity * M` |
| `upload` | `POST /upload` | Returns body byte length |
| `static` | `GET /static/{file}` | sendfile zero-copy, ETag, 404 |
| `echo-ws` | `ws:///ws` | RFC 6455 handshake + echo + ping/pong |

### Validation

`./scripts/validate.sh hical` — **31 passed, 0 failed**

baseline (13/13), pipelined (2/2), json (2/2), upload (3/3), static (6/6, 1 skip: compression), echo-ws (7/7)