### PR TITLE
hical: add json-comp (gzip) test

### DIFF
--- a/frameworks/hical/README.md
+++ b/frameworks/hical/README.md
@@ -15,7 +15,7 @@ web framework built on Boost.Asio.
 ## Test Types
 
 - baseline, pipelined, limited-conn
-- json
+- json, json-comp (gzip)
 - upload
 - static
 - echo-ws

--- a/frameworks/hical/meta.json
+++ b/frameworks/hical/meta.json
@@ -11,6 +11,7 @@
     "pipelined",
     "limited-conn",
     "json",
+    "json-comp",
     "upload",
     "static",
     "echo-ws"


### PR DESCRIPTION
## Description

hical added [GzipCompression middleware](https://github.com/Hical61/Hical/blob/main/src/core/GzipCompression.h) in v2.6.6, which auto-negotiates `Accept-Encoding: gzip` and returns compressed responses (`Content-Encoding: gzip`). The benchmark server now wraps the `SyncAfterHandler` into a coroutine lambda to enable the `json-comp` profile.

No code change was needed in the Dockerfile — it still builds from main branch with `-DHICAL_BUILD_HTTPARENA=ON`.

## Changes

- `meta.json`: added `json-comp` to tests array
- `README.md`: updated test types list