### PR TITLE
[scripts] fix benchmark-lite exiting 1 after successful non-DB runs

### DIFF
--- a/scripts/benchmark-lite.sh
+++ b/scripts/benchmark-lite.sh
@@ -210,7 +210,7 @@ import json; print(str(json.load(open('$meta')).get('enabled', True)).lower())" 
 
     local need_pg=false
     if framework_subscribes_to async-db; then need_pg=true; fi
-    $need_pg && postgres_start
+    if $need_pg; then postgres_start; fi
 
     local profiles_to_run
     if [ -n "$PROFILE_FILTER" ]; then
@@ -232,7 +232,10 @@ import json; print(str(json.load(open('$meta')).get('enabled', True)).lower())" 
         done
     done
 
-    $need_pg && postgres_stop
+    # `if` rather than `$need_pg && postgres_stop`: as the function's last
+    # statement, the &&-list would make run_framework return 1 for non-DB
+    # frameworks and kill the script under `set -e` after a successful run.
+    if $need_pg; then postgres_stop; fi
 }
 
 # ── Single (profile, conns) iteration ──────────────────────────────────────

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -186,7 +186,7 @@ need_pg=false
 for t in async-db crud api-4 api-16 gateway-64 gateway-h3 production-stack fortunes; do
     if framework_subscribes_to "$t"; then need_pg=true; break; fi
 done
-$need_pg && postgres_start
+if $need_pg; then postgres_start; fi
 
 # Redis sidecar — started whenever crud is in play so multi-process
 # frameworks can use it as a shared cache. Single-heap frameworks
@@ -197,7 +197,7 @@ need_redis=false
 for t in crud; do
     if framework_subscribes_to "$t"; then need_redis=true; break; fi
 done
-$need_redis && redis_start
+if $need_redis; then redis_start; fi
 
 # ── Main benchmark loop ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Bug

`run_framework()` in `scripts/benchmark-lite.sh` ended with:

```bash
$need_pg && postgres_stop
```

For frameworks that don't subscribe to `async-db`, `need_pg=false`, so this AND-list evaluates to status 1 — and since it's the **last statement of the function**, `run_framework` returns 1. Under the script's `set -euo pipefail`, the single-framework driver call `run_framework "$FRAMEWORK_ARG"` then kills the script with exit code 1 **after a fully successful benchmark**: the final `info "done"` never prints, the EXIT trap runs, and callers/CI see a failure.

### Repro

```
./scripts/benchmark-lite.sh vanilla-ws   # or any non-DB framework
```

Completes all runs, prints `=== Best: ... ===`, exits 1.

## Fix

Convert the guard to a form whose status doesn't propagate:

```bash
if $need_pg; then postgres_stop; fi
```

Also converted for consistency/robustness (currently benign only because they're not the last statement of a function):

- the matching `$need_pg && postgres_start` in `benchmark-lite.sh`
- the `$need_pg && postgres_start` / `$need_redis && redis_start` guards in `benchmark.sh`

A comment was left on the `postgres_stop` site so the `&&` form doesn't get reintroduced. Both scripts pass `bash -n`; minimal repro under `set -euo pipefail` confirms the old form aborts the script where the new form runs to completion with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)