### PR TITLE
Add araara framework entries

### DIFF
--- a/frameworks/araara-standard/Dockerfile
+++ b/frameworks/araara-standard/Dockerfile
@@ -1,0 +1,47 @@
+# HttpArena standard-mode submission image for araara.
+#
+# This package builds the same benchmark server as the tuned araara entry, but
+# sets HCS_ARENA_MODE=standard so arena/server/arena.ml keeps Hcs.Server defaults
+# where the harness does not require protocol, port, TLS, or upload size fields.
+
+FROM ocaml/opam:debian-12-ocaml-5.4 AS build
+
+ARG HCS_VERSION=0.16.1
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git libpq-dev libgmp-dev zlib1g-dev libzstd-dev libssl-dev pkg-config m4 cmake \
+    && rm -rf /var/lib/apt/lists/*
+USER opam
+WORKDIR /app
+
+# Provides hcs, http-proto, repodb, and repodb-postgresql. Public-readable git.
+RUN opam repo add araara git+https://tangled.org/gdiazlo.tngl.sh/repo && opam update
+
+RUN opam source --dir hcs "hcs.${HCS_VERSION}"
+COPY standard-mode.patch /app/standard-mode.patch
+WORKDIR /app/hcs
+RUN git apply /app/standard-mode.patch
+RUN opam install -y . --deps-only \
+ && opam install -y repodb repodb-postgresql climate yojson \
+ && opam exec -- dune build arena/server/arena.exe
+
+RUN mkdir -p /app/staging/lib \
+ && cp -L _build/default/arena/server/arena.exe /app/staging/server \
+ && ldd _build/default/arena/server/arena.exe \
+      | awk '/=> \//{print $3}' | sort -u \
+      | grep -vE '/(libc|libm|libpthread|libdl|librt|ld-linux)[.-]' \
+      | while read -r lib; do cp -Lv "$lib" /app/staging/lib/ 2>/dev/null || true; done \
+ && ls -1 /app/staging/lib
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /app/staging/lib/ /usr/local/lib/
+COPY --from=build /app/staging/server /usr/local/bin/server
+RUN ldconfig
+
+ENV HCS_ARENA_MODE=standard
+
+EXPOSE 8080 8443 8081 8082
+CMD ["/usr/local/bin/server"]

--- a/frameworks/araara-standard/README.md
+++ b/frameworks/araara-standard/README.md
@@ -8,6 +8,9 @@ with `HCS_ARENA_MODE=standard`. In that mode the server keeps
 `Hcs.Server.default_config` values except for harness-required listener fields
 such as protocol, port, TLS, and the upload profile's accepted body size.
 
+It still uses all detected physical cores, matching the tuned entry and the
+HttpArena benchmark machine.
+
 The Dockerfile applies `standard-mode.patch` to the cloned HCS release before
 building so this behavior is available while the tuned entry can stay pinned to
 the same release.

--- a/frameworks/araara-standard/README.md
+++ b/frameworks/araara-standard/README.md
@@ -1,0 +1,15 @@
+# araara-standard
+
+Experimental standard-mode HttpArena entry for araara, an OCaml 5 web stack
+built on HCS and Eio.
+
+This entry builds the same benchmark server as `frameworks/araara`, but runs it
+with `HCS_ARENA_MODE=standard`. In that mode the server keeps
+`Hcs.Server.default_config` values except for harness-required listener fields
+such as protocol, port, TLS, and the upload profile's accepted body size.
+
+The Dockerfile applies `standard-mode.patch` to the cloned HCS release before
+building so this behavior is available while the tuned entry can stay pinned to
+the same release.
+
+Not implemented: HTTP/3 / QUIC, gRPC, gateway-64, and production-stack.

--- a/frameworks/araara-standard/README.md
+++ b/frameworks/araara-standard/README.md
@@ -10,6 +10,7 @@ such as protocol, port, TLS, and the upload profile's accepted body size.
 
 It still uses all detected physical cores, matching the tuned entry and the
 HttpArena benchmark machine.
+`SO_REUSEPORT` remains enabled so each domain can bind the required ports.
 
 The Dockerfile applies `standard-mode.patch` to the cloned HCS release before
 building so this behavior is available while the tuned entry can stay pinned to

--- a/frameworks/araara-standard/meta.json
+++ b/frameworks/araara-standard/meta.json
@@ -1,0 +1,30 @@
+{
+  "display_name": "araara-standard",
+  "language": "OCaml",
+  "engine": "hcs",
+  "type": "experimental",
+  "mode": "standard",
+  "description": "araara - an OCaml 5 web stack built on HCS, using HCS server defaults where possible for the HttpArena harness. Eio, radix-trie routing, Phoenix-style plugs, Postgres via repodb, gzip/zstd compression. HTTP/3 and gRPC are not implemented.",
+  "repo": "https://araara.ml",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-comp",
+    "json-tls",
+    "upload",
+    "static",
+    "async-db",
+    "crud",
+    "api-4",
+    "api-16",
+    "baseline-h2",
+    "static-h2",
+    "baseline-h2c",
+    "json-h2c",
+    "echo-ws"
+  ],
+  "maintainers": ["gdiazlo"]
+}

--- a/frameworks/araara-standard/standard-mode.patch
+++ b/frameworks/araara-standard/standard-mode.patch
@@ -19,16 +19,3 @@ index 19f8884..8c6f61a 100644
        max_connections = 200000;
        reuse_port = true;
        (* Stream large request bodies instead of buffering them whole: /upload
-@@ -911,8 +914,10 @@ let command =
-   let open Climate.Arg_parser in
-   let+ domains =
-     named_with_default [ "d"; "domains"; "cpus" ] int
--      ~default:(physical_core_count ())
--      ~doc:"Number of server domains (default: physical core count)"
-+      ~default:(if is_standard_mode () then 1 else physical_core_count ())
-+      ~doc:
-+        "Number of server domains (default: 1 in standard mode, physical core \
-+         count in tuned mode)"
-   and+ dataset_path =
-     named_with_default [ "dataset" ] string ~default:"/data/dataset.json"
-       ~doc:"Path to dataset.json"

--- a/frameworks/araara-standard/standard-mode.patch
+++ b/frameworks/araara-standard/standard-mode.patch
@@ -11,7 +11,7 @@ index 19f8884..8c6f61a 100644
  let base_config =
 -  Hcs.Server.
 +  let open Hcs.Server in
-+  if is_standard_mode () then default_config
++  if is_standard_mode () then { default_config with reuse_port = true }
 +  else
      {
        default_config with

--- a/frameworks/araara-standard/standard-mode.patch
+++ b/frameworks/araara-standard/standard-mode.patch
@@ -1,0 +1,34 @@
+diff --git a/arena/server/arena.ml b/arena/server/arena.ml
+index 19f8884..8c6f61a 100644
+--- a/arena/server/arena.ml
++++ b/arena/server/arena.ml
+@@ -759,11 +759,14 @@ let gc_tuning () =
+       max_overhead = 1000;
+     }
+ 
++let is_standard_mode () = Sys.getenv_opt "HCS_ARENA_MODE" = Some "standard"
++
+ let base_config =
+-  Hcs.Server.
++  let open Hcs.Server in
++  if is_standard_mode () then default_config
++  else
+     {
+       default_config with
+-      backlog = 4096;
+       max_connections = 200000;
+       reuse_port = true;
+       (* Stream large request bodies instead of buffering them whole: /upload
+@@ -911,8 +914,10 @@ let command =
+   let open Climate.Arg_parser in
+   let+ domains =
+     named_with_default [ "d"; "domains"; "cpus" ] int
+-      ~default:(physical_core_count ())
+-      ~doc:"Number of server domains (default: physical core count)"
++      ~default:(if is_standard_mode () then 1 else physical_core_count ())
++      ~doc:
++        "Number of server domains (default: 1 in standard mode, physical core \
++         count in tuned mode)"
+   and+ dataset_path =
+     named_with_default [ "dataset" ] string ~default:"/data/dataset.json"
+       ~doc:"Path to dataset.json"

--- a/frameworks/araara-standard/standard-mode.patch
+++ b/frameworks/araara-standard/standard-mode.patch
@@ -5,7 +5,7 @@ index 19f8884..8c6f61a 100644
 @@ -759,11 +759,14 @@ let gc_tuning () =
        max_overhead = 1000;
      }
- 
+
 +let is_standard_mode () = Sys.getenv_opt "HCS_ARENA_MODE" = Some "standard"
 +
  let base_config =

--- a/frameworks/araara/Dockerfile
+++ b/frameworks/araara/Dockerfile
@@ -1,0 +1,46 @@
+# HttpArena submission image for araara.
+#
+# HttpArena builds a framework with frameworks/<name>/ as the context. This image
+# adds araara's opam repository, fetches the HCS package source through opam, and
+# builds the benchmark server from that released package source.
+
+FROM ocaml/opam:debian-12-ocaml-5.4 AS build
+
+ARG HCS_VERSION=0.16.1
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git libpq-dev libgmp-dev zlib1g-dev libzstd-dev libssl-dev pkg-config m4 cmake \
+    && rm -rf /var/lib/apt/lists/*
+USER opam
+WORKDIR /app
+
+# Provides hcs, http-proto, repodb, and repodb-postgresql. Public-readable git.
+RUN opam repo add araara git+https://tangled.org/gdiazlo.tngl.sh/repo && opam update
+
+RUN opam source --dir hcs "hcs.${HCS_VERSION}"
+WORKDIR /app/hcs
+RUN opam install -y . --deps-only \
+ && opam install -y repodb repodb-postgresql climate yojson \
+ && opam exec -- dune build arena/server/arena.exe
+
+RUN mkdir -p /app/staging/lib \
+ && cp -L _build/default/arena/server/arena.exe /app/staging/server \
+ && ldd _build/default/arena/server/arena.exe \
+      | awk '/=> \//{print $3}' | sort -u \
+      | grep -vE '/(libc|libm|libpthread|libdl|librt|ld-linux)[.-]' \
+      | while read -r lib; do cp -Lv "$lib" /app/staging/lib/ 2>/dev/null || true; done \
+ && ls -1 /app/staging/lib
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /app/staging/lib/ /usr/local/lib/
+COPY --from=build /app/staging/server /usr/local/bin/server
+RUN ldconfig
+
+ENV EIO_BACKEND=io-uring
+ENV HCS_H2_MAX_STREAMS=64
+
+EXPOSE 8080 8443 8081 8082
+CMD ["/usr/local/bin/server"]

--- a/frameworks/araara/README.md
+++ b/frameworks/araara/README.md
@@ -1,0 +1,20 @@
+# araara
+
+Experimental tuned HttpArena entry for araara, an OCaml 5 web stack built on
+HCS and Eio.
+
+The benchmark server source is `arena/server/arena.ml` in the HCS repository.
+This Dockerfile clones the HCS release selected by `HCS_REF` and builds that
+server, so the framework directory only contains submission metadata and build
+instructions.
+
+Listeners:
+
+| Port | Protocol | Profiles |
+|------|----------|----------|
+| 8080 | HTTP/1.1 + h2c upgrade + WebSocket | baseline, pipelined, limited-conn, json, json-comp, upload, static, async-db, crud, api-*, echo-ws |
+| 8443 | TLS, ALPN `h2,http/1.1` | baseline-h2, static-h2 |
+| 8081 | TLS, ALPN `http/1.1` | json-tls |
+| 8082 | cleartext HTTP/2 prior-knowledge | baseline-h2c, json-h2c |
+
+Not implemented: HTTP/3 / QUIC, gRPC, gateway-64, and production-stack.

--- a/frameworks/araara/meta.json
+++ b/frameworks/araara/meta.json
@@ -1,0 +1,30 @@
+{
+  "display_name": "araara",
+  "language": "OCaml",
+  "engine": "hcs",
+  "type": "experimental",
+  "mode": "tuned",
+  "description": "araara - an OCaml 5 web stack built on HCS, Eio, a zero-copy sans-I/O HTTP codec, radix-trie routing, Phoenix-style plugs, Postgres via repodb, and gzip/zstd compression. HTTP/3 and gRPC are not implemented.",
+  "repo": "https://araara.ml",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-comp",
+    "json-tls",
+    "upload",
+    "static",
+    "async-db",
+    "crud",
+    "api-4",
+    "api-16",
+    "baseline-h2",
+    "static-h2",
+    "baseline-h2c",
+    "json-h2c",
+    "echo-ws"
+  ],
+  "maintainers": ["gdiazlo"]
+}


### PR DESCRIPTION
## Description

Adds two experimental araara framework entries:

- `araara`: tuned mode
- `araara-standard`: standard mode, using HCS server defaults where possible

Both Dockerfiles build from araara's opam repository:

```sh
opam repo add araara git+https://tangled.org/gdiazlo.tngl.sh/repo
opam source --dir hcs hcs.0.16.1
```

The tuned entry sets `EIO_BACKEND=io-uring` and `HCS_H2_MAX_STREAMS=64`. The standard entry applies a small source patch to the released HCS benchmark server so it can run with `HCS_ARENA_MODE=standard` and keep `Hcs.Server.default_config` values where the HttpArena harness does not require listener-specific fields.

Subscribed profiles: baseline, pipelined, limited-conn, json, json-comp, json-tls, upload, static, async-db, crud, api-4, api-16, baseline-h2, static-h2, baseline-h2c, json-h2c, echo-ws.

Not included: HTTP/3, gRPC, gateway-64, production-stack.

Validation performed locally:

- `python3 -m json.tool frameworks/araara/meta.json`
- `python3 -m json.tool frameworks/araara-standard/meta.json`
- `git diff --check origin/main...HEAD`
- `docker build --no-cache -t httparena-araara frameworks/araara`
- `docker build --no-cache -t httparena-araara-standard frameworks/araara-standard`

`VALIDATE_TIMEOUT=1200 ./scripts/validate.sh araara` built the image successfully, then failed before starting araara because this local machine already has services bound to host-network sidecar ports (`5432` and `6379`), preventing HttpArena's Postgres/Redis validation sidecars from becoming ready.

Per the PR template, maintainers can run:

```bash
/benchmark -f araara
/benchmark -f araara-standard
```
