### PR TITLE
chore: bump all V frameworks to latest V (80e76cdad) — measure evolution

### DIFF
--- a/frameworks/fasthttp/Dockerfile
+++ b/frameworks/fasthttp/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get -qq update && \
         ca-certificates git build-essential libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit cd213a17c (built from source). No release
+# Pinned, reproducible V at master commit 80e76cdad (built from source). No release
 # tag carries the modern stdlib this framework needs: the pooled Go-style `db.pg`
 # (vlang/v#27265) and the single-element-array-push codegen fix (vlang/v#27470, which
 # is why 0.5.1 was previously pinned). This commit also carries the Boehm GC
@@ -14,7 +14,7 @@ RUN apt-get -qq update && \
 # bootstraps via the matching vc; if a much later rebuild ever fails to bootstrap,
 # pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout cd213a17c && \
+    cd /opt/v && git checkout 80e76cdad && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 WORKDIR /app

--- a/frameworks/pico/Dockerfile
+++ b/frameworks/pico/Dockerfile
@@ -5,11 +5,11 @@ RUN apt-get -qq update && \
         ca-certificates git build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit 6c4d26f1f (built from source), keeping the
+# Pinned, reproducible V at master commit 80e76cdad (built from source), keeping the
 # V frameworks on one toolchain. `make` bootstraps via the matching vc; if a much
 # later rebuild ever fails to bootstrap, pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout 6c4d26f1f && \
+    cd /opt/v && git checkout 80e76cdad && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 WORKDIR /app

--- a/frameworks/vanilla-epoll/Dockerfile
+++ b/frameworks/vanilla-epoll/Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get -qq update && \
         ca-certificates build-essential git libpq-dev liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit c0624b274 (built from source). Moved off
+# Pinned, reproducible V at master commit 80e76cdad (built from source). Moved off
 # the 0.5.1 tag: the codegen regression that forced the pin (single-element array
 # push 4-7x slower, vlang/v#27468) is fixed (vlang/v#27470), and the vanilla library
 # now uses `ArrayFlags.managed` (the buf_view non-marking window) which only exists
 # on post-0.5.1 V. `make` bootstraps via the matching vc; if a much later rebuild
 # ever fails to bootstrap, pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout c0624b274 && \
+    cd /opt/v && git checkout 80e76cdad && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 # Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server),

--- a/frameworks/vanilla-io_uring/Dockerfile
+++ b/frameworks/vanilla-io_uring/Dockerfile
@@ -5,16 +5,16 @@ RUN apt-get -qq update && \
         ca-certificates build-essential git libpq-dev liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit cd213a17c (built from source). Master is
+# Pinned, reproducible V at master commit 80e76cdad (built from source). Master is
 # now preferred over the 0.5.1 tag: the codegen regression that forced 0.5.1 (single-
 # element array push 4-7x slower, vlang/v#27468) is fixed (vlang/v#27470), and the
-# code uses the modern pooled Go-style db.pg (vlang/v#27265). cd213a17c also carries
+# code uses the modern pooled Go-style db.pg (vlang/v#27265). 80e76cdad also carries
 # the Boehm GC free-space-divisor fix (vlang/v#27560, fixes vlang/v#27555) that
 # recovers the default-GC throughput regression seen in the c0624b2..6c4d26f range.
 # For a current master commit, `make` bootstraps via the matching vc; if a much later
 # rebuild ever fails to bootstrap, pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout cd213a17c && \
+    cd /opt/v && git checkout 80e76cdad && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 # Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server),

--- a/frameworks/veb/Dockerfile
+++ b/frameworks/veb/Dockerfile
@@ -5,15 +5,15 @@ RUN apt-get -qq update && \
         ca-certificates git build-essential libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit cd213a17c (built from source). No release
+# Pinned, reproducible V at master commit 80e76cdad (built from source). No release
 # tag carries the modern stdlib this framework needs: the pooled Go-style `db.pg`
-# (vlang/v#27265). cd213a17c also carries the Boehm GC free-space-divisor fix
+# (vlang/v#27265). 80e76cdad also carries the Boehm GC free-space-divisor fix
 # (vlang/v#27560, fixes vlang/v#27555) that recovers the default-GC throughput
 # regression seen in the c0624b2..6c4d26f range. `make` bootstraps via the matching
 # vc; if a much later rebuild ever fails to bootstrap, pin vlang/vc to the commit
 # cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout cd213a17c && \
+    cd /opt/v && git checkout 80e76cdad && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 WORKDIR /app


### PR DESCRIPTION
Bumps all five V frameworks (`fasthttp`, `pico`, `veb`, `vanilla-epoll`, `vanilla-io_uring`) to **V master `80e76cdad`** (2026-06-27), up from the current mixed pins (`cd213a17c` / `6c4d26f1f` / `c0624b274`), to measure evolution from the latest toolchain.

The most benchmark-relevant change in `6c4d26f1f..80e76cdad` is **cgen: lower the Boehm GC free-space divisor to 1 for the opt modes** (vlang/v#27560), which reduces collection frequency for the default-GC frameworks (fasthttp/pico/veb/vanilla-io_uring); `vanilla-epoll` is `-gc none` so it's a control. All five build-verified locally with V `80e76cdad`.

Benchmarks triggered per framework in the comments (no `--save`).
