### PR TITLE
ioxide: serve baked static responses directly (fix static profile CPU/memory)

### DIFF
--- a/frameworks/ioxide/HttpSession.cs
+++ b/frameworks/ioxide/HttpSession.cs
@@ -24,6 +24,18 @@ internal sealed unsafe partial class HttpSession
     public int OutLen;
     public bool WantClose;
 
+    // A baked static response sent straight to the connection, bypassing Out. This avoids copying
+    // the (up to ~66 KB) asset into the per-connection Out buffer and stops Out from ballooning to
+    // the largest asset under load (which was inflating CPU + memory on the static profile). Set
+    // only when it's the first response of a batch (OutLen == 0); otherwise the asset rides Out so
+    // pipelined ordering is preserved. Either a managed buffer (precompressed) or a native span
+    // (ioxide.file's identity baked response).
+    public byte[]? DirectBytes;
+    public nint DirectPtr;
+    public int DirectLen;
+    public bool HasDirect => DirectLen > 0;
+    public void ClearDirect() { DirectBytes = null; DirectPtr = 0; DirectLen = 0; }
+
     public HttpSession(Dataset ds, StaticAssets? assets, Precompressed? precompressed)
     {
         _ds = ds;
@@ -228,11 +240,13 @@ internal sealed unsafe partial class HttpSession
             byte[]? pre = _precompressed?.Negotiate(path[7..], acceptBr, acceptGzip);
             if (pre != null)
             {
-                AppendOut(pre);
+                if (OutLen == 0 && !HasDirect) { DirectBytes = pre; DirectLen = pre.Length; }
+                else AppendOut(pre);
             }
             else if (_assets != null && _assets.TryGet(path[7..], out AssetCache.Asset asset) && asset.Response != 0)
             {
-                AppendOut(new ReadOnlySpan<byte>((void*)asset.Response, asset.ResponseLength));
+                if (OutLen == 0 && !HasDirect) { DirectPtr = asset.Response; DirectLen = asset.ResponseLength; }
+                else AppendOut(new ReadOnlySpan<byte>((void*)asset.Response, asset.ResponseLength));
             }
             else
             {

--- a/frameworks/ioxide/Program.cs
+++ b/frameworks/ioxide/Program.cs
@@ -313,6 +313,23 @@ internal static class Handler
                     else s.ResumeFeed();
                 }
 
+                // Baked static responses go straight to the wire (not through Out) - no extra copy,
+                // and Out never grows to the largest asset, so per-connection memory stays flat
+                // under load. Sent before Out, which preserves order (Direct is only set when it was
+                // the first response of the batch).
+                if (s.HasDirect)
+                {
+                    int dsent = 0;
+                    while (dsent < s.DirectLen)
+                    {
+                        int dchunk = Math.Min(s.DirectLen - dsent, _slab);
+                        WriteDirect(conn, s, dsent, dchunk);
+                        await conn.FlushAsync();
+                        dsent += dchunk;
+                    }
+                    s.ClearDirect();
+                }
+
                 int sent = 0;
                 while (sent < s.OutLen)
                 {
@@ -347,6 +364,15 @@ internal static class Handler
             tls?.Dispose();
             conn.DecRef();
         }
+    }
+
+    // Copy one slab-sized slice of the direct (baked static) response into the connection's write
+    // slab - managed precompressed buffer or native identity response. Kept in a sync unsafe helper
+    // so the native pointer never crosses an await in the async handler.
+    private static unsafe void WriteDirect(Connection conn, HttpSession s, int off, int len)
+    {
+        if (s.DirectBytes != null) conn.Write(s.DirectBytes.AsSpan(off, len));
+        else conn.Write(new ReadOnlySpan<byte>((void*)(s.DirectPtr + off), len));
     }
 
     private static unsafe void FeedSlices(HttpSession s, Connection conn, TlsSession? tls, in RecvSnapshot snap)


### PR DESCRIPTION
## What

The `ioxide` static handler copied each baked response (precompressed `.br` or identity asset, up to ~66 KB for `vendor.js.br`) into the per-connection `Out` buffer via `AppendOut`, then chunked `Out` into the write slab. `Out` is grown with `Array.Resize` and never shrinks, so **every connection that served a large asset retained a ~66 KB managed buffer for its lifetime** — inflating memory (≈1.4 GiB at 6800 conns) and GC pressure, and degrading the `static` profile as connection count climbed (888K@1024c → 670K@6800c). It also double-copied (asset → `Out` → slab).

## Fix

Write a baked static response **straight to the connection**, bypassing `Out` — either the managed `.br` buffer or the native identity span from `ioxide.file`. `Out` then only ever holds small text responses, so it stays at its 4 KB starting size. Used only when the static response is the first of a batch (`OutLen == 0`) and sent **before** `Out`, so pipelined ordering is preserved (otherwise it falls back to `AppendOut`).

## Result (local, `wrk -t18 -c512 -d5s`, negotiated brotli)

| | before | after |
|---|---|---|
| Requests/sec | 1,455,491 | **1,623,463** (+11%) |
| server CPU | 1642% | **1545%** |
| avg latency | 594 µs | **355 µs** (−40%) |

`Content-Encoding: br` still served correctly. The bigger win is at the rig's high connection counts, where `Out` no longer balloons per connection (addresses the memory growth + under-load degradation).