### PR TITLE
bump vanilla + V pins to latest (vanilla f64f4b88, V 02015a7c)

### DIFF
--- a/frameworks/vanilla-epoll/Dockerfile
+++ b/frameworks/vanilla-epoll/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone https://github.com/vlang/v /opt/v && \
 # (or rate-limit) failed the whole build (MDA2AV/HttpArena#895). To pick up upstream
 # library fixes, bump this commit.
 RUN git clone https://github.com/enghitalo/vanilla /root/.vmodules/vanilla && \
-    git -C /root/.vmodules/vanilla checkout a7f22dab29f012b44d36b1e1cae6bda82166ad30
+    git -C /root/.vmodules/vanilla checkout 1822cbb4b5316f433df4805bb68560fadd4df385
 
 WORKDIR /app
 COPY . .

--- a/frameworks/vanilla-epoll/Dockerfile
+++ b/frameworks/vanilla-epoll/Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get -qq update && \
         ca-certificates build-essential git libpq-dev liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit c0624b274 (built from source). Moved off
+# Pinned, reproducible V at master commit 02015a7c (built from source). Moved off
 # the 0.5.1 tag: the codegen regression that forced the pin (single-element array
 # push 4-7x slower, vlang/v#27468) is fixed (vlang/v#27470), and the vanilla library
 # now uses `ArrayFlags.managed` (the buf_view non-marking window) which only exists
 # on post-0.5.1 V. `make` bootstraps via the matching vc; if a much later rebuild
 # ever fails to bootstrap, pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout c0624b274 && \
+    cd /opt/v && git checkout 02015a7ce111e4d0cfd5b5d78711ad0db7586936 && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 # Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server),
@@ -22,7 +22,7 @@ RUN git clone https://github.com/vlang/v /opt/v && \
 # (or rate-limit) failed the whole build (MDA2AV/HttpArena#895). To pick up upstream
 # library fixes, bump this commit.
 RUN git clone https://github.com/enghitalo/vanilla /root/.vmodules/vanilla && \
-    git -C /root/.vmodules/vanilla checkout 1822cbb4b5316f433df4805bb68560fadd4df385
+    git -C /root/.vmodules/vanilla checkout f64f4b88bb71888b8e84f47de4059a5a36067493
 
 WORKDIR /app
 COPY . .

--- a/frameworks/vanilla-io_uring/Dockerfile
+++ b/frameworks/vanilla-io_uring/Dockerfile
@@ -5,14 +5,14 @@ RUN apt-get -qq update && \
         ca-certificates build-essential git libpq-dev liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Pinned, reproducible V at master commit c0624b274 (built from source). Master is
+# Pinned, reproducible V at master commit 02015a7c (built from source). Master is
 # now preferred over the 0.5.1 tag: the codegen regression that forced 0.5.1 (single-
 # element array push 4-7x slower, vlang/v#27468) is fixed (vlang/v#27470), and the
 # code uses the modern pooled Go-style db.pg (vlang/v#27265). For a current master
 # commit, `make` bootstraps via the matching vc; if a much later rebuild ever fails
 # to bootstrap, pin vlang/vc to the commit cut for this V.
 RUN git clone https://github.com/vlang/v /opt/v && \
-    cd /opt/v && git checkout c0624b274 && \
+    cd /opt/v && git checkout 02015a7ce111e4d0cfd5b5d78711ad0db7586936 && \
     make && ln -s /opt/v/v /usr/local/bin/v
 
 # Install the vanilla HTTP server as the `vanilla` module (import vanilla.http_server),
@@ -21,7 +21,7 @@ RUN git clone https://github.com/vlang/v /opt/v && \
 # main moved, but that hit api.github.com every build and a transient 504/rate-limit
 # failed the whole build (MDA2AV/HttpArena#895). Bump this commit to pick up lib fixes.
 RUN git clone https://github.com/enghitalo/vanilla /root/.vmodules/vanilla && \
-    git -C /root/.vmodules/vanilla checkout a7f22dab29f012b44d36b1e1cae6bda82166ad30
+    git -C /root/.vmodules/vanilla checkout f64f4b88bb71888b8e84f47de4059a5a36067493
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Bumps the `vanilla-epoll` and `vanilla-io_uring` pins to the latest upstream:

- **vanilla** → `f64f4b88` (enghitalo/vanilla main): io_uring per-connection buffer
  reuse, `buf_view` framing on io_uring, the no-Result request-framing twin, the
  docs refresh, and the new CI bench harness.
- **V** → `02015a7c` (vlang/v master): thread-local allocation (the default Boehm
  GC now scales across cores) plus the upstream fixes vanilla filed (empty-array
  alloc, `error_sentinel`, `strconv.write_dec`, slice `.noslices`, cgen).

### Verification (local, this bump)
Both images build cleanly (V `make` bootstrap from `02015a7c` + compile of vanilla
`f64f4b88`) and serve every profile. Full `benchmark-lite` run, both backends,
512c, best-of-3 — **0 5xx across all profiles**:

| profile | vanilla-epoll | vanilla-io_uring |
|---|--:|--:|
| baseline | 601K | 558K |
| pipelined | 7.41M | 6.45M |
| limited-conn | 384K | 369K |
| json | 206K | 214K |
| json-comp | 401K | 374K |
| static | 159K | 69K |
| async-db | 41K | 19K |

> Local laptop numbers (loopback/generator-bound) — for a "builds + serves + no
> 5xx" sanity check, **not** leaderboard figures. The authoritative numbers come
> from the arena CI run this PR triggers. io_uring trailing on `static`/`async-db`
> is pre-existing (the io_uring static high-conn cliff + the io_uring DB ceiling),
> not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
