### PR TITLE
Add hanami framework

### DIFF
--- a/frameworks/hanami/Dockerfile
+++ b/frameworks/hanami/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:4.0-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential libjemalloc2 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Use Jemalloc
+ENV LD_PRELOAD=libjemalloc.so.2
+
+ENV RUBY_YJIT_ENABLE=1
+ENV RUBY_MN_THREADS=1
+ENV RACK_ENV=production
+ENV HANAMI_ENV=production
+ENV WEB_CONCURRENCY=auto
+ENV MAX_THREADS=4
+ENV MAX_IO_THREADS=10
+
+WORKDIR /app
+
+COPY Gemfile .
+RUN bundle install --jobs=$(nproc)
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["bundle", "exec", "puma", "-C", "puma.rb"]

--- a/frameworks/hanami/Gemfile
+++ b/frameworks/hanami/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "hanami", "~> 2.3"
+gem "hanami-controller", "~> 2.3"
+gem "hanami-router", "~> 2.3"
+gem "json"
+gem "puma", "~> 8.0"
+gem "rack"
+gem "rackup"

--- a/frameworks/hanami/README.md
+++ b/frameworks/hanami/README.md
@@ -1,0 +1,30 @@
+# hanami
+
+Hanami actions and router on Puma.
+
+## Stack
+
+- **Language:** Ruby 4.0 with YJIT
+- **Framework:** Hanami 2.3
+- **Server:** Puma 8, one worker per core, jemalloc
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/pipeline` | GET | Returns `ok` (plain text) |
+| `/baseline11` | GET | Sums query parameter values |
+| `/baseline11` | POST | Sums query parameters + request body |
+| `/json/{count}?m=N` | GET | First `count` dataset items with `total = price * quantity * m` |
+| `/upload` | POST | Reads the body in chunks and returns the byte count |
+
+## Notes
+
+- One action class per endpoint, routed by the Hanami router
+- JSON generated per request, response format set through the action response
+- Compression through `Rack::Deflater` in `config.ru`
+- The benchmark posts bodies with no Content-Type, which Rack would parse as
+  form data, so form parsing is restricted to real form media types
+- hanami-router parses every request body as a query string unless it is told
+  the body was already parsed, which the 20 MB upload cannot afford, so
+  `config.ru` sets that flag

--- a/frameworks/hanami/app/action.rb
+++ b/frameworks/hanami/app/action.rb
@@ -1,0 +1,24 @@
+require "hanami/action"
+require "rack"
+
+module Arena
+  class Action < Hanami::Action
+    private
+
+    # The benchmark posts bodies with no Content-Type, which Rack parses as form
+    # data, so the query is read from QUERY_STRING and the body from rack.input.
+    def query_sum(request)
+      ::Rack::Utils.parse_query(request.env["QUERY_STRING"]).values.sum do |value|
+        Array(value).first.to_i
+      end
+    end
+
+    def request_body(request)
+      input = request.env["rack.input"]
+      return "" unless input
+
+      input.rewind
+      input.read.to_s
+    end
+  end
+end

--- a/frameworks/hanami/app/actions/baseline11.rb
+++ b/frameworks/hanami/app/actions/baseline11.rb
@@ -1,0 +1,13 @@
+module Arena
+  module Actions
+    class Baseline11 < Arena::Action
+      def handle(request, response)
+        total = query_sum(request)
+        total += request_body(request).strip.to_i if request.post?
+
+        response.format = :txt
+        response.body = total.to_s
+      end
+    end
+  end
+end

--- a/frameworks/hanami/app/actions/items.rb
+++ b/frameworks/hanami/app/actions/items.rb
@@ -1,0 +1,27 @@
+require "json"
+
+module Arena
+  module Actions
+    class Items < Arena::Action
+      DATASET = begin
+        path = ENV.fetch("DATASET_PATH", "/data/dataset.json")
+        File.exist?(path) ? JSON.parse(File.read(path)) : []
+      rescue StandardError
+        []
+      end
+
+      def handle(request, response)
+        count = request.params[:count].to_i.clamp(0, DATASET.length)
+        m = request.params[:m].to_i
+        m = 1 if m.zero?
+
+        items = DATASET.first(count).map do |item|
+          item.merge("total" => item["price"] * item["quantity"] * m)
+        end
+
+        response.format = :json
+        response.body = JSON.generate(items: items, count: items.length)
+      end
+    end
+  end
+end

--- a/frameworks/hanami/app/actions/pipeline.rb
+++ b/frameworks/hanami/app/actions/pipeline.rb
@@ -1,0 +1,10 @@
+module Arena
+  module Actions
+    class Pipeline < Arena::Action
+      def handle(request, response)
+        response.format = :txt
+        response.body = "ok"
+      end
+    end
+  end
+end

--- a/frameworks/hanami/app/actions/upload.rb
+++ b/frameworks/hanami/app/actions/upload.rb
@@ -1,0 +1,20 @@
+module Arena
+  module Actions
+    class Upload < Arena::Action
+      def handle(request, response)
+        input = request.env["rack.input"]
+        size = 0
+
+        if input
+          input.rewind
+          while (chunk = input.read(65_536))
+            size += chunk.bytesize
+          end
+        end
+
+        response.format = :txt
+        response.body = size.to_s
+      end
+    end
+  end
+end

--- a/frameworks/hanami/config.ru
+++ b/frameworks/hanami/config.ru
@@ -1,0 +1,36 @@
+require "hanami/boot"
+require "rack"
+
+# The benchmark posts plain and binary bodies. Rack parses a body with no
+# Content-Type as form data, so form parsing is limited to real form types.
+Rack::Request::Helpers.module_eval do
+  FORM_MEDIA_TYPES = ["application/x-www-form-urlencoded", "multipart/form-data"].freeze
+
+  def form_data?
+    FORM_MEDIA_TYPES.include?(media_type)
+  end
+
+  def parseable_data?
+    false
+  end
+end
+
+# hanami-router parses every request body as a query string unless someone
+# already parsed it, which the 20 MB upload cannot afford. The flag it looks at
+# is the same one its body parser middleware sets.
+class SkipRouterBodyParsing
+  PARSED_BODY = "router.parsed_body".freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    env[PARSED_BODY] = nil unless env.key?(PARSED_BODY)
+    @app.call(env)
+  end
+end
+
+use SkipRouterBodyParsing
+use Rack::Deflater
+run Hanami.app

--- a/frameworks/hanami/config/app.rb
+++ b/frameworks/hanami/config/app.rb
@@ -1,0 +1,6 @@
+require "hanami"
+
+module Arena
+  class App < Hanami::App
+  end
+end

--- a/frameworks/hanami/config/routes.rb
+++ b/frameworks/hanami/config/routes.rb
@@ -1,0 +1,9 @@
+module Arena
+  class Routes < Hanami::Routes
+    get "/pipeline", to: "pipeline"
+    get "/baseline11", to: "baseline11"
+    post "/baseline11", to: "baseline11"
+    get "/json/:count", to: "items"
+    post "/upload", to: "upload"
+  end
+end

--- a/frameworks/hanami/meta.json
+++ b/frameworks/hanami/meta.json
@@ -1,0 +1,19 @@
+{
+  "display_name": "hanami",
+  "language": "Ruby",
+  "type": "flagship",
+  "mode": "standard",
+  "engine": "Puma",
+  "description": "Hanami 2.3 actions and router on Puma, one worker per core. Routing and params through the Hanami API, JSON generated per request, gzip through Rack::Deflater.",
+  "repo": "https://github.com/hanami/hanami",
+  "enabled": true,
+  "tests": [
+    "baseline",
+    "pipelined",
+    "limited-conn",
+    "json",
+    "json-comp",
+    "upload"
+  ],
+  "maintainers": []
+}

--- a/frameworks/hanami/puma.rb
+++ b/frameworks/hanami/puma.rb
@@ -1,0 +1,6 @@
+threads ENV.fetch("MAX_THREADS", 4).to_i
+max_io_threads ENV.fetch("MAX_IO_THREADS", 10).to_i
+
+bind "tcp://0.0.0.0:8080"
+
+preload_app!


### PR DESCRIPTION
Adds Hanami (Ruby) with the profiles it can run: baseline, pipelined, limited-conn, json, json-comp, upload.

One Hanami action per endpoint on Puma, JSON generated per request, gzip through Rack::Deflater. The benchmark posts bodies with no Content-Type, which Rack parses as form data, so form parsing is restricted to real form media types.

Checked locally by building the image and calling every endpoint of those profiles: query and body sums, per request totals with the multiplier, Accept-Encoding negotiation and the 20 MB upload.

I am not a maintainer of Hanami and I am not involved in its development, I used Claude Code to help me implement the entry correctly.