### PR TITLE
Notify: stop checking out the fork, which checkout v5 now refuses

### DIFF
--- a/.github/workflows/notify-maintainers.yml
+++ b/.github/workflows/notify-maintainers.yml
@@ -13,17 +13,18 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      # No ref: on pull_request_target the default is the base branch, which is the only side this
+      # job needs. It reads meta.json to know who to ping, and that must come from the base anyway.
       - uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          fetch-depth: 0
 
       - name: Detect changed frameworks and notify maintainers
         run: |
-          frameworks=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+          frameworks=$(gh api \
+            "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename' \
             | grep '^frameworks/' \
             | cut -d'/' -f2 \
-            | sort -u)
+            | sort -u || true)
 
           if [ -z "$frameworks" ]; then
             echo "No framework changes detected"


### PR DESCRIPTION
"Notify Framework Maintainers" fails on every pull request that comes from a fork, which is most of them. `actions/checkout@v5` now refuses to check out a fork's head under `pull_request_target`, because that would run the fork's code with the base repository's token and secrets:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

It failed on #1125 and on "Update Workerman and add more tests" in the same minute.

The job does not need the fork's side at all: it reads `meta.json` to know who to ping, and the base is the right place to read that from, since a fork can otherwise write the mention list itself. So the checkout goes back to its default ref and the changed paths come from the pull request API instead of `git diff`.

One behaviour changes: a pull request that adds a brand new framework has no `meta.json` on the base, so nobody is pinged for it. The author is skipped by this job anyway, and they are the only maintainer such an entry has.
