### PR TITLE
[sinatra] Let Symbol#to_s return a frozen string

### DIFF
--- a/frameworks/sinatra/app.rb
+++ b/frameworks/sinatra/app.rb
@@ -5,6 +5,8 @@ Bundler.require(:default)
 
 require 'pg'
 
+Symbol.alias_method(:to_s, :name)
+
 class Hash
   def symbolize_keys!
     transform_keys! { |key| key.to_sym }


### PR DESCRIPTION
This should reduce string allocations.
Large codebases like Shopify and GitHub run this in production: https://bugs.ruby-lang.org/issues/22137
This is how Ruby 4.1 works:
https://github.com/ruby/ruby/pull/17781