### PR TITLE
Add monoxide framework entry

### DIFF
--- a/frameworks/monoxide/Data.cs
+++ b/frameworks/monoxide/Data.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using System.Text.Json;
+
+namespace MonoxideArena;
+
+/// <summary>One dataset item, parsed to model fields at startup and serialized field-by-field per
+/// request (no precomputed response fragments). String values are clean ASCII in the bench dataset.</summary>
+internal readonly struct Item(long id, byte[] name, byte[] category, long price, long quantity,
+                              bool active, byte[][] tags, long score, long ratingCount)
+{
+    public readonly long Id = id, Price = price, Quantity = quantity, Score = score, RatingCount = ratingCount;
+    public readonly bool Active = active;
+    public readonly byte[] Name = name, Category = category;
+    public readonly byte[][] Tags = tags;
+}
+
+/// <summary>Read-only items for the json profile, shared across reactor threads after load.</summary>
+internal sealed class Dataset
+{
+    public readonly Item[] Items;
+    public int Count => Items.Length;
+    public static readonly Dataset Empty = new(Array.Empty<Item>());
+
+    private Dataset(Item[] items) => Items = items;
+
+    public static Dataset Load(string path)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllBytes(path));
+            JsonElement root = doc.RootElement;
+            var items = new Item[root.GetArrayLength()];
+            int i = 0;
+            foreach (JsonElement e in root.EnumerateArray())
+            {
+                JsonElement rating = e.GetProperty("rating");
+                JsonElement tagsEl = e.GetProperty("tags");
+                var tags = new byte[tagsEl.GetArrayLength()][];
+                int t = 0;
+                foreach (JsonElement tag in tagsEl.EnumerateArray())
+                    tags[t++] = Encoding.UTF8.GetBytes(tag.GetString() ?? "");
+                items[i++] = new Item(
+                    e.GetProperty("id").GetInt64(),
+                    Encoding.UTF8.GetBytes(e.GetProperty("name").GetString() ?? ""),
+                    Encoding.UTF8.GetBytes(e.GetProperty("category").GetString() ?? ""),
+                    e.GetProperty("price").GetInt64(),
+                    e.GetProperty("quantity").GetInt64(),
+                    e.GetProperty("active").GetBoolean(),
+                    tags,
+                    rating.GetProperty("score").GetInt64(),
+                    rating.GetProperty("count").GetInt64());
+            }
+            return new Dataset(items);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[monoxide] dataset load failed ({path}): {ex.Message}");
+            return Empty;
+        }
+    }
+}

--- a/frameworks/monoxide/Dockerfile
+++ b/frameworks/monoxide/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.5 AS build
+WORKDIR /src
+
+# Monoxide - the ioxide-native HTTP/1.1 framework. Cloned to /src/monoxide, where
+# monoxide-arena.csproj's $(MonoxideSrc) project reference resolves. Monoxide pulls
+# ioxide + Glyph11 + ioxide.file from nuget.org transitively. This entry targets
+# net11.0; the SDK provides the .NET 11 framework (preview).
+RUN git clone --depth 1 https://github.com/MDA2AV/Monoxide.git monoxide
+
+WORKDIR /src/app
+COPY . .
+RUN dotnet publish monoxide-arena.csproj -c Release --no-self-contained -o /app
+
+FROM mcr.microsoft.com/dotnet/runtime:11.0.0-preview.5
+WORKDIR /app
+COPY --from=build /app .
+
+EXPOSE 8080 8081
+ENTRYPOINT ["dotnet", "monoxide-arena.dll"]

--- a/frameworks/monoxide/Program.cs
+++ b/frameworks/monoxide/Program.cs
@@ -1,0 +1,137 @@
+using System.Buffers.Text;
+using System.Runtime.InteropServices;
+
+using Monoxide;
+
+using ioxide;
+
+namespace MonoxideArena;
+
+/// <summary>
+/// Monoxide arena entry — the HttpArena H1 profiles served through the Monoxide framework on the
+/// ioxide engine. Slice 1: baseline / pipelined / json (no external deps). Routing, parsing, and
+/// response framing are the framework's; this file is just the route map + the json/baseline shapes.
+/// </summary>
+internal static class Program
+{
+    private static Dataset _ds = Dataset.Empty;
+
+    private static PosixSignalRegistration? _sigTerm;
+    private static PosixSignalRegistration? _sigInt;
+
+    private static int Main()
+    {
+        // Exit promptly on docker stop / Ctrl-C (closes sockets before the bench's next profile).
+        _sigTerm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, ctx => { ctx.Cancel = true; Environment.Exit(0); });
+        _sigInt  = PosixSignalRegistration.Create(PosixSignal.SIGINT,  ctx => { ctx.Cancel = true; Environment.Exit(0); });
+
+        int reactors = Math.Min(Environment.ProcessorCount, 64);
+        if (int.TryParse(Environment.GetEnvironmentVariable("IOXIDE_REACTORS"), out int r) && r > 0)
+            reactors = r;
+
+        ushort port = 8080;
+        if (ushort.TryParse(Environment.GetEnvironmentVariable("IOXIDE_PORT"), out ushort p) && p > 0)
+            port = p;
+
+        string dsPath = Environment.GetEnvironmentVariable("IOXIDE_DATASET") ?? "/data/dataset.json";
+        _ds = Dataset.Load(dsPath);
+
+        var config = new ServerConfig
+        {
+            Port              = port,
+            ReactorCount      = reactors,
+            Incremental       = false,
+            RecvBufferSize    = 16 * 1024,
+            BufferRingEntries = 256,
+        };
+
+        MonoxideApp app = MonoxideApp.Create(config)
+            .MapGet("/pipeline", static ctx => ctx.Text("ok"u8))
+            .MapGet("/json/{count}", Json)     // path param /json/<count>?m=<mult>; brotli on Accept-Encoding: br
+            .MapPost("/upload", Upload);       // POST body byte count
+
+        string staticRoot = Environment.GetEnvironmentVariable("IOXIDE_STATIC") ?? "/data/static";
+        bool hasStatic = Directory.Exists(staticRoot);
+        if (hasStatic)
+            app.MapStatic("/static", staticRoot);   // ioxide.file-backed, precompressed-aware
+
+        app.MapFallback(Baseline);             // /baseline11, /, and anything else → a + b + body
+
+        Console.WriteLine($"[monoxide] {reactors} reactors on :{port} (dataset={_ds.Count} items, static={(hasStatic ? "on" : "off")})");
+        app.Run();
+
+        return 0;
+    }
+
+    // GET /json/{count}?m={mult} → {"items":[...],"count":N}, total = price*quantity*m.
+    private static void Json(MonoxideContext ctx)
+    {
+        if (!ctx.TryRouteInt(out int count) || count < 1 || count > _ds.Count)
+        {
+            ctx.Status("404 Not Found"u8);
+            return;
+        }
+
+        long m = 1;
+        if (ctx.TryQuery("m"u8, out ReadOnlySpan<byte> mv))
+            Utf8Parser.TryParse(mv, out m, out _);
+
+        ctx.Append("{\"items\":["u8);
+        for (int i = 0; i < count; i++)
+        {
+            if (i > 0) ctx.Append(","u8);
+            ref readonly Item it = ref _ds.Items[i];
+            ctx.Append("{\"id\":"u8);                 ctx.AppendInt(it.Id);
+            ctx.Append(",\"name\":\""u8);             ctx.Append(it.Name);
+            ctx.Append("\",\"category\":\""u8);       ctx.Append(it.Category);
+            ctx.Append("\",\"price\":"u8);            ctx.AppendInt(it.Price);
+            ctx.Append(",\"quantity\":"u8);           ctx.AppendInt(it.Quantity);
+            ctx.Append(it.Active ? ",\"active\":true,\"tags\":["u8 : ",\"active\":false,\"tags\":["u8);
+            for (int t = 0; t < it.Tags.Length; t++)
+            {
+                if (t > 0) ctx.Append(","u8);
+                ctx.Append("\""u8); ctx.Append(it.Tags[t]); ctx.Append("\""u8);
+            }
+            ctx.Append("],\"rating\":{\"score\":"u8); ctx.AppendInt(it.Score);
+            ctx.Append(",\"count\":"u8);              ctx.AppendInt(it.RatingCount);
+            ctx.Append("},\"total\":"u8);             ctx.AppendInt(it.Price * it.Quantity * m);
+            ctx.Append("}"u8);
+        }
+        ctx.Append("],\"count\":"u8); ctx.AppendInt(count);
+        ctx.Append("}"u8);
+
+        if (ctx.AcceptsBrotli) ctx.JsonBrotli();
+        else ctx.Json();
+    }
+
+    // POST /upload → text/plain decimal of the received body byte count (the loop frames the body).
+    private static void Upload(MonoxideContext ctx)
+    {
+        Span<byte> num = stackalloc byte[16];
+        Utf8Formatter.TryFormat(ctx.Body.Length, num, out int n);
+        ctx.Text(num[..n]);
+    }
+
+    // GET/POST /baseline11?a=&b= (and any unmatched path, e.g. POST /) → text/plain decimal a+b+body.
+    private static void Baseline(MonoxideContext ctx)
+    {
+        long a = 0, b = 0;
+        if (ctx.TryQuery("a"u8, out ReadOnlySpan<byte> av)) Utf8Parser.TryParse(av, out a, out _);
+        if (ctx.TryQuery("b"u8, out ReadOnlySpan<byte> bv)) Utf8Parser.TryParse(bv, out b, out _);
+
+        long sum = a + b + ParseLoose(ctx.Body.Span);
+        Span<byte> num = stackalloc byte[24];
+        Utf8Formatter.TryFormat(sum, num, out int n);
+        ctx.Text(num[..n]);
+    }
+
+    // Parse the first run of decimal digits in the body as a long (0 if none).
+    private static long ParseLoose(ReadOnlySpan<byte> body)
+    {
+        int i = 0;
+        while (i < body.Length && (body[i] < (byte)'0' || body[i] > (byte)'9')) i++;
+        long v = 0;
+        while (i < body.Length && body[i] >= (byte)'0' && body[i] <= (byte)'9') { v = v * 10 + (body[i] - (byte)'0'); i++; }
+        return v;
+    }
+}

--- a/frameworks/monoxide/README.md
+++ b/frameworks/monoxide/README.md
@@ -1,0 +1,29 @@
+# monoxide
+
+[Monoxide](https://github.com/MDA2AV/Monoxide) - an ioxide-native HTTP/1.1 web framework. Shared-nothing
+per-reactor: requests are parsed off the io_uring recv rings with [Glyph11](https://github.com/MDA2AV/Glyph11)
+and responses written straight into the write slab - no `Stream`, no `Pipe` - on the published
+[ioxide](https://github.com/MDA2AV/ioxide) 0.0.10 engine.
+
+Routing, parsing, keep-alive, pipelining, chunked bodies, and response framing are the framework's; this
+entry's `Program.cs` is just the route map.
+
+## Profiles
+
+| profile | how |
+|---|---|
+| baseline / pipelined / limited-conn | `a + b + body` sum, text/plain; the framework's Glyph11 parse + keep-alive + pipelining |
+| json | dataset items serialized field-by-field, `total = price*quantity*m` |
+| json-comp | json brotli-encoded per request when the client sends `Accept-Encoding: br` |
+| upload | POST body drained against the framing, byte count returned |
+| static | `ioxide.file` baked snapshots, br > gz > identity negotiation (`Content-Encoding` + `Vary`) |
+
+## Build
+
+The Dockerfile clones Monoxide to `/src/monoxide`. Local build:
+`dotnet build monoxide-arena.csproj -c Release -p:MonoxideSrc=/path/to/Monoxide`.
+
+## Env
+
+- `IOXIDE_REACTORS` (default: processor count), `IOXIDE_PORT` (8080)
+- `IOXIDE_DATASET` (/data/dataset.json), `IOXIDE_STATIC` (/data/static)

--- a/frameworks/monoxide/meta.json
+++ b/frameworks/monoxide/meta.json
@@ -1,0 +1,19 @@
+{
+  "display_name": "monoxide",
+  "language": "C#",
+  "type": "engine",
+  "engine": "io_uring",
+  "description": "Monoxide — an ioxide-native HTTP/1.1 web framework. Shared-nothing per-reactor: requests are parsed off the io_uring recv rings with Glyph11 and responses written straight into the write slab (no Stream, no Pipe), on the published ioxide 0.0.10 engine. Routing, keep-alive, pipelining, chunked bodies, and response framing are the framework's; the arena entry is just the route map. Static rides ioxide.file's baked snapshots with br/gz Accept-Encoding negotiation.",
+  "repo": "https://github.com/MDA2AV/Monoxide",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-comp",
+    "upload",
+    "static"
+  ],
+  "maintainers": []
+}

--- a/frameworks/monoxide/monoxide-arena.csproj
+++ b/frameworks/monoxide/monoxide-arena.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <RootNamespace>MonoxideArena</RootNamespace>
+    <AssemblyName>monoxide-arena</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!-- Monoxide (the framework). The Dockerfile clones it to /src/monoxide, where this project
+         reference resolves; override with -p:MonoxideSrc=/path/to/Monoxide for a local build.
+         Monoxide pulls ioxide + Glyph11 + ioxide.file (static) from nuget.org transitively. -->
+    <MonoxideSrc Condition="'$(MonoxideSrc)' == ''">/src/monoxide</MonoxideSrc>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MonoxideSrc)/Monoxide/Monoxide.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What

Adds the `monoxide` framework entry — **Monoxide**, an ioxide-native HTTP/1.1 web framework.

## Monoxide

Shared-nothing per-reactor: requests are parsed off the io_uring recv rings with [Glyph11](https://github.com/MDA2AV/Glyph11) and responses written straight into the write slab — **no `Stream`, no `Pipe`** — on the published [ioxide](https://github.com/MDA2AV/ioxide) `0.0.10` engine. Routing, keep-alive, pipelining, chunked bodies, and response framing are the framework's; the entry's `Program.cs` is just the route map.

## Profiles

`baseline`, `pipelined`, `limited-conn`, `json`, `json-comp` (brotli on `Accept-Encoding: br`), `upload`, `static` (ioxide.file baked snapshots + br/gz negotiation). All 7 verified locally.

`async-db` / `crud` / `json-tls` are in progress and get added to `meta.json` as they land.

## Build

The Dockerfile clones [MDA2AV/Monoxide](https://github.com/MDA2AV/Monoxide) to `/src/monoxide` (the `MonoxideSrc` ProjectReference pattern, mirroring `genhttp-11-ioxide`).