### PR TITLE
perf(vanilla-epoll): zero-copy key for static asset lookup (fixes -gc none leak)

### DIFF
--- a/frameworks/vanilla-epoll/main.v
+++ b/frameworks/vanilla-epoll/main.v
@@ -354,7 +354,12 @@ fn handle(req_buffer []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
 	} else if route == '/fortunes' {
 		return w.start_fortunes(mut out, mut ac)
 	} else if route.starts_with('/static/') {
-		if f := w.ro.assets[route[8..]] {
+		// Zero-copy lookup key: a view into the request buffer. The map only hashes the
+		// key bytes and never retains it, so the view is safe. `route[8..]` would be a
+		// substr -> a fresh heap string every request, which `-gc none` never frees
+		// (+625 MiB over 20M requests, proven in isolation). Mirrors the vanilla lib's
+		// own static_assets module (http_server/static_assets/static_assets.v).
+		if f := w.ro.assets[unsafe { tos(route.str + 8, route.len - 8) }] {
 			wb(mut out, f.header)
 			core.queue_file(f.fd, 0, f.size)
 		} else {


### PR DESCRIPTION
## What

The `vanilla-epoll` static handler builds its asset-map lookup key with `route[8..]`:

```v
if f := w.ro.assets[route[8..]] {
```

In V, `route[8..]` is `string.substr` → `malloc_noscan(len+1)` + memcpy: a fresh heap string on **every** request. The `vanilla-epoll` image is built `-gc none` (see `frameworks/vanilla-epoll/Dockerfile`), so nothing ever frees it — an unbounded leak on the static hot path.

This replaces it with a non-owning view, `tos(route.str + 8, route.len - 8)`. A V map lookup only hashes the key's bytes and never retains the key, so the view is safe. It mirrors the vanilla library's own `static_assets` module, which already uses a zero-copy `tos()` key (`http_server/static_assets/static_assets.v`).

## Why now / impact

On the `static` profile, `vanilla-epoll` RSS balloons with connection count (262 → 426 → 912 MiB at 1024 → 4096 → 6800 conns) while iris/zix stay flat (~140–280 MiB). This leak is the cause.

Proven in isolation — identical `map[string]int` + 20,000,000 lookups, `v -prod -gc none`, RSS read from `/proc/self/status`, only the key construction differing:

| key | RSS |
| --- | --- |
| `route[8..]` (substr) | **+625 MiB**, monotonic (~31 B/request) |
| `tos(route.str+8, len-8)` (view) | **+28 KiB**, flat |

Compiles clean with the Dockerfile flags (`v -prod -gc none`). One-line change.

> Note: `frameworks/vanilla-io_uring/main.v` has the same line, but that image ships the default Boehm GC (not `-gc none`), so the substr is collected there — no leak, only minor per-request GC churn. A separate per-framework PR can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)