### PR TITLE
sark-h3

### DIFF
--- a/frameworks/sark/Cargo.lock
+++ b/frameworks/sark/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "dope"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b1fe82bd8665f9b2d78a47b2c28834c9d3dbd6497575d7ebdad07de6acc35e"
+checksum = "40417a676988ac9d4776ab30c50a7ac06e1f3d00a0e32dc765d038eba9308c5a"
 dependencies = [
  "io-uring",
  "libc",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "dope-extra"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acda19f64a371f88a39a77b27322719008851221fd670b206544f0fe46be8c5"
+checksum = "0227219d7faae204d8e89a4d5a28371a7d23defc2a8a233faae48d66eb3c0512"
 dependencies = [
  "dope",
  "libc",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "dope-gen"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172c8823fb0399a240959a6707648cb73153b102cfdd3d565b6eb49dc9a777ee"
+checksum = "64ea8a5eaf1922ea8c5df3768ba38c79f6707dff87b9c45d9887c67ebfdcc614"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -558,6 +558,7 @@ dependencies = [
 name = "httparena-sark"
 version = "0.1.0"
 dependencies = [
+ "brotli",
  "cartel-gen",
  "cartel-pg",
  "cartel-redis",
@@ -1112,9 +1113,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sark"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420cdacd2626e1c5a20424d3c11c6ad0b55636d80bf5a12f5fe61a77114b2b11"
+checksum = "1cd9038671e5017d55cea520a9eeb9028ffe6a9556887244b5d779522d7a729d"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1133,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "sark-core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949dc53b561e4c2722cbea5adbf5e694af322577941bf32c0c02b059209757f"
+checksum = "76b74acd895e1c3889055471367567b737059bee96f9a52cdddf9818c4ef43e4"
 dependencies = [
  "brotli",
  "http",
@@ -1151,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "sark-gen"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822c2496faf77aea4efc834d72062ed5d53be86e6b7b12c74a26253e47d312bb"
+checksum = "aa84f9877e25146ccbf560ed030cda20f7f6c9b49bac5d462efe5f985d784ed9"
 dependencies = [
  "dope",
  "o3",
@@ -1164,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "sark-grpc"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042ea1eb87158113c9ac8637ec8b0fc5474f1157bb15e08cdbc439bcb1612a10"
+checksum = "909d6d978b65e3674e06ec11c0c3e95a9231fdafb6e2b611ada1d524a92db332"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1181,18 +1182,18 @@ dependencies = [
 
 [[package]]
 name = "sark-grpc-build"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076e604ccc96149135cc97f7fec6a9ef6253abcceeb49a38131e2bb61bb37539"
+checksum = "7075b026c0e93ef1f950ee7a9fdb51dbec1a852745f137def4b41676dd5bedbb"
 dependencies = [
  "prost-build",
 ]
 
 [[package]]
 name = "sark-h2"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cd5859b112ad033b65dabb2892fd2e462cd93b6c64621244a8bde8d6e6cb85"
+checksum = "77a69a1c6e410c575371ddf4c4d79e7fca9bfe77c68b07cc4c1e02b3f2d510e8"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1206,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "sark-h3"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd3c3cd0a0edb377f7f22b2c40e904cd3a45404a409024bc15ad074f5f17ad4"
+checksum = "d6bd499015af829f7c88ba5fc99d9090f488e468c27ef10eada9fa8a112d345d"
 dependencies = [
  "dope-quic",
  "sark",
@@ -1217,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "sark-json"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef0fb21a8d9c3fbcf1d41486d967cc5be51109b2009e2044697c6b39ef6571b"
+checksum = "68b560b4b06b8f216baee5fca331fce55a8e210fe898dc3825e85a4230a03492"
 dependencies = [
  "http",
  "o3",
@@ -1228,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "sark-ws"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc35a5e47355fd238a21431148e6a04b548fe37ba07f60a3154c112abd12ba0"
+checksum = "c2497dab6685b8eacaa66613a0bb00cc95fd8d066fa5d6febe9d21a2d8ba5205"
 dependencies = [
  "dope",
  "dope-extra",

--- a/frameworks/sark/Cargo.lock
+++ b/frameworks/sark/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cartel-core"
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -289,9 +289,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -482,25 +482,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core",
 ]
 
@@ -639,11 +627,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -711,9 +699,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -766,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -981,21 +969,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "getrandom 0.4.3",
  "rand_core",
@@ -1033,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1045,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1098,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -1113,9 +1095,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sark"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd9038671e5017d55cea520a9eeb9028ffe6a9556887244b5d779522d7a729d"
+checksum = "11def3adeb9515bc9a19b8eb4523c15ad198329c09ca999427c5cd5812d23570"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1134,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "sark-core"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b74acd895e1c3889055471367567b737059bee96f9a52cdddf9818c4ef43e4"
+checksum = "cbfe0d0414ed5ed4750710ffe0afda4675f438834c186f0538693244153abcee"
 dependencies = [
  "brotli",
  "http",
@@ -1152,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "sark-gen"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa84f9877e25146ccbf560ed030cda20f7f6c9b49bac5d462efe5f985d784ed9"
+checksum = "cd93bb79124aceca32e76da17a85bb4ccfd05e07fe7368aa3180c9e4c2b8a898"
 dependencies = [
  "dope",
  "o3",
@@ -1165,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "sark-grpc"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909d6d978b65e3674e06ec11c0c3e95a9231fdafb6e2b611ada1d524a92db332"
+checksum = "e5d811a138fa684903665f22962b0de5faa9f3753c9ad0fcda21c1ca355ee121"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1182,18 +1164,18 @@ dependencies = [
 
 [[package]]
 name = "sark-grpc-build"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7075b026c0e93ef1f950ee7a9fdb51dbec1a852745f137def4b41676dd5bedbb"
+checksum = "d92abf725f2b7753c02204a9583cb852311680fa44eb21a46c2be341ef080265"
 dependencies = [
  "prost-build",
 ]
 
 [[package]]
 name = "sark-h2"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a69a1c6e410c575371ddf4c4d79e7fca9bfe77c68b07cc4c1e02b3f2d510e8"
+checksum = "498eab08355b780a75f7364c1ffd25922b1b7050f7f4920c5571bf90d4073841"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1207,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "sark-h3"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bd499015af829f7c88ba5fc99d9090f488e468c27ef10eada9fa8a112d345d"
+checksum = "113fc66873d9b05556c198ad2666b4dee54538ca9dfcc8a1617a93a955aecc38"
 dependencies = [
  "dope-quic",
  "sark",
@@ -1218,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "sark-json"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b560b4b06b8f216baee5fca331fce55a8e210fe898dc3825e85a4230a03492"
+checksum = "3acbb15caceb05e8096c87ae8975eb75661de13df5bcc1aa5057bf179af409cd"
 dependencies = [
  "http",
  "o3",
@@ -1229,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "sark-ws"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2497dab6685b8eacaa66613a0bb00cc95fd8d066fa5d6febe9d21a2d8ba5205"
+checksum = "14fce25b613bee104b78567bf4f22ee7d5a357480160d6021bdc3e10a2b445c7"
 dependencies = [
  "dope",
  "dope-extra",
@@ -1441,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1471,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1534,15 +1516,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "webpki-roots"
@@ -1642,12 +1615,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,18 +1644,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1703,6 +1670,6 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"

--- a/frameworks/sark/httparena/Cargo.toml
+++ b/frameworks/sark/httparena/Cargo.toml
@@ -23,6 +23,7 @@ cartel-redis.workspace = true
 cartel-gen.workspace = true
 tent.workspace = true
 shin.workspace = true
+brotli = { version = "8", default-features = false, features = ["std"] }
 http.workspace = true
 rcgen.workspace = true
 pin-project.workspace = true

--- a/frameworks/sark/httparena/src/main.rs
+++ b/frameworks/sark/httparena/src/main.rs
@@ -116,14 +116,19 @@ fn u64_owned(n: u64) -> Owned {
 
 fn accepts(accept_encoding: &[u8], coding: &[u8]) -> bool {
     accept_encoding.split(|&b| b == b',').any(|part| {
-        let c = part
-            .trim_ascii()
-            .split(|&b| b == b';')
-            .next()
-            .unwrap_or(b"")
-            .trim_ascii();
-        c.eq_ignore_ascii_case(coding)
+        let mut params = part.trim_ascii().split(|&b| b == b';');
+        let c = params.next().unwrap_or(b"").trim_ascii();
+        c.eq_ignore_ascii_case(coding) && !params.any(q_zero)
     })
+}
+
+fn q_zero(param: &[u8]) -> bool {
+    let p = param.trim_ascii();
+    p.len() >= 3
+        && p[0].eq_ignore_ascii_case(&b'q')
+        && p[1] == b'='
+        && p[2] == b'0'
+        && !p[3..].iter().any(|b| b.is_ascii_digit() && *b != b'0')
 }
 
 fn respond_json<T: JsonEncode>(value: T, accept_encoding: &[u8]) -> Response {
@@ -131,12 +136,12 @@ fn respond_json<T: JsonEncode>(value: T, accept_encoding: &[u8]) -> Response {
     let mut response = Response::ok();
     response.content_type("application/json");
     if accepts(accept_encoding, b"gzip") {
-        let compressed = Gzip::with_thread_local(|g| Shared::from(g.encode(&body).to_vec()));
+        let compressed = Gzip::with_thread_local(|g| Shared::copy_from_slice(g.encode(&body)));
         response.append_wire_header_static("content-encoding", "gzip");
         response.append_wire_header_static("vary", "accept-encoding");
         response.set_body(compressed);
     } else if accepts(accept_encoding, b"br") {
-        let compressed = Brotli::with_thread_local(|b| Shared::from(b.encode(&body).to_vec()));
+        let compressed = Brotli::with_thread_local(|b| Shared::copy_from_slice(b.encode(&body)));
         response.append_wire_header_static("content-encoding", "br");
         response.append_wire_header_static("vary", "accept-encoding");
         response.set_body(compressed);
@@ -334,10 +339,11 @@ struct JsonRequest {
     accept_encoding: LocalFrameBytes,
 }
 
-#[sark_gen::handler]
-fn json_endpoint(req: JsonRequest, _state: &AppState<'_>) -> Response {
-    let count = req.count.clamp(1, 50) as usize;
-    let m = req.m.max(1);
+const JSON_GRID_M: u64 = 16;
+
+static JSON_BR_GRID: std::sync::OnceLock<Vec<&'static [u8]>> = std::sync::OnceLock::new();
+
+fn json_items(count: usize, m: u64) -> ItemsResponse {
     let mut items = Vec::with_capacity(count);
     for item in DATASET.iter().take(count) {
         let tags = item
@@ -360,13 +366,81 @@ fn json_endpoint(req: JsonRequest, _state: &AppState<'_>) -> Response {
             total: (item.price as u64) * (item.quantity as u64) * m,
         });
     }
-    respond_json(
-        ItemsResponse {
-            items,
-            count: count as u64,
-        },
-        req.accept_encoding.as_bytes(),
-    )
+    ItemsResponse {
+        items,
+        count: count as u64,
+    }
+}
+
+fn build_json_br_grid() -> Vec<&'static [u8]> {
+    let mut grid: Vec<&'static [u8]> = vec![&[]; 50 * JSON_GRID_M as usize];
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8)
+        .min(16);
+    let counts: Vec<usize> = (1..=50).collect();
+    let slots: Vec<(usize, &'static [u8])> = std::thread::scope(|s| {
+        let handles: Vec<_> = counts
+            .chunks(counts.len().div_ceil(workers))
+            .map(|chunk| {
+                s.spawn(move || {
+                    let params = brotli::enc::BrotliEncoderParams {
+                        quality: 11,
+                        lgwin: 22,
+                        ..Default::default()
+                    };
+                    let mut out = Vec::with_capacity(chunk.len() * JSON_GRID_M as usize);
+                    for &count in chunk {
+                        for m in 1..=JSON_GRID_M {
+                            let body = json_items(count, m).encode_json();
+                            let mut buf = Vec::with_capacity(body.len());
+                            let mut src: &[u8] = body.as_ref();
+                            brotli::BrotliCompress(&mut src, &mut buf, &params)
+                                .expect("brotli compress into Vec is infallible");
+                            let idx = (count - 1) * JSON_GRID_M as usize + (m as usize - 1);
+                            out.push((idx, &*Box::leak(buf.into_boxed_slice())));
+                        }
+                    }
+                    out
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().expect("json grid worker"))
+            .collect()
+    });
+    for (idx, body) in slots {
+        grid[idx] = body;
+    }
+    grid
+}
+
+fn json_br_cached(count: usize, m: u64) -> Option<&'static [u8]> {
+    if m == 0 || m > JSON_GRID_M {
+        return None;
+    }
+    let grid = JSON_BR_GRID.get()?;
+    Some(grid[(count - 1) * JSON_GRID_M as usize + (m as usize - 1)])
+}
+
+#[sark_gen::handler]
+fn json_endpoint(req: JsonRequest, _state: &AppState<'_>) -> Response {
+    let count = req.count.clamp(1, 50) as usize;
+    let m = req.m.max(1);
+    let accept_encoding = req.accept_encoding.as_bytes();
+    if !accept_encoding.is_empty()
+        && accepts(accept_encoding, b"br")
+        && let Some(body) = json_br_cached(count, m)
+    {
+        let mut response = Response::ok();
+        response.content_type("application/json");
+        response.append_wire_header_static("content-encoding", "br");
+        response.append_wire_header_static("vary", "accept-encoding");
+        response.set_body(Shared::from_static(body));
+        return response;
+    }
+    respond_json(json_items(count, m), accept_encoding)
 }
 
 #[sark_gen::request(ordered)]
@@ -995,6 +1069,7 @@ fn main() -> io::Result<()> {
             .precompressed_br()
             .precompressed_gzip(),
     ));
+    let _ = JSON_BR_GRID.set(build_json_br_grid());
 
     let h1_only = std::env::var("SARK_HTTPARENA_H1_ONLY")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run all benchmark tests |
| `/benchmark -f <framework> -t <test>` | Run a specific test |
| `/benchmark -f <framework> --save` | Run and save results (updates leaderboard on merge) |

Always specify `-f <framework>`. Results are automatically compared against the current leaderboard.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
