### PR TITLE
perf(phoenix-bandit): speed up crud and benchmark controllers

### DIFF
--- a/frameworks/phoenix-bandit/lib/phoenix_bandit_web/controllers/benchmark_controller.ex
+++ b/frameworks/phoenix-bandit/lib/phoenix_bandit_web/controllers/benchmark_controller.ex
@@ -3,6 +3,8 @@ defmodule PhoenixBanditWeb.BenchmarkController do
 
   @compile {:inline, clamp_int: 3, sum_params: 1}
 
+  @body_length 16_384
+
   def pipeline(conn, _params) do
     conn
     |> put_resp_content_type("text/plain")
@@ -106,7 +108,7 @@ defmodule PhoenixBanditWeb.BenchmarkController do
   end
 
   def upload(conn, _params) do
-    size = read_body_chunks(conn, 0)
+    {size, conn} = read_body_chunks(conn, 0)
 
     conn
     |> put_resp_header("server", "Phoenix")
@@ -173,9 +175,9 @@ defmodule PhoenixBanditWeb.BenchmarkController do
   end
 
   defp read_body_chunks(conn, acc_size) do
-    case read_body(conn) do
-      {:ok, binary, _conn} ->
-        acc_size + byte_size(binary)
+    case read_body(conn, length: @body_length) do
+      {:ok, binary, conn} ->
+        {acc_size + byte_size(binary), conn}
 
       {:more, binary, conn} ->
         read_body_chunks(conn, acc_size + byte_size(binary))

--- a/frameworks/phoenix-bandit/lib/phoenix_bandit_web/controllers/crud_controller.ex
+++ b/frameworks/phoenix-bandit/lib/phoenix_bandit_web/controllers/crud_controller.ex
@@ -21,8 +21,8 @@ defmodule PhoenixBanditWeb.CrudController do
 
   def list(conn, params) do
     category = Map.get(params, "category", "electronics")
-    page = params |> Map.get("page", "1") |> String.to_integer() |> max(1)
-    limit = params |> Map.get("limit", "10") |> String.to_integer() |> max(1) |> min(50)
+    page = params |> Map.get("page", "1") |> String.to_integer()
+    limit = params |> Map.get("limit", "10") |> String.to_integer()
 
     offset = (page - 1) * limit
 
@@ -80,12 +80,20 @@ defmodule PhoenixBanditWeb.CrudController do
            price,
            quantity
          ]) do
-      {:ok, %Postgrex.Result{rows: [row]}} ->
+      {:ok, %Postgrex.Result{num_rows: 1}} ->
         :ets.delete(:items_cache, to_string(id))
+
+        item = %{
+          id: id,
+          name: name,
+          category: category,
+          price: price,
+          quantity: quantity
+        }
 
         conn
         |> put_status(:created)
-        |> json(row_to_item(row))
+        |> json(item)
 
       _error ->
         send_resp(conn, 500, "")
@@ -104,10 +112,17 @@ defmodule PhoenixBanditWeb.CrudController do
            quantity,
            item_id
          ]) do
-      {:ok, %Postgrex.Result{rows: [row]}} ->
+      {:ok, %Postgrex.Result{num_rows: 1}} ->
         :ets.delete(:items_cache, id)
 
-        json(conn, row_to_item(row))
+        item = %{
+          id: item_id,
+          name: name,
+          price: price,
+          quantity: quantity
+        }
+
+        json(conn, item)
 
       {:ok, %Postgrex.Result{num_rows: 0}} ->
         send_resp(conn, 404, "")


### PR DESCRIPTION
## Description

Optimize the `POST /upload` endpoint, and for `POST /crud/items` and `PUT /crud/items/{id}`, return only the data described in the guide.

---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
