### PR TITLE
Fix the language split, three missing language colors, and two stale references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Notable changes to test profiles, scoring, and validation.
 
+> **This file covers changes through 2026-04-16.** Later work is not recorded here — notably the five-value framework `type` vocabulary (`flagship` / `emerging` / `engine` / `infrastructure` / `experimental`) and the retirement of the Hugo site. For current specifications, read `site/content/docs/` (profiles, scoring, implementation rules) and `scripts/lib/profiles.sh` (the profile table the runner actually reads).
+
 ## 2026-04-16
 
 ### CRUD — realistic REST API benchmark (H/1.1 Isolated)

--- a/frameworks/bananabread/meta.json
+++ b/frameworks/bananabread/meta.json
@@ -1,6 +1,6 @@
 {
   "display_name": "bananabread",
-  "language": "TypeScript",
+  "language": "TS",
   "type": "emerging",
   "mode": "standard",
   "engine": "seagreen",

--- a/scripts/lib/profiles.sh
+++ b/scripts/lib/profiles.sh
@@ -71,7 +71,7 @@ parse_profile() {
 }
 
 # Map an endpoint to the tool name that handles it.
-# Returns one of: gcannon, wrk, h2load, h2load-h3, ghz, oha
+# Returns one of: gcannon, wrk, h2load, h2load-h3, ghz
 endpoint_tool() {
     case "$1" in
         # wrk (lua script rotation)

--- a/site/data/langcolors.json
+++ b/site/data/langcolors.json
@@ -22,5 +22,7 @@
   "Dart":       { "accent": "#0175c2", "text": "#01589b", "textDark": "#40c4ff", "rgb": "1,117,194" },
   "Clojure":    { "accent": "#5881d8", "text": "#3e64b8", "textDark": "#91b3ed", "rgb": "88,129,216" },
   "Erlang":     { "accent": "#a20031", "text": "#880029", "textDark": "#c63762", "rgb": "162,0,49" },
+  "V":          { "accent": "#4f87c4", "text": "#3b6ea6", "textDark": "#8fbce8", "rgb": "79,135,196" },
+  "OCaml":      { "accent": "#ef7a08", "text": "#c46306", "textDark": "#f9a75a", "rgb": "239,122,8" },
   "Type-C":     { "accent": "#059669", "text": "#047857", "textDark": "#34d399", "rgb": "5,150,105" }
 }


### PR DESCRIPTION
Four small corrections, each independently verifiable.

### 1. `TypeScript` vs `TS` rendered as two languages

`bananabread` was the only framework declaring `TypeScript`; the other four TS entries (`bun-websocket`, `deno-websocket`, `elysia`, `hono-bun`) declare `TS`. The board keys language off that string, so TypeScript showed up as a separate language in the filters and in every language tally. `langcolors.json` has a `TS` entry and no `TypeScript` one, so bananabread was also drawing an uncoloured badge.

### 2. …and it wasn't the only colour gap

`V` (**7 frameworks** — fasthttp, pico, vanilla-epoll, vanilla-h2c, vanilla-io_uring, vanilla-ws, +1) and `OCaml` (araara, araara-standard) had no entry either. That's **9 frameworks** falling back to the default swatch. Added both with their canonical brand colours in the file's existing `accent`/`text`/`textDark`/`rgb` shape.

All **22 languages in use now resolve**. The four unused entries (Crystal, Gleam, Lua, Nim) are left as headroom.

### 3. Stale `oha` reference

`endpoint_tool()`'s doc comment still advertised `oha` as a possible return value. oha was replaced by `h2load-h3` for every HTTP/3 profile, and the function has no oha branch — it returns `gcannon`, `wrk`, `h2load`, `h2load-h3` or `ghz`.

### 4. CHANGELOG cutoff

`CHANGELOG.md` stops at 2026-04-16 while claiming to record notable changes to profiles, scoring and validation. Rather than reconstruct three months of history from git and risk documenting it wrong, this states the cutoff and points at what is current (`site/content/docs/`, `scripts/lib/profiles.sh`).

**Say the word if you want the backfill written** — 33 commits since then touch the file's declared scope.

### Deliberately not changed: the 7 resultless frameworks

`araara`, `araara-standard`, `aspnet-minimal-iouring`, `bananabread`, `spring-jvm-grpc`, `tonic-grpc`, `ultimate-express`.

This looked like a display bug but isn't — the board builds its framework list from `D.results`, so a framework with no rows never renders at all. They're waiting on a first benchmark run, and nothing is broken until they get one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)