### PR TITLE
Reject meta.json test subscriptions that aren't real profiles

### DIFF
--- a/frameworks/aleph/meta.json
+++ b/frameworks/aleph/meta.json
@@ -13,16 +13,11 @@
     "json",
     "json-comp",
     "upload",
-    "noisy",
-    "short-lived",
-    "mixed",
     "json-tls",
     "api-4",
     "api-16",
     "async-db",
-    "sync-db",
     "static",
-    "tcp-frag",
     "fortunes",
     "crud"
   ]

--- a/frameworks/hyperf/meta.json
+++ b/frameworks/hyperf/meta.json
@@ -16,7 +16,6 @@
     "upload",
     "static",
     "async-db",
-    "noisy",
     "api-4",
     "api-16",
     "echo-ws",

--- a/frameworks/phoenix-bandit/meta.json
+++ b/frameworks/phoenix-bandit/meta.json
@@ -22,7 +22,6 @@
     "echo-ws",
     "echo-ws-pipeline",
     "baseline-h2",
-    "static-h2",
-    "json-h2"
+    "static-h2"
   ]
 }

--- a/frameworks/php/meta.json
+++ b/frameworks/php/meta.json
@@ -13,7 +13,7 @@
     "limited-conn",
     "json",
     "json-comp",
-    "json-lts",
+    "json-tls",
     "upload",
     "api-4",
     "api-16",

--- a/frameworks/ring-http-exchange/meta.json
+++ b/frameworks/ring-http-exchange/meta.json
@@ -13,15 +13,11 @@
     "json",
     "json-comp",
     "upload",
-    "short-lived",
-    "mixed",
     "json-tls",
     "api-4",
     "api-16",
     "async-db",
-    "sync-db",
     "static",
-    "tcp-frag",
     "fortunes",
     "crud"
   ]

--- a/scripts/lib/framework.sh
+++ b/scripts/lib/framework.sh
@@ -31,6 +31,25 @@ import json; print(','.join(json.load(open('$meta_file')).get('tests', [])))" 2>
 
     info "framework: $FRAMEWORK ($DISPLAY_NAME, $LANGUAGE)"
     info "subscribed tests: $FRAMEWORK_TESTS"
+
+    framework_validate_tests
+}
+
+# A `tests` entry that doesn't name a real profile is otherwise silent:
+# framework_subscribes_to() returns false, the driver logs "skip", and the
+# framework quietly loses that coverage on every run since the typo landed.
+# `php` lost json-tls to "json-lts" this way. Fail loudly instead.
+#
+# PROFILES comes from profiles.sh, which is sourced *after* this file — that's
+# fine, the name resolves when this runs, not when the file is sourced.
+framework_validate_tests() {
+    local t unknown=()
+    for t in ${FRAMEWORK_TESTS//,/ }; do
+        [ -n "${PROFILES[$t]+x}" ] || unknown+=("$t")
+    done
+    [ ${#unknown[@]} -eq 0 ] || fail \
+"$FRAMEWORK/meta.json subscribes to unknown profile(s): ${unknown[*]}
+       known profiles: $(printf '%s\n' "${!PROFILES[@]}" | sort | tr '\n' ' ')"
 }
 
 framework_subscribes_to() {

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -58,6 +58,22 @@ fi
 TESTS=$(python3 -c "import json; print(' '.join(json.load(open('$META_FILE'))['tests']))")
 echo "[info] Subscribed tests: $TESTS"
 
+# Reject test names that aren't real profiles, before spending a build on it.
+# Nothing downstream would complain: has_test() just returns false and the
+# section is skipped, so a typo reads as a clean pass while the framework
+# silently loses that coverage in every benchmark run. Sourced rather than
+# re-listed so PROFILES stays the single source of truth.
+source "$SCRIPT_DIR/lib/profiles.sh"
+UNKNOWN_TESTS=()
+for t in $TESTS; do
+    [ -n "${PROFILES[$t]+x}" ] || UNKNOWN_TESTS+=("$t")
+done
+if [ ${#UNKNOWN_TESTS[@]} -gt 0 ]; then
+    echo "FAIL: meta.json subscribes to unknown profile(s): ${UNKNOWN_TESTS[*]}"
+    echo "      known profiles: $(printf '%s\n' "${!PROFILES[@]}" | sort | tr '\n' ' ')"
+    exit 1
+fi
+
 has_test() {
     # Exact whole-token match. `grep -qw` treats "-" as a word boundary
     # and matches "baseline" against "baseline-h2c" / "baseline-h2", and


### PR DESCRIPTION
A `tests` entry naming a profile that doesn't exist **fails open**: `framework_subscribes_to()` returns false, the driver logs `skip`, and the framework loses that coverage on every run from the typo onward. Nothing complains — the run finishes green, the leaderboard just has one fewer row, and `validate.sh` passes too, because `has_test()` is false so the section never executes.

Twelve such subscriptions had accumulated across five frameworks:

| framework | dead entry | resolution |
|---|---|---|
| `php` | `json-lts` | → `json-tls` (transposition) |
| `phoenix-bandit` | `json-h2` | dropped — see below |
| `aleph` | `noisy`, `short-lived`, `mixed`, `sync-db`, `tcp-frag` | dropped (retired profiles) |
| `ring-http-exchange` | `short-lived`, `mixed`, `sync-db`, `tcp-frag` | dropped (retired profiles) |
| `hyperf` | `noisy` | dropped (retired profile) |

### The two judgement calls

**`php` is the one with real lost coverage.** `nginx.conf` does `listen 8081 ssl` and proxies `/` to FPM, so `json-tls` has worked all along — it was simply never asked to run. Renaming turns the test back on, and CI validates it on this PR.

**`phoenix-bandit`'s `json-h2` is dropped, not corrected to `json-h2c`.** `json-h2` was never a profile in any revision of `profiles.sh`, and `json-h2c` is prior-knowledge cleartext on `:8082` while `runtime.exs` binds only 8080 and 8443 — "fixing" the name would have enabled a test that connects to a closed port. Its `baseline-h2`/`static-h2` on 8443 are the h2 coverage it actually implements.

The other eight name profiles retired before the current set, so there is nothing to point them at.

### Two guards, so it can't come back

- **`framework_load_meta()`** validates `FRAMEWORK_TESTS` against the `PROFILES` keys and fails the run, printing the unknown names and the known set. It lives in `framework.sh`, which `benchmark.sh` and `benchmark-lite.sh` both source and both call. It reads `PROFILES` at call time — `profiles.sh` is sourced *after* `framework.sh` in both drivers, which is fine for a function body.
- **`validate.sh`** does the same right after parsing `tests` and *before* the build, so a contributor's typo fails in CI on the PR that introduces it rather than quietly shrinking their framework's coverage. It sources `lib/profiles.sh` rather than restating the list, keeping `PROFILES` the single source of truth; no name in it collides with `validate.sh`.

### Verified both directions

- Guard rejects php's original `json-lts` (exit 1, names it) and accepts all 139 `meta.json` unchanged.
- `validate.sh` exits 1 on unknown names before the build; a valid set proceeds past the check untouched (0 false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)