### PR TITLE
Fix duplicate env key that breaks benchmark-pr.yml

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -134,8 +134,6 @@ jobs:
 
       - name: Commit saved results
         if: inputs.save == 'true'
-        env:
-          FRAMEWORK: ${{ inputs.framework }}
         run: |
           PR_DATA=$(gh api "/repos/${{ github.repository }}/pulls/${{ inputs.pr }}" --jq '.head.ref + " " + .head.repo.full_name')
           PR_BRANCH=$(echo "$PR_DATA" | awk '{print $1}')
@@ -159,6 +157,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FRAMEWORK: ${{ inputs.framework }}
 
       - name: Post results to PR
         if: always()


### PR DESCRIPTION
**`/benchmark` is currently broken on `main` — this restores it.**

#1034 added `env: FRAMEWORK` to the *Commit saved results* step, which already declared `env: GH_TOKEN` at its end. Two `env` keys in one step is invalid and GitHub rejects the **whole file**:

```
failed to parse workflow: (Line: 160, Col: 9): 'env' is already defined
```

Every push since the merge shows a failed `benchmark-pr.yml` check for this reason, and the workflow cannot be dispatched at all.

### Why it got through

I validated with `yaml.safe_load`, and **PyYAML silently accepts duplicate mapping keys** (last one wins) while GitHub Actions rejects them. The local check passed on a file GitHub considers invalid.

All six workflows now validate against a loader that raises on duplicates:

```
benchmark-pr.yml: OK   deploy.yml: OK        pr-commands.yml: OK
benchmark.yml: OK      notify-maintainers.yml: OK   validate.yml: OK
```

My fault, and caught only because we tried a real `--save` — worth doing before trusting the rest of #1034.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
