### PR TITLE
refactor(vanilla-epoll): extract shared emit_xcache helper for io_uring parity

### DIFF
--- a/frameworks/vanilla-epoll/main.v
+++ b/frameworks/vanilla-epoll/main.v
@@ -236,6 +236,21 @@ fn write_resp(mut out []u8, ctype string, body string) {
 	ws(mut out, body)
 }
 
+// emit_xcache writes a complete 200 JSON response carrying an X-Cache: HIT|MISS header
+// straight into `out` — the single framing shared by the crud GET hit/miss paths (and
+// byte-identical to the vanilla-io_uring twin's emit_xcache, so the two entries diff
+// cleanly). `body` is the render buffer (snapshotted under the read-lock on a HIT).
+fn emit_xcache(mut out []u8, ctype string, body []u8, cache string) {
+	ws(mut out, 'HTTP/1.1 200 OK\r\nServer: vanilla\r\nX-Cache: ')
+	ws(mut out, cache)
+	ws(mut out, '\r\nContent-Type: ')
+	ws(mut out, ctype)
+	ws(mut out, '\r\nContent-Length: ')
+	wi(mut out, i64(body.len))
+	ws(mut out, '\r\nConnection: keep-alive\r\n\r\n')
+	wb(mut out, body)
+}
+
 // emit_int writes a 200 whose body is a single integer, formatting it into the
 // reused per-worker scratch. The obvious `write_resp(.., n.str())` heap-allocates
 // an int->string on every request — a permanent leak under `-gc none` (e.g. the
@@ -716,11 +731,7 @@ fn (mut w WorkerCtx) start_crud_get(mut out []u8, mut ac core.AsyncCtx, id int) 
 	}
 	if hit {
 		// Cache hit: answer synchronously, no DB round-trip.
-		ws(mut out,
-			'HTTP/1.1 200 OK\r\nServer: vanilla\r\nX-Cache: HIT\r\nContent-Type: application/json\r\nContent-Length: ')
-		wi(mut out, i64(w.scratch.len))
-		ws(mut out, '\r\nConnection: keep-alive\r\n\r\n')
-		wb(mut out, w.scratch)
+		emit_xcache(mut out, 'application/json', w.scratch, 'HIT')
 		return .done
 	}
 	w.reset_params()
@@ -758,11 +769,7 @@ fn (mut w WorkerCtx) render_crud_get(mut out []u8, res pg_async.Result, id int) 
 		slot.valid = true
 		w.ro.crud_mu.unlock()
 	}
-	ws(mut out,
-		'HTTP/1.1 200 OK\r\nServer: vanilla\r\nX-Cache: MISS\r\nContent-Type: application/json\r\nContent-Length: ')
-	wi(mut out, i64(w.scratch.len))
-	ws(mut out, '\r\nConnection: keep-alive\r\n\r\n')
-	wb(mut out, w.scratch)
+	emit_xcache(mut out, 'application/json', w.scratch, 'MISS')
 }
 
 fn (mut w WorkerCtx) start_crud_create(mut out []u8, mut ac core.AsyncCtx, req request_parser.HttpRequest) core.AsyncStep {


### PR DESCRIPTION
## What & why

Small maintainability refactor, paired with the `vanilla-io_uring` convergence PR. `vanilla-epoll` inlined the crud X-Cache response framing in two places (the `crud` GET cache **hit** and **miss** paths). This folds both into one `emit_xcache` helper.

The helper is **byte-identical** to the code it replaces, and **identical to the `emit_xcache` now used by the `vanilla-io_uring` twin** — so both entries share one audited X-Cache framing and diff cleanly. `vanilla-epoll` remains the performance reference; this only removes duplication.

## Change

- Add `emit_xcache(mut out, ctype, body, cache)` next to `emit` / `write_resp`.
- Use it in `start_crud_get` (HIT) and `render_crud_get` (MISS).

No behavior or performance change.

## Validation

Verified against a seeded Postgres that the `crud` GET **MISS** and **HIT** responses are byte-for-byte unchanged (and identical to the `vanilla-io_uring` twin, whose full-route byte-diff is covered in its PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
