### PR TITLE
Optimize SEO for terms 'webserver benchmarks' and 'http server benchmarks' 

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,5 +1,6 @@
 ---
-title: HttpArena
+title: HTTP Server Benchmarks – HttpArena
+description: "HttpArena delivers open HTTP server benchmarks and webserver benchmarks across 28+ test profiles — HTTP/1.1, HTTP/2, HTTP/3, gRPC, WebSocket. Open-source, automated, reproducible."
 layout: hextra-home
 ---
 
@@ -16,7 +17,7 @@ layout: hextra-home
 
 <div class="hx-mb-12">
 {{< hextra/hero-subtitle >}}
-  An open benchmarking platform that measures HTTP, gRPC, and WebSocket framework performance under realistic workloads using io_uring-based load generation. Add your framework, get results automatically.
+  An open HTTP server benchmark platform — compare webserver, gRPC, and WebSocket framework performance under realistic workloads using io_uring-based load generation. Add your framework, get results automatically.
 {{< /hextra/hero-subtitle >}}
 </div>
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -48,7 +48,7 @@ menu:
         icon: github
 
 params:
-  description: "HTTP framework benchmark arena"
+  description: "Open-source HTTP server benchmarks and webserver benchmark platform — compare HTTP/1.1, HTTP/2, HTTP/3, gRPC, and WebSocket framework performance under realistic workloads."
   theme:
     default: system
     displayToggle: false


### PR DESCRIPTION
Currently, we are not on Google page 1 for terms "webserver benchmarks" and "http server benchmarks". This shows in the Google traffic which we only have for the term "httparena" but nothing else.

Description and title are the most important fields to achieve this, so we adjust them here.

<img width="865" height="412" alt="image" src="https://github.com/user-attachments/assets/3a572fbc-f36d-4ac0-bbc6-0a608ff1973c" />