### PR TITLE
Add C++/IRIS engine (iris-ha-gw)

### DIFF
--- a/frameworks/iris/Dockerfile
+++ b/frameworks/iris/Dockerfile
@@ -1,0 +1,32 @@
+# =============================================================================
+# HTTPArena image: IRIS gateway (baseline, pipelined, json, static).
+# Source is pulled from the public IRIS repository (AGPL-3.0) at a pinned ref.
+# =============================================================================
+FROM ubuntu:24.04 AS build
+
+ARG IRIS_REPO=https://github.com/Cobra007-star-source/IRIS.git
+ARG IRIS_REF=v0.3.0-ha
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        g++ cmake make git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${IRIS_REF}" "${IRIS_REPO}" .
+
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release \
+        -DIRIS_BUILD_GATEWAY=ON -DIRIS_PROFILE=racing -DIRIS_BUILD_DB=OFF \
+        -DIRIS_BUILD_EXAMPLES=OFF -DIRIS_BUILD_BENCHMARKS=OFF \
+        -DIRIS_BUILD_TESTS=OFF -DIRIS_BUILD_SIMDJSON=OFF -DIRIS_BUILD_BOWTIE=OFF \
+ && cmake --build build --target iris-ha-gw -j "$(nproc)"
+
+FROM ubuntu:24.04
+COPY --from=build /src/build/gateway/iris-ha-gw /iris-ha-gw
+
+ENV PORT=8080
+ENV DATASET_PATH=/data/dataset.json
+ENV STATIC_DIR=/data/static
+
+EXPOSE 8080
+ENTRYPOINT ["/iris-ha-gw", "--port", "8080"]

--- a/frameworks/iris/meta.json
+++ b/frameworks/iris/meta.json
@@ -1,0 +1,17 @@
+{
+  "display_name": "iris",
+  "language": "C++",
+  "type": "engine",
+  "engine": "epoll",
+  "description": "Thread-per-core C++ HTTP/1.1 gateway on epoll/SO_REUSEPORT with a hand-written incremental parser. Zero-allocation steady state: fixed per-connection buffers, precomputed response templates, per-request JSON serialization from the mounted dataset, and static assets served via precompressed .br/.gz negotiation with Linux sendfile from sealed memfd responses.",
+  "repo": "https://github.com/Cobra007-star-source/IRIS",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "static"
+  ],
+  "maintainers": ["Cobra007-star-source"]
+}

--- a/site/data/baseline-4096.json
+++ b/site/data/baseline-4096.json
@@ -752,6 +752,26 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 4050752,
+    "avg_latency": "1.01ms",
+    "p99_latency": "2.29ms",
+    "cpu": "6021.5%",
+    "memory": "144MiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "451.73MB/s",
+    "input_bw": "312.91MB/s",
+    "reconnects": 0,
+    "status_2xx": 20253763,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 822062,

--- a/site/data/baseline-512.json
+++ b/site/data/baseline-512.json
@@ -752,6 +752,26 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 3591519,
+    "avg_latency": "142us",
+    "p99_latency": "411us",
+    "cpu": "5022.9%",
+    "memory": "87MiB",
+    "connections": 512,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "400.57MB/s",
+    "input_bw": "277.44MB/s",
+    "reconnects": 0,
+    "status_2xx": 17957595,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 817316,

--- a/site/data/frameworks.json
+++ b/site/data/frameworks.json
@@ -423,6 +423,13 @@
     "type": "engine",
     "engine": "io_uring"
   },
+  "iris": {
+    "dir": "iris",
+    "description": "Thread-per-core C++ HTTP/1.1 gateway on epoll/SO_REUSEPORT with a hand-written incremental parser. Zero-allocation steady state: fixed per-connection buffers, precomputed response templates, per-request JSON serialization from the mounted dataset, and static assets served via precompressed .br/.gz negotiation with Linux sendfile from sealed memfd responses.",
+    "repo": "https://github.com/Cobra007-star-source/IRIS",
+    "type": "engine",
+    "engine": "epoll"
+  },
   "ktor-ghost": {
     "dir": "ktor-ghost",
     "description": "JetBrains Ktor 3.x on Netty with Kotlin coroutines, Ghost Serializer, JDK 21.",

--- a/site/data/json-4096.json
+++ b/site/data/json-4096.json
@@ -678,6 +678,26 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 1916387,
+    "avg_latency": "1.14ms",
+    "p99_latency": "8.19ms",
+    "cpu": "4675.9%",
+    "memory": "411MiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "9.98GB/s",
+    "input_bw": "91.38MB/s",
+    "reconnects": 381797,
+    "status_2xx": 9581935,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 395250,

--- a/site/data/limited-conn-4096.json
+++ b/site/data/limited-conn-4096.json
@@ -752,6 +752,26 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 2858197,
+    "avg_latency": "1.31ms",
+    "p99_latency": "2.01ms",
+    "cpu": "5756.3%",
+    "memory": "202MiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "318.80MB/s",
+    "input_bw": "220.79MB/s",
+    "reconnects": 1428683,
+    "status_2xx": 14290985,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 665691,

--- a/site/data/limited-conn-512.json
+++ b/site/data/limited-conn-512.json
@@ -752,6 +752,26 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 2573975,
+    "avg_latency": "182us",
+    "p99_latency": "603us",
+    "cpu": "5280.5%",
+    "memory": "99MiB",
+    "connections": 512,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "287.11MB/s",
+    "input_bw": "198.83MB/s",
+    "reconnects": 1286978,
+    "status_2xx": 12869875,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 656997,

--- a/site/data/pipelined-4096.json
+++ b/site/data/pipelined-4096.json
@@ -734,6 +734,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 37675193,
+    "avg_latency": "1.74ms",
+    "p99_latency": "3.39ms",
+    "cpu": "6527.0%",
+    "memory": "160MiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 16,
+    "bandwidth": "4.10GB/s",
+    "reconnects": 0,
+    "status_2xx": 188375967,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 584867,

--- a/site/data/pipelined-512.json
+++ b/site/data/pipelined-512.json
@@ -734,6 +734,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 37253529,
+    "avg_latency": "219us",
+    "p99_latency": "586us",
+    "cpu": "6220.1%",
+    "memory": "86MiB",
+    "connections": 512,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 16,
+    "bandwidth": "4.06GB/s",
+    "reconnects": 0,
+    "status_2xx": 186267648,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 619926,

--- a/site/data/static-1024.json
+++ b/site/data/static-1024.json
@@ -647,6 +647,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 1772261,
+    "avg_latency": "517.63us",
+    "p99_latency": "5.86ms",
+    "cpu": "3973.7%",
+    "memory": "93MiB",
+    "connections": 1024,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "27.05GB",
+    "reconnects": 0,
+    "status_2xx": 9038024,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 284595,

--- a/site/data/static-4096.json
+++ b/site/data/static-4096.json
@@ -647,6 +647,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 1925804,
+    "avg_latency": "1.65ms",
+    "p99_latency": "11.83ms",
+    "cpu": "4331.6%",
+    "memory": "182MiB",
+    "connections": 4096,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "29.39GB",
+    "reconnects": 0,
+    "status_2xx": 9820175,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 282154,

--- a/site/data/static-6800.json
+++ b/site/data/static-6800.json
@@ -647,6 +647,25 @@
     "status_5xx": 0
   },
   {
+    "framework": "iris",
+    "language": "C++",
+    "rps": 1953922,
+    "avg_latency": "2.61ms",
+    "p99_latency": "18.34ms",
+    "cpu": "4517.4%",
+    "memory": "255MiB",
+    "connections": 6800,
+    "threads": 64,
+    "duration": "5s",
+    "pipeline": 1,
+    "bandwidth": "29.82GB",
+    "reconnects": 0,
+    "status_2xx": 9966697,
+    "status_3xx": 0,
+    "status_4xx": 0,
+    "status_5xx": 0
+  },
+  {
     "framework": "ktor",
     "language": "Kotlin",
     "rps": 273800,

--- a/site/static/logs/baseline/4096/iris.log
+++ b/site/static/logs/baseline/4096/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/baseline/512/iris.log
+++ b/site/static/logs/baseline/512/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/json/4096/iris.log
+++ b/site/static/logs/json/4096/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/limited-conn/4096/iris.log
+++ b/site/static/logs/limited-conn/4096/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/limited-conn/512/iris.log
+++ b/site/static/logs/limited-conn/512/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/pipelined/4096/iris.log
+++ b/site/static/logs/pipelined/4096/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/pipelined/512/iris.log
+++ b/site/static/logs/pipelined/512/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/static/1024/iris.log
+++ b/site/static/logs/static/1024/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/static/4096/iris.log
+++ b/site/static/logs/static/4096/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)

--- a/site/static/logs/static/6800/iris.log
+++ b/site/static/logs/static/6800/iris.log
@@ -1,0 +1,2 @@
+[iris-ha-gw] listening on :8080 dataset=/data/dataset.json(50 items) static=/data/static(ok)
+[iris-gw] reuseport CBPF: cpu-affine steering (128)


### PR DESCRIPTION
## Summary

Adds **IRIS** ([Cobra007-star-source/IRIS](https://github.com/Cobra007-star-source/IRIS), AGPL-3.0) as a C++ `engine` framework:

- `frameworks/iris` — `baseline`, `pipelined`, `limited-conn`, `json`, `static`
- Docker image clones IRIS at `v0.3.0-ha` and builds `iris-ha-gw` (Release, racing profile, no DB)

## Design notes

- Thread-per-core epoll/SO_REUSEPORT gateway with fixed per-connection buffers
- `/json/{count}?m=` serializes from the mounted dataset per request
- `/static/*` serves precompressed `.br`/`.gz` variants with Linux sendfile from sealed memfd responses

## Test plan

- [ ] CI builds `frameworks/iris` Docker image
- [ ] `/validate -f iris` passes on the self-hosted runner

Made with [Cursor](https://cursor.com)