### PR TITLE
Restore the type squares in the results grids

### DIFF
--- a/site/static/new-leaderboard/index.html
+++ b/site/static/new-leaderboard/index.html
@@ -243,6 +243,13 @@
   .badge{font-size:.6rem; font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:.1rem .34rem; border-radius:5px; white-space:nowrap; flex:none}
   /* type as a small colored square (no label) in tables; fixed lang slot keeps names aligned. .badge stays for the modal */
   .tsq{width:10px; height:10px; border-radius:3px; flex:none; display:inline-block}
+  /* One rule per line: these five used to share a line, and removing the
+     infrastructure tier (#1017) took the whole line with it, leaving every
+     square transparent. */
+  .tsq-flagship{background:#2e9e6a}
+  .tsq-emerging{background:#3b73c4}
+  .tsq-experimental{background:#d98e2b}
+  .tsq-engine{background:#cb5f51}
   /* 'tuned' mode cue - yellow ring around the type square / badge */
   .tsq.tuned, .badge.tuned{position:relative}
   .tsq.tuned::after, .badge.tuned::after{content:""; position:absolute; top:0; bottom:0; right:calc(100% + 2px); width:4px; background:#c89a3c}


### PR DESCRIPTION
The little type squares next to every framework in the results grids stopped rendering after #1017.

### Cause

All five type colours lived on **one line**:

```css
.tsq-flagship{…} .tsq-emerging{…} .tsq-experimental{…} .tsq-engine{…} .tsq-infrastructure{…}
```

so deleting "the infrastructure badge rule" deleted the whole line. Every other removal in #1017 was correctly scoped — the filter pill, the tooltip, the abbreviation, the localStorage whitelist, the `isScored` branch and `.b-infrastructure` were all infrastructure-only. This one wasn't, because the line was shared.

`.tsq` kept its `width`, `height` and `border-radius` but lost every `background`, so each square rendered as a 10×10 **transparent** box. Both grid renderers still emit `class="tsq tsq-<type>"` — the markup was fine, there was just no colour to paint. The yellow **tuned** ring kept showing because it's an `::after` with its own background, which is exactly why the squares looked like they vanished from beside an otherwise intact marker.

### Fix

Restores the four surviving colours at their original values — unchanged, and still matching the `.b-*` badge and filter-pill palette:

| type | colour |
|---|---|
| flagship | `#2e9e6a` |
| emerging | `#3b73c4` |
| experimental | `#d98e2b` |
| engine | `#cb5f51` |

**One rule per line now**, so removing a tier can't silently take the others again.

### Verification

Headless Chrome against the real `data.js`/`docs.js`, run on this branch and on `main` for comparison:

| filter | `main` | this branch |
|---|---|---|
| flagship + emerging | **51/51 transparent** | 0/51, correct colours |
| engine | **26/26 transparent** | 0/26, `rgb(203,95,81)` |
| experimental | **2/2 transparent** | 0/2, `rgb(217,142,43)` |

Checked in both grid renderers (composite table and profile grid) and in dark mode; the tuned ring still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
