### PR TITLE
follow-up for zix-grpc

### DIFF
--- a/frameworks/zix-grpc/src/main.zig
+++ b/frameworks/zix-grpc/src/main.zig
@@ -1,3 +1,5 @@
+//! HttpArena: zix-grpc
+//! zix version: 0.3.0
 const std = @import("std");
 const zix = @import("zix");
 

--- a/site/data/stream-grpc-64.json
+++ b/site/data/stream-grpc-64.json
@@ -55,5 +55,24 @@
     "status_3xx": 0,
     "status_4xx": 0,
     "status_5xx": 32
+  },
+  {
+    "framework": "zix-grpc",
+    "language": "Zig",
+    "rps": 8331000,
+    "avg_latency": "143.74ms",
+    "p99_latency": "812.02ms",
+    "cpu": "44.3%",
+    "memory": "90MiB",
+    "connections": 64,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "0",
+    "reconnects": 0,
+    "status_2xx": 8331,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 144
   }
 ]

--- a/site/data/unary-grpc-1024.json
+++ b/site/data/unary-grpc-1024.json
@@ -154,5 +154,24 @@
     "status_3xx": 0,
     "status_4xx": 0,
     "status_5xx": 0
+  },
+  {
+    "framework": "zix-grpc",
+    "language": "Zig",
+    "rps": 6895367,
+    "avg_latency": "7.74ms",
+    "p99_latency": "7.74ms",
+    "cpu": "3933.8%",
+    "memory": "1.1GiB",
+    "connections": 1024,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "438.36MB/s",
+    "reconnects": 0,
+    "status_2xx": 34821605,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
   }
 ]

--- a/site/data/unary-grpc-256.json
+++ b/site/data/unary-grpc-256.json
@@ -154,5 +154,24 @@
     "status_3xx": 0,
     "status_4xx": 0,
     "status_5xx": 0
+  },
+  {
+    "framework": "zix-grpc",
+    "language": "Zig",
+    "rps": 7041146,
+    "avg_latency": "2.29ms",
+    "p99_latency": "2.29ms",
+    "cpu": "3801.9%",
+    "memory": "346MiB",
+    "connections": 256,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "447.62MB/s",
+    "reconnects": 0,
+    "status_2xx": 35557792,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
   }
 ]

--- a/site/static/logs/stream-grpc/64/zix-grpc.log
+++ b/site/static/logs/stream-grpc/64/zix-grpc.log
@@ -1,0 +1,1 @@
+zix grpc server (epoll mux): :::8080 (64 workers)

--- a/site/static/logs/unary-grpc/1024/zix-grpc.log
+++ b/site/static/logs/unary-grpc/1024/zix-grpc.log
@@ -1,0 +1,1 @@
+zix grpc server (epoll mux): :::8080 (64 workers)

--- a/site/static/logs/unary-grpc/256/zix-grpc.log
+++ b/site/static/logs/unary-grpc/256/zix-grpc.log
@@ -1,0 +1,1 @@
+zix grpc server (epoll mux): :::8080 (64 workers)


### PR DESCRIPTION
## Description

Bump HttpArena to zix-grpc 0.3.x

adding:
- zix gRPC implementation.

Required to call from HttpArena:
- [x] `/benchmark -f zix-grpc`
- [x] `/benchmark -f zix-grpc --save`

---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
