### PR TITLE
ioxide: drop the local NuGet feed

### DIFF
--- a/frameworks/ioxide/nuget.config
+++ b/frameworks/ioxide/nuget.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <!-- Local feed for the unpublished ioxide 0.0.8 packages (revalidated asset cache + zero-copy
-         send knob). Remove once 0.0.8 is published to nuget.org. -->
-    <add key="ioxide-local" value="/home/diogo/Desktop/Socket/ioxide-local-feed" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
`frameworks/ioxide/nuget.config` declared a package source at an absolute path — `/home/diogo/Desktop/Socket/ioxide-local-feed` — added when the ioxide builds it needed were not yet on nuget.org.

Every version the arena references is published now, so the source is dead weight. It is also actively harmful:

- it points at a directory that exists on **one machine**, so anywhere else it is a source that contributes nothing and quietly falls back;
- on that machine it can **shadow a published package** with a locally built one of the same version number, which means CI and a developer can build byte-different assemblies while both claim `0.4.169`.

## Verification

All seven packages resolve from nuget.org after removal, checked via each `.nupkg.metadata`:

```
ioxide           https://api.nuget.org/v3/index.json
ioxide.http2     https://api.nuget.org/v3/index.json
ioxide.file      https://api.nuget.org/v3/index.json
ioxide.ngtcp2    https://api.nuget.org/v3/index.json
```

The framework builds, and serves: static over plaintext returns the asset checksum-identical to disk, and h2 over TLS negotiates and answers 200.

No source changes — this is the `nuget.config` deletion only.