### PR TITLE
Optimize SEO for term 'web server'

### DIFF
--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -6,7 +6,7 @@
 <link rel="canonical" href="https://www.http-arena.com/">
 <link rel="icon" href="/favicon.ico" sizes="any">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<title>HTTP Server Benchmarks – HttpArena</title>
+<title>HTTP Web Server Benchmarks – HttpArena</title>
 <meta name="description" content="Independent webserver benchmarks across every major framework and protocol (H1, H2, H3, gRPC, WebSocket) in multiple categories.">
 <style>
   :root{


### PR DESCRIPTION
Currently "webserver" and "server" are good, but "web server" is not.