### PR TITLE
Removed  `zix` as websocket entry

### DIFF
--- a/site/data/echo-ws-16384.json
+++ b/site/data/echo-ws-16384.json
@@ -596,25 +596,6 @@
     "status_5xx": 0
   },
   {
-    "framework": "zix",
-    "language": "Zig",
-    "rps": 1822757,
-    "avg_latency": "65us",
-    "p99_latency": "309us",
-    "cpu": "3918.2%",
-    "memory": "191MiB",
-    "connections": 16384,
-    "threads": 64,
-    "duration": "5s",
-    "pipeline": 1,
-    "bandwidth": "12.17MB/s",
-    "reconnects": 0,
-    "status_2xx": 9113789,
-    "status_3xx": 0,
-    "status_4xx": 0,
-    "status_5xx": 0
-  },
-  {
     "framework": "zix-ws",
     "language": "Zig",
     "rps": 4232201,

--- a/site/data/echo-ws-4096.json
+++ b/site/data/echo-ws-4096.json
@@ -596,25 +596,6 @@
     "status_5xx": 0
   },
   {
-    "framework": "zix",
-    "language": "Zig",
-    "rps": 1877060,
-    "avg_latency": "66us",
-    "p99_latency": "176us",
-    "cpu": "4140.5%",
-    "memory": "95MiB",
-    "connections": 4096,
-    "threads": 64,
-    "duration": "5s",
-    "pipeline": 1,
-    "bandwidth": "12.53MB/s",
-    "reconnects": 0,
-    "status_2xx": 9385302,
-    "status_3xx": 0,
-    "status_4xx": 0,
-    "status_5xx": 0
-  },
-  {
     "framework": "zix-ws",
     "language": "Zig",
     "rps": 4513022,

--- a/site/data/echo-ws-512.json
+++ b/site/data/echo-ws-512.json
@@ -596,25 +596,6 @@
     "status_5xx": 0
   },
   {
-    "framework": "zix",
-    "language": "Zig",
-    "rps": 1985036,
-    "avg_latency": "63us",
-    "p99_latency": "122us",
-    "cpu": "4277.4%",
-    "memory": "66MiB",
-    "connections": 512,
-    "threads": 64,
-    "duration": "5s",
-    "pipeline": 1,
-    "bandwidth": "13.25MB/s",
-    "reconnects": 0,
-    "status_2xx": 9925184,
-    "status_3xx": 0,
-    "status_4xx": 0,
-    "status_5xx": 0
-  },
-  {
     "framework": "zix-ws",
     "language": "Zig",
     "rps": 4279997,

--- a/site/data/echo-ws-pipeline-16384.json
+++ b/site/data/echo-ws-pipeline-16384.json
@@ -418,25 +418,6 @@
     "status_5xx": 0
   },
   {
-    "framework": "zix",
-    "language": "Zig",
-    "rps": 57595760,
-    "avg_latency": "4.53ms",
-    "p99_latency": "8.95ms",
-    "cpu": "6459.3%",
-    "memory": "276MiB",
-    "connections": 16384,
-    "threads": 64,
-    "duration": "5s",
-    "pipeline": 16,
-    "bandwidth": "384.74MB/s",
-    "reconnects": 0,
-    "status_2xx": 287978800,
-    "status_3xx": 0,
-    "status_4xx": 0,
-    "status_5xx": 0
-  },
-  {
     "framework": "zix-ws",
     "language": "Zig",
     "rps": 53628657,

--- a/site/data/echo-ws-pipeline-4096.json
+++ b/site/data/echo-ws-pipeline-4096.json
@@ -418,25 +418,6 @@
     "status_5xx": 0
   },
   {
-    "framework": "zix",
-    "language": "Zig",
-    "rps": 59002588,
-    "avg_latency": "1.11ms",
-    "p99_latency": "2.33ms",
-    "cpu": "6572.1%",
-    "memory": "124MiB",
-    "connections": 4096,
-    "threads": 64,
-    "duration": "5s",
-    "pipeline": 16,
-    "bandwidth": "393.75MB/s",
-    "reconnects": 0,
-    "status_2xx": 295012941,
-    "status_3xx": 0,
-    "status_4xx": 0,
-    "status_5xx": 0
-  },
-  {
     "framework": "zix-ws",
     "language": "Zig",
     "rps": 65562329,

--- a/site/data/echo-ws-pipeline-512.json
+++ b/site/data/echo-ws-pipeline-512.json
@@ -418,25 +418,6 @@
     "status_5xx": 0
   },
   {
-    "framework": "zix",
-    "language": "Zig",
-    "rps": 58552182,
-    "avg_latency": "139us",
-    "p99_latency": "363us",
-    "cpu": "6469.3%",
-    "memory": "78MiB",
-    "connections": 512,
-    "threads": 64,
-    "duration": "5s",
-    "pipeline": 16,
-    "bandwidth": "390.77MB/s",
-    "reconnects": 0,
-    "status_2xx": 292760911,
-    "status_3xx": 0,
-    "status_4xx": 0,
-    "status_5xx": 0
-  },
-  {
     "framework": "zix-ws",
     "language": "Zig",
     "rps": 60158423,


### PR DESCRIPTION
## Description

Resolving https://github.com/MDA2AV/HttpArena/issues/881

<img width="961" height="1052" alt="ss-20260617-035020" src="https://github.com/user-attachments/assets/55cb329c-1115-4840-aaa5-ebcb46ec9617" />

---

Double check. Let me know if there's something for this PR.