### PR TITLE
[rage] Let Symbol#to_s return a frozen string

### DIFF
--- a/frameworks/rage/app/controllers/application_controller.rb
+++ b/frameworks/rage/app/controllers/application_controller.rb
@@ -20,7 +20,6 @@ class ApplicationController < RageController::API
       return unless ENV['DATABASE_URL']
       ConnectionPool.new(size: pool_size, timeout: 5) do
         db = PG.connect(ENV['DATABASE_URL'])
-        db.field_name_type = :symbol
         db.prepare('select', SELECT_QUERY)
         db.prepare('crud_get', CRUD_GET_SQL)
         db.prepare('crud_list', CRUD_LIST_SQL)

--- a/frameworks/rage/app/controllers/benchmark_controller.rb
+++ b/frameworks/rage/app/controllers/benchmark_controller.rb
@@ -66,14 +66,14 @@ class BenchmarkController < ApplicationController
 
     items = rows.map do |r|
       {
-        id: r[:id],
-        name: r[:name],
-        category: r[:category],
-        price: r[:price],
-        quantity: r[:quantity],
-        active: r[:active] == 't',
-        tags: JSON.parse(r[:tags]),
-        rating: { score: r[:rating_score], count: r[:rating_count] }
+        id: r['id'],
+        name: r['name'],
+        category: r['category'],
+        price: r['price'],
+        quantity: r['quantity'],
+        active: r['active'] == 't',
+        tags: JSON.parse(r['tags']),
+        rating: { score: r['rating_score'], count: r['rating_count'] }
       }
     end
     render json: { items: items, count: items.length }

--- a/frameworks/rage/app/controllers/items_controller.rb
+++ b/frameworks/rage/app/controllers/items_controller.rb
@@ -96,15 +96,15 @@ class ItemsController < ApplicationController
 
   def map_row(row)
     mapped_row = {
-      id: row[:id],
-      name: row[:name],
-      category: row[:category],
-      price: row[:price],
-      quantity: row[:quantity],
-      active: row[:active] == 1,
+      id: row['id'],
+      name: row['name'],
+      category: row['category'],
+      price: row['price'],
+      quantity: row['quantity'],
+      active: row['active'] == 1,
     }
-    mapped_row[:tags] = JSON.parse(row[:tags]) if row.has_key?(:tags)
-    mapped_row[:rating] = { score: row[:rating_score], count: row[:rating_count] } if row.has_key?(:rating_score) && row.has_key?(:rating_count)
+    mapped_row[:tags] = JSON.parse(row['tags']) if row['tags']
+    mapped_row[:rating] = { score: row['rating_score'], count: row['rating_count'] } if row['rating_score'] && row['rating_count']
     mapped_row
   end
 end

--- a/frameworks/rage/config/application.rb
+++ b/frameworks/rage/config/application.rb
@@ -5,6 +5,8 @@ Bundler.require(:default)
 
 require 'rage/all'
 
+Symbol.alias_method(:to_s, :name)
+
 Rage.configure do
   # use this to add settings that are constant across all environments
   config.public_file_server.enabled = true


### PR DESCRIPTION
This should reduce string allocations.
Large codebases like Shopify and GitHub run this in production: https://bugs.ruby-lang.org/issues/22137
This is how Ruby 4.1 works:
https://github.com/ruby/ruby/pull/17781