### PR TITLE
[rack-falcon] Let Symbol#to_s return a frozen string

### DIFF
--- a/frameworks/rack-falcon/app.rb
+++ b/frameworks/rack-falcon/app.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+Symbol.alias_method(:to_s, :name)
 # Our Rack application to be executed by rackup
 
 require 'rack'


### PR DESCRIPTION
This should reduce string allocations.
Large codebases like Shopify and GitHub run this in production: https://bugs.ruby-lang.org/issues/22137
This is also how Ruby 4.1 will work:
https://github.com/ruby/ruby/pull/17781