### PR TITLE
Update workerman websockets

### DIFF
--- a/frameworks/workerman-websocket/Dockerfile
+++ b/frameworks/workerman-websocket/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV PROCESS_MULTIPLIER=1
 ENV EVENT_LOOP=Select
@@ -6,8 +6,7 @@ ENV EVENT_LOOP=Select
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
-RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
-    apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
+RUN apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
 RUN apt-get install -yqq php8.5-cli php8.5-xml > /dev/null
 

--- a/frameworks/workerman-websocket/Dockerfile
+++ b/frameworks/workerman-websocket/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.5-cli php8.5-xml > /dev/null
+RUN apt-get install -yqq zip unzip php8.5-cli php8.5-xml php8.5-zip> /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 

--- a/frameworks/workerman-websocket/composer.json
+++ b/frameworks/workerman-websocket/composer.json
@@ -1,6 +1,6 @@
 {
 	"require": {
-		"workerman/workerman": "^5"
+		"workerman/workerman": "^5.2.2"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
## Description
Update to Workerman v5.2.2 more RFC compliant


---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run every test the framework subscribes to |
| `/benchmark -f <framework> -t <test>` | Run one test only |
| `/benchmark -f <framework> --save` | Run and save results (updates the leaderboard on merge) |
| `/benchmark -f <framework> -t <test> --save` | Run one test and save results |
| `/benchmark -f <framework> --compare <other>` | Measure the deltas against another framework instead of this one |
| `/benchmark-multiple -f <fw1>,<fw2>,...` | Benchmark several frameworks in one run — takes `-t` and `--save` too; saved results land in a single commit |
| `/benchmark-multiple --save` | No `-f` needed: benchmark and save every framework the PR touches |
| `/benchmark-test -t <test>` | Benchmark **all** enabled frameworks subscribed to `<test>` and save the results |

For `/benchmark`, always specify `-f <framework>`; the flags combine in any order. Results come back as a comment with a per-profile table of RPS, p99, CPU and memory — one table per framework on multi runs. A new benchmark comment while a run is in flight queues behind it (one deep) instead of cancelling it. For multi-framework PRs (dependency bumps, same-language refactors) prefer `/benchmark-multiple`, which runs everything in a single job and commits all saved results together, so no run overwrites another. `--compare` works on single-framework runs only.

**What the deltas are measured against.** By default, this framework's own results published on `main` - answering *"did this change help?"*. When you are tuning a variant or a successor entry, `--compare` re-bases them on another entry instead:

```
/benchmark -f genhttp-11 --compare genhttp
```

The reply states which baseline it used, and profiles the other framework does not run show `n/a` rather than a delta.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
