### PR TITLE
Fix PHP dockerfile

### DIFF
--- a/frameworks/php/Dockerfile
+++ b/frameworks/php/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common >/dev
 RUN apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev nginx-extras \
                     zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
-                    php8.5-fpm php8.5-cli php8.5-pgsql > /dev/null
+                    php8.5-fpm php8.5-cli php8.5-pgsql
 
 COPY conf/* /etc/php/8.5/fpm/
 COPY src/ src/

--- a/frameworks/php/Dockerfile
+++ b/frameworks/php/Dockerfile
@@ -1,15 +1,13 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common >/dev/null
 
-RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php >/dev/null && \
-    LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/nginx >/dev/null && \
-    apt-get update -yqq > /dev/null && apt-get upgrade -yqq >/dev/null && \
+RUN apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev nginx-extras \
                     zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
-                    php8.5-fpm php8.5-cli php8.5-pgsql >/dev/null
+                    php8.5-fpm php8.5-cli php8.5-pgsql > /dev/null
 
 COPY conf/* /etc/php/8.5/fpm/
 COPY src/ src/

--- a/frameworks/php/Dockerfile
+++ b/frameworks/php/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common >/dev
 
 RUN apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev nginx-extras \
-                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
-                    php8.5-fpm php8.5-cli php8.5-pgsql
+                    zlib1g-dev libpcre2-dev libargon2-dev libsodium-dev libkrb5-dev \
+                    php8.5-fpm php8.5-cli php8.5-pgsql > /dev/null
 
 COPY conf/* /etc/php/8.5/fpm/
 COPY src/ src/

--- a/frameworks/php/meta.json
+++ b/frameworks/php/meta.json
@@ -18,6 +18,7 @@
     "api-4",
     "api-16",
     "static",
+    "static-tls",
     "async-db",
     "baseline-h2",
     "static-h2",

--- a/frameworks/php/nginx.conf
+++ b/frameworks/php/nginx.conf
@@ -64,7 +64,7 @@ http {
     #               image/svg+xml;
 
     upstream fastcgi_backend {
-        server unix:/var/run/php/php-fpm.sock;
+        server unix:/run/php/php-fpm.sock;
         keepalive 36;
     }
 
@@ -111,6 +111,11 @@ http {
             fastcgi_param  CONTENT_TYPE       $content_type;
             fastcgi_param  CONTENT_LENGTH     $content_length;
             #include        /etc/nginx/fastcgi_params;
+        }
+
+        location /static/ { 
+            root /data;
+            add_header    Last-Modified '';
         }
     }
 


### PR DESCRIPTION
## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run every test the framework subscribes to |
| `/benchmark -f <framework> -t <test>` | Run one test only |
| `/benchmark -f <framework> --save` | Run and save results (updates the leaderboard on merge) |
| `/benchmark -f <framework> -t <test> --save` | Run one test and save results |
| `/benchmark -f <framework> --compare <other>` | Measure the deltas against another framework instead of this one |
| `/benchmark-multiple -f <fw1>,<fw2>,...` | Benchmark several frameworks in one run — takes `-t` and `--save` too; saved results land in a single commit |
| `/benchmark-multiple --save` | No `-f` needed: benchmark and save every framework the PR touches |
| `/benchmark-test -t <test>` | Benchmark **all** enabled frameworks subscribed to `<test>` and save the results |

For `/benchmark`, always specify `-f <framework>`; the flags combine in any order. Results come back as a comment with a per-profile table of RPS, p99, CPU and memory — one table per framework on multi runs. A new benchmark comment while a run is in flight queues behind it (one deep) instead of cancelling it. For multi-framework PRs (dependency bumps, same-language refactors) prefer `/benchmark-multiple`, which runs everything in a single job and commits all saved results together, so no run overwrites another. `--compare` works on single-framework runs only.

**What the deltas are measured against.** By default, this framework's own results published on `main` - answering *"did this change help?"*. When you are tuning a variant or a successor entry, `--compare` re-bases them on another entry instead:

```
/benchmark -f genhttp-11 --compare genhttp
```

The reply states which baseline it used, and profiles the other framework does not run show `n/a` rather than a delta.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
