### PR TITLE
fix(vanilla-epoll/io_uring): lazy json-comp gz cache — drop ~135 MiB -gc none boot leak

### DIFF
--- a/frameworks/vanilla-epoll/main.v
+++ b/frameworks/vanilla-epoll/main.v
@@ -69,7 +69,8 @@ mut:
 	// (~25 MiB, lazily allocated).
 	crud    []CrudSlot
 	crud_mu &sync.RwMutex = unsafe { nil }
-	gz      map[u64][]u8 // json-comp: precomputed at boot, READ-ONLY during serving (lock-free reads)
+	gz      map[u64][]u8 // json-comp: (count<<32)|m -> gzipped response bytes
+	gz_mu   &sync.RwMutex = unsafe { nil }
 }
 
 // CrudSlot is one entry of the id-indexed crud cache slab. `buf` is the rendered
@@ -870,62 +871,67 @@ fn (w &WorkerCtx) write_json_response(mut out []u8, count int, m i64) {
 	write_json_into(w.ro, mut out, count, m)
 }
 
-// gz_response_ep builds the COMPLETE gzipped /json response for (count, m). Pure
-// function of the shared dataset; precomputed once at boot (see main) and also the
-// cold path for an unexpected param.
-fn gz_response_ep(ro &SharedRO, count int, m i64) []u8 {
-	body := ro.json_body(count, m)
-	gz := gzip.compress(body.bytes()) or { return []u8{} }
+// write_json_gzip is the json-comp path: a LAZY, process-shared, RwMutex-guarded
+// cache of complete gzipped responses keyed by (count<<32)|m. Compress once on the
+// first miss, then append the cached bytes on every hit (the profile is
+// compression-bound).
+//
+// Do NOT precompute the full (count x m) grid at boot. This binary is `-gc none`,
+// and V's gzip.compress leaks ~157 KiB of scratch per call (vlang/v#27606), so
+// precomputing the ~800-key grid leaked ~135 MiB of permanent RSS at startup
+// (measured 77 -> 213 MiB). Lazy compresses only the ~8 (count,m) pairs the profile
+// actually sends (~1.3 MiB). The shared rlock is NOT a bottleneck: epoll is healthy
+// at 16384 conns with it; the io_uring json-comp@16384 collapse is worker/thread
+// oversubscription from the co-hosted json-tls listener, not this lock
+// (enghitalo/vanilla#89).
+fn (mut w WorkerCtx) write_json_gzip(mut out []u8, count int, m i64) {
+	key := (u64(u32(count)) << 32) | u64(u32(m))
+	mut cached := []u8{}
+	w.ro.gz_mu.@rlock()
+	if c := w.ro.gz[key] {
+		unsafe {
+			cached = c
+		}
+	}
+	w.ro.gz_mu.runlock()
+	if cached.len > 0 {
+		wb(mut out, cached)
+		return
+	}
+	body := w.json_body(count, m)
+	gz := gzip.compress(body.bytes()) or {
+		write_resp(mut out, 'application/json', body)
+		return
+	}
 	mut resp := []u8{cap: gz.len + 128}
 	ws(mut resp,
 		'HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Encoding: gzip\r\nContent-Type: application/json\r\nContent-Length: ')
 	wi(mut resp, i64(gz.len))
 	ws(mut resp, '\r\nConnection: keep-alive\r\n\r\n')
 	unsafe { resp.push_many(gz.data, gz.len) }
-	return resp
+	w.ro.gz_mu.@lock()
+	if w.ro.gz.len < 1024 {
+		w.ro.gz[key] = resp
+	}
+	w.ro.gz_mu.unlock()
+	wb(mut out, resp)
 }
 
-// write_json_gzip is the json-comp path. The cache is fully precomputed at boot and
-// READ-ONLY during serving, so the hot path is a LOCK-FREE map read — no per-request
-// shared RwMutex (which contended across workers under the co-hosted json-tls
-// server's extra threads and collapsed io_uring json-comp @16384; enghitalo/vanilla#89).
-fn (w &WorkerCtx) write_json_gzip(mut out []u8, count int, m i64) {
-	key := (u64(u32(count)) << 32) | u64(u32(m))
-	if cached := w.ro.gz[key] {
-		wb(mut out, cached)
-		return
-	}
-	// Param outside the precomputed grid (not sent by the benchmark): build + send
-	// without caching, so the hot path stays write-free and lock-free.
-	resp := gz_response_ep(w.ro, count, m)
-	if resp.len > 0 {
-		wb(mut out, resp)
-	} else {
-		write_resp(mut out, 'application/json', w.ro.json_body(count, m))
-	}
-}
-
-// json_body builds the /json body for (count, m). Defined on &SharedRO so it can
-// run at boot (gz precompute) without a WorkerCtx; WorkerCtx.json_body delegates.
-fn (ro &SharedRO) json_body(count int, m i64) string {
+fn (w &WorkerCtx) json_body(count int, m i64) string {
 	mut sb := strings.new_builder(count * 224 + 32)
 	sb.write_string('{"items":[')
 	for i in 0 .. count {
 		if i > 0 {
 			sb.write_u8(`,`)
 		}
-		sb.write_string(ro.prefixes[i])
-		sb.write_decimal(ro.dataset[i].price * ro.dataset[i].quantity * m)
+		sb.write_string(w.ro.prefixes[i])
+		sb.write_decimal(w.ro.dataset[i].price * w.ro.dataset[i].quantity * m)
 		sb.write_u8(`}`)
 	}
 	sb.write_string('],"count":')
 	sb.write_decimal(i64(count))
 	sb.write_u8(`}`)
 	return sb.str()
-}
-
-fn (w &WorkerCtx) json_body(count int, m i64) string {
-	return w.ro.json_body(count, m)
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -1341,27 +1347,14 @@ fn main() {
 		sendfile_min_bytes: 16 * 1024
 	}) or { panic('vanilla-epoll: static_assets init failed: ${err}') }
 
-	mut ro := &SharedRO{
+	ro := &SharedRO{
 		dataset:  dataset
 		prefixes: prefixes
 		asv:      asv
 		crud:     []CrudSlot{len: crud_cache_slots}
 		crud_mu:  sync.new_rwmutex()
 		gz:       map[u64][]u8{}
-	}
-
-	// Precompute json-comp gzip responses at boot so write_json_gzip reads the cache
-	// LOCK-FREE during serving (no per-request shared RwMutex — that contended across
-	// workers and, with the co-hosted json-tls server's threads, collapsed io_uring
-	// json-comp @16384; enghitalo/vanilla#89). Bounded grid covering count<=50 / m<=8.
-	gz_cap_count := if dataset.len < 64 { dataset.len } else { 64 }
-	for c in 1 .. gz_cap_count + 1 {
-		for mm in 1 .. 17 {
-			r := gz_response_ep(ro, c, i64(mm))
-			if r.len > 0 {
-				ro.gz[(u64(u32(c)) << 32) | u64(u32(mm))] = r
-			}
-		}
+		gz_mu:    sync.new_rwmutex()
 	}
 
 	// ── json-tls profile: the same /json handler over HTTPS on :8081 ───────────

--- a/frameworks/vanilla-io_uring/main.v
+++ b/frameworks/vanilla-io_uring/main.v
@@ -60,7 +60,8 @@ mut:
 	// json-comp cache: the gzipped response for a given (count, m) is fully
 	// deterministic and gzip dominates the cost, so compress once and reuse.
 	// Key = (count << 32) | m. The benchmark hits only a few pairs, so it's tiny.
-	gz_cache map[u64][]u8 // json-comp: precomputed at boot, READ-ONLY during serving (lock-free reads)
+	gz_cache map[u64][]u8
+	gz_mu    &sync.RwMutex = unsafe { nil }
 }
 
 struct CrudCreate {
@@ -385,39 +386,45 @@ fn (sh &Shared) write_json_response(mut out []u8, count int, m i64) {
 	ws(mut out, '}')
 }
 
-// gz_response builds the COMPLETE gzipped /json response for (count, m). Pure
-// function of the shared dataset (deterministic), so it is precomputed once at
-// boot (see main) and also serves the cold path for an unexpected param.
-fn gz_response(sh &Shared, count int, m i64) []u8 {
+// write_json_gzip is the json-comp path. The gzipped response for a given
+// (count, m) is fully deterministic and gzip CPU dominates the cost, so we cache
+// the COMPLETE response bytes and just append the cached copy on a hit — no
+// rebuild, no recompress. Compressing once instead of per-request is the whole
+// win for json-comp (the profile is compression-bound, not allocation-bound).
+//
+// Kept LAZY, not precomputed at boot: precomputing the full (count x m) grid would
+// compress ~800 keys vs the ~8 the profile sends. On the `-gc none` epoll sibling
+// that leaked ~135 MiB via gzip.compress scratch (vlang/v#27606); this io_uring
+// binary is default-GC so it would not leak, but lazy keeps both entries identical
+// and the shared lock is not a bottleneck (the json-comp@16384 collapse is thread
+// oversubscription from the co-hosted json-tls listener, enghitalo/vanilla#89).
+fn (mut sh Shared) write_json_gzip(mut out []u8, count int, m i64) {
+	key := (u64(u32(count)) << 32) | u64(u32(m))
+	sh.gz_mu.@rlock()
+	cached := sh.gz_cache[key] or { []u8{} }
+	sh.gz_mu.runlock()
+	if cached.len > 0 {
+		out << cached
+		return
+	}
 	body := sh.json_body(count, m)
-	gz := gzip.compress(body.bytes()) or { return []u8{} }
+	gz := gzip.compress(body.bytes()) or {
+		write_resp(mut out, 'application/json', body)
+		return
+	}
 	mut resp := []u8{cap: gz.len + 128}
 	ws(mut resp,
 		'HTTP/1.1 200 OK\r\nServer: vanilla\r\nContent-Encoding: gzip\r\nContent-Type: application/json\r\nContent-Length: ')
 	wi(mut resp, i64(gz.len))
 	ws(mut resp, '\r\nConnection: keep-alive\r\n\r\n')
 	unsafe { resp.push_many(gz.data, gz.len) }
-	return resp
-}
-
-// write_json_gzip is the json-comp path. The gzipped response per (count, m) is
-// deterministic, so the cache is fully precomputed at boot and is READ-ONLY during
-// serving — the hot path is a lock-free map read (no per-request shared RwMutex,
-// which contended across all workers and collapsed io_uring json-comp @16384).
-fn (sh &Shared) write_json_gzip(mut out []u8, count int, m i64) {
-	key := (u64(u32(count)) << 32) | u64(u32(m))
-	if cached := sh.gz_cache[key] {
-		out << cached
-		return
+	// Store it (bounded so a flood of distinct m values can't grow it without limit).
+	sh.gz_mu.@lock()
+	if sh.gz_cache.len < 1024 {
+		sh.gz_cache[key] = resp
 	}
-	// Param outside the precomputed grid (not sent by the benchmark): build and
-	// send WITHOUT caching, so the hot path stays write-free and lock-free.
-	resp := gz_response(sh, count, m)
-	if resp.len > 0 {
-		out << resp
-	} else {
-		write_resp(mut out, 'application/json', sh.json_body(count, m))
-	}
+	sh.gz_mu.unlock()
+	out << resp
 }
 
 // json_body builds just the /json body string (used for the gzip path).
@@ -762,20 +769,7 @@ fn main() {
 		cache:    map[int]string{}
 		cache_mu: sync.new_rwmutex()
 		gz_cache: map[u64][]u8{}
-	}
-
-	// Precompute the json-comp (gzip) responses at boot so write_json_gzip reads the
-	// cache LOCK-FREE during serving (no per-request shared RwMutex — that contended
-	// across workers and collapsed io_uring json-comp @16384 conns). The profile's
-	// params are bounded; cover count 1..min(dataset,64) x m 1..16.
-	gz_cap_count := if dataset.len < 64 { dataset.len } else { 64 }
-	for c in 1 .. gz_cap_count + 1 {
-		for mm in 1 .. 17 {
-			r := gz_response(sh, c, i64(mm))
-			if r.len > 0 {
-				sh.gz_cache[(u64(u32(c)) << 32) | u64(u32(mm))] = r
-			}
-		}
+		gz_mu:    sync.new_rwmutex()
 	}
 
 	// ── json-tls profile: /json over HTTPS on :8081 via the epoll + kTLS backend ──


### PR DESCRIPTION
## What

Restore the **lazy, shared, lock-guarded** json-comp gz cache on `vanilla-epoll` and `vanilla-io_uring`, reverting the lock-free boot precompute that shipped in #956/#957.

## Why

The precompute compressed the full `(count × m)` grid (~800 keys) at boot. On the **`-gc none`** `vanilla-epoll` build, V's `gzip.compress` leaks ~157 KiB of internal scratch per call (upstream bug, [vlang/v#27606](https://github.com/vlang/v/issues/27606)) — so the boot precompute leaked **~135 MiB of permanent RSS**. The last benchmark run showed it directly:

| vanilla-epoll mem | before (#956 combo) | after precompute |
|---|---|---|
| baseline 512 | 77 MiB | 213 MiB |
| json-comp 16384 | 221 MiB | 377 MiB |
| static 1024 | 100 MiB | 235 MiB |

(flat ~+135 MiB across *every* profile — the signature of a one-time boot allocation, reproduced exactly in isolation: 800 × `gzip.compress` under `-gc none` = ~135 MiB, reclaimed under default GC.)

The lazy cache compresses only the **8 `(count,m)` pairs the json-comp profile actually sends** (`/json/{1,5,10,15,25,40,50}` with `m∈1..8`), ≈ 1.3 MiB. This PR restores the **exact** json-comp code CI measured at 77 MiB in the #956/#957 *combo* commit, plus a guard comment so the precompute isn't reintroduced.

## The lock-free change had no upside

It was meant to fix the io_uring `json-comp@16384` collapse (a lock-contention hypothesis). The benchmark refuted it:

- **epoll** is healthy at 16384c **with** the shared lock (2.32M rps, CPU ~6100% — saturated).
- **io_uring** collapsed regardless, and *worse* with the precompute: 1.88M → **159K rps**, CPU 4312% → **438%**.

CPU *dropping* at max conns = rings starving, i.e. **worker/thread oversubscription** from the co-hosted json-tls listener (io_uring workers + the TLS thread pool exceed cores at 16384c), not lock contention. The real fix is a per-server worker cap ([enghitalo/vanilla#89](https://github.com/enghitalo/vanilla/issues/89) fix #1) — tracked as a follow-up, not in this PR.

`vanilla-io_uring` is default-GC so it didn't leak, but it's reverted too for parity and to restore its validated pre-cleanup state.

## Validation

- Diff is **only** the json-comp revert + an explanatory comment; both files `vfmt`-parse clean.
- The restored json-comp is byte-identical to the #956/#957 combo code that CI already measured at 77 MiB.
- Expected on a re-run: `vanilla-epoll` baseline mem back to ~77 MiB; json-comp behavior unchanged from the combo (healthy epoll@16384). No `/benchmark` triggered here — happy to run it on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
