### PR TITLE
chore(vanilla-epoll): bump V toolchain to latest master (80e76cdad)

### DIFF
--- a/frameworks/vanilla-epoll/Dockerfile
+++ b/frameworks/vanilla-epoll/Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get -qq update && \
         ca-certificates build-essential git libpq-dev liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit c0624b274 (built from source). Moved off
+# Pinned, reproducible V at master commit 80e76cdad (built from source). Moved off
 # the 0.5.1 tag: the codegen regression that forced the pin (single-element array
 # push 4-7x slower, vlang/v#27468) is fixed (vlang/v#27470), and the vanilla library
 # now uses `ArrayFlags.managed` (the buf_view non-marking window) which only exists
 # on post-0.5.1 V. `make` bootstraps via the matching vc; if a much later rebuild
 # ever fails to bootstrap, pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout c0624b274 && \
+    cd /opt/v && git checkout 80e76cdad && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 # Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server),


### PR DESCRIPTION
## Bump V toolchain: `c0624b274` → `80e76cdad` (latest master, 2026-06-27)

**Framework:** `vanilla-epoll` — the `vanilla` library's epoll backend, built **`-gc none`** (no garbage collector; hot paths are zero-alloc). Pins only the V compiler. The vanilla library pin (`1822cbb`) is **unchanged**.

### V changes in the bump range `c0624b274..80e76cdad`
This is the largest jump of the set (`c0624b274` is 2026-06-20). Because vanilla-epoll runs **`-gc none`**, every GC-related change in the range is **irrelevant** to it:
- the Boehm free-space-divisor tuning (#27560), thread-local allocation (#27544 / #27488), and the TLA opt-out (#27572) — all no-ops under `-gc none`.

What *can* affect it is pure **codegen** in the range: aux type-symbol hash stabilization (#27570), the interface type-table index fix under `-usecache` (#27381), and assorted `cgen` correctness fixes (sumtype/generics). The `v3` backend work does not apply (`-prod` uses the C backend).

### Expected effect
Mostly **flat** — vanilla-epoll's hot paths are already zero-alloc and `-gc none` insulates it from the GC churn other frameworks see. The value here is confirming the **latest V still compiles and runs the `-gc none` zero-alloc paths correctly** across a 1-week codegen jump (no codegen regression).

### Verification
Build-verified locally with V `80e76cdad`: `v -prod -gc none .` → OK.

`/benchmark -f vanilla-epoll` triggered below (no `--save`).
