### PR TITLE
bench: reset Postgres before each DB profile (fix cross-profile contamination)

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -219,6 +219,25 @@ run_one() {
 
     banner "$FRAMEWORK / $profile / ${CONNS}c (tool=$tool)"
 
+    # Reset Postgres before each DB profile so it sees the same clean,
+    # freshly-seeded server a standalone `benchmark.sh <fw> <profile>` run gets.
+    # Postgres is started once and shared across the whole run, so otherwise the
+    # previous profile's warm buffers / planner stats / table bloat bleed into
+    # this one. That contamination is severe: after async-db's seq-scan load
+    # leaves every page resident, crud's cached-read backends all become
+    # runnable at once and Postgres spins ~120 cores on snapshot/buffer
+    # contention, collapsing crud from ~680k to ~210k rps. The first DB profile
+    # already has a fresh server from the upfront postgres_start, so skip it.
+    case "$endpoint" in
+        async-db|crud|api-4|api-16|fortunes)
+            if [ "${PG_DIRTY:-false}" = true ]; then
+                info "resetting postgres for a clean per-profile baseline"
+                postgres_start
+            fi
+            PG_DIRTY=true
+            ;;
+    esac
+
     # Compose-orchestrated profiles (gateway-*, production-stack) use
     # a multi-container stack instead of a single framework container.
     local is_gateway=false


### PR DESCRIPTION
## Problem

The benchmark driver starts **one** Postgres sidecar per `benchmark.sh` invocation and shares it across every profile, while the framework container is restarted per profile. That asymmetry lets one profile's Postgres state bleed into the next.

It surfaced as a large, reproducible gap for `crud`:

- `./scripts/benchmark.sh ioxide crud` (standalone) → **~680k rps**
- `./scripts/benchmark.sh ioxide` (full run, `async-db` then `crud`) → **~210k rps, decaying to ~110k**

Same machine, same code, same data (`async-db` is read-only, so the table contents are identical).

## Root cause

`async-db` drives ~10M sequential scans and leaves the entire `items` table resident in Postgres shared buffers. When `crud` then runs against that warm server, its single-item-read backends are all immediately runnable (no I/O stalls), so ~190 backends pile onto the read path at once and Postgres spins on snapshot / buffer-mapping contention.

Measured — server vs Postgres `docker stats` + `pg_stat_activity` once/sec:

| scenario | crud rps | server CPU | Postgres CPU | active backends |
|---|---|---|---|---|
| fresh PG (standalone) | ~680k | ~2900% | ~3900% (~39 cores) | ~220 |
| shared PG (after async-db) | 210k → 110k | ~400% | **~12000% (~120 cores)** | ~190, nearly all `on-CPU` |

Wait-event sampling during the meltdown: ~190 backends `on-CPU` running `SELECT ... FROM items WHERE id = $N`, with a trickle on `IPC/ProcArrayGroupUpdate` + `LWLock/BufferContent` — snapshot/buffer contention, **not** lock waits, **not** sequential scans, **not** connection exhaustion (ruled those out empirically — raising `max_connections` and pinning PG's cpuset both did nothing).

## Fix

Reset (drop + freshly seed) Postgres before each DB-subscribed profile (`async-db`, `crud`, `api-4`, `api-16`, `fortunes`), so every profile sees the same clean server a standalone single-profile run gives it. The first DB profile reuses the upfront `postgres_start`; subsequent ones reset via a `PG_DIRTY` flag.

## Result

Full `benchmark.sh ioxide` (async-db → crud) after the fix:

- `async-db`: ~368k (unchanged)
- `crud`: **633k → 676k → 690k** — server back to ~2900%, Postgres back to ~39 cores

crud in the full run now matches its standalone figure.

## Scope & cost

- **General correctness fix, not framework-specific.** Any framework whose DB profile ran after another DB profile in a multi-profile run was contaminated the same way; high-connection-pool frameworks are hit hardest (more backends → more snapshot contention when warm). Existing leaderboard `crud` / `api-*` / `async-db` numbers produced via full multi-profile runs may be understated and worth re-running; per-profile (solo) results are unaffected.
- Adds ~one Postgres restart + reseed (~5–10s) per DB profile beyond the first.

## Test plan

- [x] `benchmark.sh ioxide` (async-db + crud): crud rebounds 210k → 690k, matches standalone; PG back to ~39 cores, server to ~2900%
- [ ] full ioxide test set including `api-4` / `api-16`
- [ ] spot-check another DB framework (e.g. a flagship) for regressions
