### PR TITLE
Do not run deployment job when syncing forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,9 @@ concurrency:
 
 jobs:
   build:
+    # Don't deploy from forks (e.g. when syncing main from upstream). The
+    # GitHub Pages deployment isn't available on forks and the run would fail.
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -46,6 +49,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
When creating or updating a fork, the action `Deploy Site` will be triggered on `main` of that fork, which fails because the fork usually does not have GitHub pages enabled (which is a good thing as it would create tons of identical websites otherwise). This creates noise for contributors as they receive an e-mail about the failed workflow everytime they sync the fork.

Example: https://github.com/Kaliumhexacyanoferrat/HttpArena/actions/runs/30205713564/job/89803305823

This change updates the workflow to run only on a non-forked repository.