### PR TITLE
Badges: publish each framework's rank, one per protocol family

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Generate leaderboard data
         run: python3 scripts/gen_leaderboard_data.py
 
+      # The README badges carry a rank computed by a Python port of the board's
+      # own scoring. Publishing a badge that disagrees with the page it links to
+      # is worse than publishing none, so a drifted port fails the deploy.
+      - name: Check badge ranks against the board
+        run: node scripts/check_badge_parity.js
+
       - name: Assemble site — standalone leaderboard at root
         working-directory: site
         run: |
@@ -41,6 +47,7 @@ jobs:
           cp -r root/. public/                                                       # 404.html, robots.txt, favicon.ico/.svg, and the /leaderboard/ -> / redirect
           cp -r generated/docs public/docs                                          # pre-rendered Knowledge Base pages (real /docs/<id>/ URLs) + docs.css
           cp generated/sitemap.xml public/sitemap.xml                               # root + every /docs/<id>/ (generated, replaces the old static one)
+          cp -r generated/badge public/badge                                        # shields.io endpoints behind the README badges, /badge/<fw>/<family>.json
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/README.md
+++ b/README.md
@@ -106,6 +106,52 @@ Another badge variants:
 - WebSocket: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-websocket.svg`
 - gRPC: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-grpc.svg`
 
+### Rank badge
+
+The badges above say you were benchmarked. This one says how you did, and it
+re-renders itself every time the board is republished:
+
+> **HTTP Arena H/1.1** · `#6 of 71`
+
+```md
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
+```
+
+Swap `actix` for your entry and `h1` for the family you want:
+
+| Family | `<family>` | Composite it reports |
+|---|---|---|
+| HTTP/1.1 | `h1` | Connection, Workload, Database and Multi-endpoint profiles |
+| HTTP/2 | `h2` | the HTTP/2 profiles |
+| HTTP/3 | `h3` | the HTTP/3 profiles |
+| Gateway | `gw` | reverse-proxy and production-stack profiles |
+| gRPC | `grpc` | unary and streaming, plaintext and TLS |
+| WebSocket | `ws` | the echo profiles |
+
+`<framework>` is your entry's name on the board, lowercased, with anything
+outside `A-Z a-z 0-9 . _ -` turned into `-` — the same name as your file in
+[`site/data/results/`](site/data/results). The full list of what is published,
+with every rank in it, is at
+[`/badge/index.json`](https://www.http-arena.com/badge/index.json).
+
+A few things worth knowing before you paste it:
+
+- **The rank is against your own tier.** `flagship` and `emerging` rank together
+  as one field, because that is the board's default view. `engine` entries rank
+  among engines, over the profile subset engines are scored on. That way a
+  framework's ceiling is never set by an engine's result, or the reverse.
+- **It only exists where you scored.** No result in a family means no badge for
+  it, and a family with a single entry in your tier publishes nothing — a rank
+  is worth showing once there was somebody to beat.
+- **It follows the default board.** Same scoring as the page it links to, with
+  the memory-efficiency and rescale toggles off. Follow the link and you land on
+  the view the number came from.
+- **It updates on deploy, then when GitHub's cache lets it.** README images are
+  proxied through Camo, so a new rank can take a few hours to show up.
+
+Shields' usual styling works — append `&style=flat-square`, `&logo=rust`, and so
+on to the `img.shields.io` URL.
+
 ---
 
 <div align="left">

--- a/scripts/check_badge_parity.js
+++ b/scripts/check_badge_parity.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+//
+// The badge ranks are produced by a Python port (write_badges() in
+// gen_leaderboard_data.py) of the board's client-side scoring. Two copies of
+// one formula drift, and the drift is silent: the badge keeps rendering, it
+// just stops agreeing with the page it links to.
+//
+// So run the real thing. This lifts the scoring functions out of
+// site/leaderboard/index.html verbatim — no reimplementation — evaluates them
+// against the same data.js the browser gets, and diffs every rank against
+// site/generated/badge/index.json.
+//
+//     node scripts/check_badge_parity.js
+//
+// Non-zero exit on any disagreement. Run it after gen_leaderboard_data.py.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HTML = path.join(ROOT, 'site/leaderboard/index.html');
+const DATA = path.join(ROOT, 'site/leaderboard/data.js');
+const INDEX = path.join(ROOT, 'site/generated/badge/index.json');
+
+for (const f of [HTML, DATA, INDEX]) {
+  if (!fs.existsSync(f)) {
+    console.error(`missing ${path.relative(ROOT, f)} — run scripts/gen_leaderboard_data.py first`);
+    process.exit(2);
+  }
+}
+
+// ── lift the scoring out of the page ────────────────────────────────────────
+// Anchored on the section comments and the one-line helpers. If a rename breaks
+// an anchor this throws rather than silently checking nothing.
+const src = fs.readFileSync(HTML, 'utf8');
+function grab(re, what) {
+  const m = src.match(re);
+  if (!m) {
+    console.error(`could not lift ${what} out of index.html — the anchor moved.`);
+    console.error('Re-point the regex in this script at the renamed code; do not skip the check.');
+    process.exit(2);
+  }
+  return m[0];
+}
+const composite = grab(/\/\/ ── COMPOSITE scoring[\s\S]*?(?=\/\/ ── render)/, 'the composite block');
+const familyOf = grab(/^\s*function familyOf\(p\)\{.*$/m, 'familyOf()');
+const memFn = grab(/^\s*function mem\(s\)\{.*$/m, 'mem()');
+const bwFn = grab(/^\s*function bw\(s\)\{.*$/m, 'bw()');
+
+// ── the data the browser would have ─────────────────────────────────────────
+const window = {};
+new Function('window', fs.readFileSync(DATA, 'utf8'))(window);
+const D = window.LB_DATA;
+
+// Everything the lifted code reaches for that lives elsewhere in the page.
+// state is pinned to the board's defaults — the view a visitor lands on when
+// they follow the badge and touch nothing.
+const stubs = `
+  var PROF = {}; D.profiles.forEach(function(p){ PROF[p.id]=p; });
+  function typeOf(fw){ return (D.meta[fw] && D.meta[fw].type) || 'emerging'; }
+  function modeOf(fw){ return (D.meta[fw] && D.meta[fw].mode) || 'standard'; }
+  function langOf(fw){ return ''; }
+  function matchQ(fw){ return true; }              // state.q is '' — no search filter
+  var state = { useMem:false, rescale:false, showTuned:true, q:'', scope:'h1', types:[] };
+`;
+const run = new Function('D', `
+  ${stubs}
+  ${familyOf}
+  ${memFn}
+  ${bwFn}
+  ${composite}
+  return function(scope, types){
+    state.scope = scope; state.types = types;   // AGG is state-independent, so its cache is safe
+    return computeComposite();
+  };
+`)(D);
+
+// ── rank the same way write_badges() does ───────────────────────────────────
+const FAMILIES = ['h1', 'h2', 'h3', 'gw', 'grpc', 'ws'];
+const LEAGUES = [['flagship', 'emerging'], ['engine'], ['experimental']];
+const MIN_FIELD = 2;
+
+function ranked(scope, types) {
+  const rows = run(scope, types).rows
+    .filter(r => r.score > 0)
+    .sort((a, b) => (b.score - a.score) || (a.fw < b.fw ? -1 : a.fw > b.fw ? 1 : 0));
+  const out = new Map();
+  let prevScore = null, prevRank = 0;
+  rows.forEach((r, i) => {
+    const rank = (prevScore !== null && Math.abs(prevScore - r.score) < 1e-9) ? prevRank : i + 1;
+    prevScore = r.score; prevRank = rank;
+    out.set(r.fw, { rank, of: rows.length, score: r.score });
+  });
+  return out;
+}
+
+// Same rule as _slug() in gen_leaderboard_data.py / rebuild_site_data.py.
+const slug = n => (n.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'unnamed').toLowerCase();
+
+const emitted = JSON.parse(fs.readFileSync(INDEX, 'utf8'));
+const problems = [];
+let checked = 0;
+
+for (const scope of FAMILIES) {
+  for (const types of LEAGUES) {
+    const expect = ranked(scope, types);
+    for (const [fw, e] of expect) {
+      const got = emitted[slug(fw)] && emitted[slug(fw)].scopes[scope];
+      if (e.of < MIN_FIELD) {
+        if (got) problems.push(`${fw} ${scope}: badge emitted for a field of ${e.of} (min ${MIN_FIELD})`);
+        continue;
+      }
+      checked++;
+      if (!got) { problems.push(`${fw} ${scope}: board ranks it #${e.rank} of ${e.of}, no badge emitted`); continue; }
+      if (got.rank !== e.rank || got.of !== e.of) {
+        problems.push(`${fw} ${scope}: badge says #${got.rank} of ${got.of}, board says #${e.rank} of ${e.of}`);
+      }
+      if (Math.abs(got.score - e.score) > 0.05) {
+        problems.push(`${fw} ${scope}: badge score ${got.score}, board score ${e.score.toFixed(1)}`);
+      }
+    }
+  }
+}
+
+// And the other direction — a badge the board would not produce at all.
+for (const [s, entry] of Object.entries(emitted)) {
+  for (const scope of Object.keys(entry.scopes)) {
+    const seen = LEAGUES.some(types => ranked(scope, types).has(entry.framework));
+    if (!seen) problems.push(`${entry.framework} ${scope}: badge emitted but the board ranks no such entry`);
+  }
+}
+
+if (problems.length) {
+  console.error(`badge parity: ${problems.length} disagreement(s) with site/leaderboard/index.html\n`);
+  problems.slice(0, 40).forEach(p => console.error('  ' + p));
+  if (problems.length > 40) console.error(`  ... and ${problems.length - 40} more`);
+  console.error('\nThe Python port in gen_leaderboard_data.py has drifted from the board. Fix the port.');
+  process.exit(1);
+}
+
+console.log(`badge parity ok — ${checked} ranks match site/leaderboard/index.html`);

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -22,6 +22,7 @@ import shutil
 import posixpath
 import html as _html
 from pathlib import Path
+from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA = ROOT / "site" / "data"
@@ -918,6 +919,250 @@ def write_sitemap(content):
     return len(urls)
 
 
+# ── README badges (shields.io endpoint) ──────────────────────────────────────
+# A framework's rank in one composite family, as a JSON document shields.io
+# renders into an SVG. The maintainer pastes one URL and it follows the board.
+#
+# The scoring below is a port of computeComposite() in site/leaderboard/index.html
+# and MUST track it. It is pinned to the board's *default* state — the score a
+# visitor sees when they click through from the badge and touch nothing:
+#
+#     useMem=false   rescale=false   showTuned=true   q=''
+#
+# so the only client-side knob left is the type filter, which the leagues below
+# reproduce. If the board's defaults or its scoring change, change this too;
+# check-badge-parity.js diffs the two and is what should catch the drift.
+
+BADGE_OUT = GEN / "badge"
+
+
+def _slug(name):
+    """URL segment for a display name. Two gateway entries carry spaces and a
+    '+', so names can't go in a path as-is. Same rule rebuild_site_data.py uses
+    for result filenames, so /badge/<slug>/ lines up with results/<slug>.json."""
+    return (re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-") or "unnamed").lower()
+
+# category -> family key. Mirrors familyOf() in index.html; anything unlisted is
+# HTTP/1.1 (Connection, Workload, Database, Multi-endpoint).
+FAMILY_OF_CAT = {"Gateway": "gw", "HTTP/2": "h2", "HTTP/3": "h3",
+                 "gRPC": "grpc", "WebSocket": "ws"}
+FAMILY_LABEL = {"h1": "H/1.1", "h2": "H/2", "h3": "H/3",
+                "gw": "Gateway", "grpc": "gRPC", "ws": "WebSocket"}
+
+# Leagues are the board's type filter. flagship+emerging is its default view and
+# ranks as one field; engine entries are scored on their own profile subset, so
+# a framework's 100 is never set by an engine's result (and vice versa).
+LEAGUES = [("flagship", "emerging"), ("engine",), ("experimental",)]
+
+# A rank is only worth publishing if something was beaten to earn it.
+BADGE_MIN_FIELD = 2
+
+# api-4/api-16 template mix — MIXW in index.html.
+MIXW = {"baseline": 0.15, "json": 1, "upload": 10, "static": 2, "async_db": 10}
+
+_MEM_RE = re.compile(r"([\d.]+)\s*([KMG]i?B)", re.I)
+_BW_RE = re.compile(r"([\d.]+)\s*([KMG]?B)/s", re.I)
+
+
+def _mem(s):
+    """"512 MiB" -> MiB. Mirrors mem() in index.html."""
+    m = _MEM_RE.search(str(s or ""))
+    if not m:
+        return 0.0
+    v, u = float(m.group(1)), m.group(2).upper()[0]
+    return v * 1024 if u == "G" else v if u == "M" else v / 1024 if u == "K" else v
+
+
+def _bw(s):
+    """"12.30MB/s" -> bytes/s. Mirrors bw() in index.html."""
+    m = _BW_RE.search(str(s or ""))
+    if not m:
+        return 0.0
+    v, u = float(m.group(1)), m.group(2).upper()[0]
+    return v * 1e9 if u == "G" else v * 1e6 if u == "M" else v * 1e3 if u == "K" else v
+
+
+def badge_aggregate(profiles, results):
+    """Average rps/mem/bw (and the api template mix) over each profile's scored
+    conns. Port of aggregate() in index.html."""
+    avg, amem, abw, atpl = {}, {}, {}, {}
+    for p in profiles:
+        pid = p["id"]
+        sums, ms, bs, cn, ts = {}, {}, {}, {}, {}
+        for c in p["scoredConns"]:
+            for r in results.get(f"{pid}-{c}", []):
+                fw = r["fw"]
+                sums[fw] = sums.get(fw, 0) + (r.get("rps") or 0)
+                cn[fw] = cn.get(fw, 0) + 1
+                ms[fw] = ms.get(fw, 0) + _mem(r.get("memory"))
+                bs[fw] = bs.get(fw, 0) + _bw(r.get("bandwidth"))
+                if pid in ("api-4", "api-16"):
+                    t = ts.setdefault(fw, dict.fromkeys(MIXW, 0.0) | {"n": 0})
+                    for k in MIXW:
+                        t[k] += r.get("tpl_" + k) or 0
+                    t["n"] += 1
+        avg[pid] = {fw: sums[fw] / cn[fw] for fw in sums}
+        amem[pid] = {fw: ms[fw] / cn[fw] for fw in sums}
+        abw[pid] = {fw: bs[fw] / cn[fw] for fw in sums}
+        if pid in ("api-4", "api-16"):
+            atpl[pid] = {fw: {k: t[k] / t["n"] for k in MIXW} for fw, t in ts.items()}
+    return {"avg": avg, "mem": amem, "bw": abw, "tpl": atpl}
+
+
+def badge_composite(agg, profiles, meta, scope, types):
+    """Composite scores for one family and one league, best first.
+
+    Port of computeComposite() at the board's default state. Returns
+    [(framework, score)] for entries that actually scored in this family;
+    an entry present only through a reference-only profile (pipelined,
+    fortunes) sums to 0 and is dropped — there is no rank to report.
+    """
+    prof = {p["id"]: p for p in profiles}
+    pids = [p["id"] for p in profiles
+            if FAMILY_OF_CAT.get(p["category"], "h1") == scope]
+    if not pids:
+        return []
+
+    A = agg
+    in_league = lambda fw: meta.get(fw, {}).get("type", "emerging") in types
+
+    def is_scored(pid, fw):
+        p = prof[pid]
+        if not p["scored"]:
+            return False
+        if meta.get(fw, {}).get("type", "emerging") == "engine":
+            return bool(p["engineScored"])
+        return True
+
+    # json-comp is scored on bandwidth-adjusted rps: the best compressor sets the
+    # bar and everyone else is penalised by the square of their size ratio.
+    min_bpr = None
+    if "json-comp" in pids and A["avg"].get("json-comp"):
+        cand = []
+        for fw, rps in A["avg"]["json-comp"].items():
+            b = A["bw"]["json-comp"].get(fw, 0)
+            if in_league(fw) and rps > 0 and b > 0:
+                cand.append(b / rps)
+        if cand:
+            min_bpr = min(cand)
+
+    def eff(pid, fw):
+        rps = A["avg"].get(pid, {}).get(fw, 0)
+        if rps <= 0:
+            return 0.0
+        t = A["tpl"].get(pid, {}).get(fw)
+        if pid in ("api-4", "api-16") and t:
+            return sum(t[k] * w for k, w in MIXW.items())
+        if pid == "json-comp" and min_bpr is not None:
+            b = A["bw"][pid].get(fw, 0)
+            if b > 0:
+                return rps * (min_bpr / (b / rps)) ** 2
+        return rps
+
+    max_r = {}
+    for pid in pids:
+        vals = [eff(pid, fw) for fw in A["avg"].get(pid, {}) if in_league(fw)]
+        max_r[pid] = max(vals, default=0.0)
+
+    rows = []
+    fwset = {fw for pid in pids for fw in A["avg"].get(pid, {})}
+    for fw in fwset:
+        if not in_league(fw):
+            continue
+        score = 0.0
+        for pid in pids:
+            rps = A["avg"].get(pid, {}).get(fw, 0)
+            if rps > 0 and max_r[pid] > 0 and is_scored(pid, fw):
+                score += (eff(pid, fw) / max_r[pid]) * 100
+        if score > 0:
+            rows.append((fw, score))
+    rows.sort(key=lambda r: (-r[1], r[0]))
+    return rows
+
+
+def _badge_link(fw, scope, types):
+    """Deep link to the exact board view the rank came from. Parameter order and
+    the omit-the-default rule follow writeHash() in index.html, so the URL the
+    badge points at is the one the board would write for that view itself."""
+    parts = []
+    if scope != "h1":
+        parts.append("scope=" + scope)
+    if sorted(types) != ["emerging", "flagship"]:
+        parts.append("type=" + ",".join(sorted(types)))
+    parts.append("q=" + quote(fw, safe=""))
+    return SITE + "/#" + "&".join(parts)
+
+
+def _badge_color(rank, total):
+    """Rank tier, scaled to the field so a 12-entry family isn't graded like a
+    90-entry one. Gold for the win, then decile / quartile / half."""
+    if rank == 1:
+        return "e3b341"
+    pct = rank / total
+    if rank <= 3 or pct <= 0.10:
+        return "brightgreen"
+    if pct <= 0.25:
+        return "green"
+    if pct <= 0.50:
+        return "yellowgreen"
+    return "blue"
+
+
+def write_badges(profiles, results, meta):
+    """One shields.io endpoint document per (framework, family) it ranks in,
+    at /badge/<framework>/<family>.json, plus an index of everything written."""
+    if BADGE_OUT.exists():
+        shutil.rmtree(BADGE_OUT)
+    agg = badge_aggregate(profiles, results)
+
+    index, written = {}, 0
+    for scope in FAMILY_LABEL:
+        for types in LEAGUES:
+            rows = badge_composite(agg, profiles, meta, scope, types)
+            total = len(rows)
+            if total < BADGE_MIN_FIELD:
+                continue    # "#1 of 1" says nothing; skip until the field fills out
+            prev_score, prev_rank = None, 0
+            for i, (fw, score) in enumerate(rows):
+                # Competition ranking: equal scores share a rank (1, 2, 2, 4).
+                if prev_score is not None and abs(prev_score - score) < 1e-9:
+                    rank = prev_rank
+                else:
+                    rank = i + 1
+                prev_score, prev_rank = score, rank
+                slug = _slug(fw)
+                doc = {
+                    "schemaVersion": 1,
+                    "label": "HTTP Arena " + FAMILY_LABEL[scope],
+                    "message": f"#{rank} of {total}",
+                    "color": _badge_color(rank, total),
+                    "labelColor": "1f2937",
+                    "cacheSeconds": 3600,
+                }
+                path = BADGE_OUT / slug / f"{scope}.json"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(json.dumps(doc, separators=(",", ":")) + "\n",
+                                encoding="utf-8")
+                written += 1
+                # The maintainer should not have to assemble any of this: the
+                # index carries the finished line to paste, deep-linked to the
+                # view that produced the number.
+                link = _badge_link(fw, scope, types)
+                shield = ("https://img.shields.io/endpoint?url="
+                          f"{SITE}/badge/{slug}/{scope}.json")
+                e = index.setdefault(slug, {"framework": fw, "scopes": {}})
+                e["scopes"][scope] = {
+                    "rank": rank, "of": total, "score": round(score, 1),
+                    "link": link,
+                    "markdown": f"[![HTTP Arena {FAMILY_LABEL[scope]}]({shield})]({link})",
+                }
+
+    BADGE_OUT.mkdir(parents=True, exist_ok=True)
+    (BADGE_OUT / "index.json").write_text(
+        json.dumps(index, indent=1, sort_keys=True) + "\n", encoding="utf-8")
+    return written, len(index)
+
+
 def main():
     global RESULTS
     RESULTS = load_results()
@@ -984,6 +1229,7 @@ def main():
     n_pages = build_doc_pages(docs_tree, docs_content)
     n_search, search_bytes = write_search_index(docs_tree, docs_content)
     n_urls = write_sitemap(docs_content)
+    n_badges, n_badge_fw = write_badges(profiles, results, meta)
 
     n_rows = sum(len(v) for v in results.values())
     print(f"wrote {OUT.relative_to(ROOT)} - {len(profiles)} profiles, "
@@ -991,6 +1237,7 @@ def main():
     print(f"wrote {DOCS_OUT.relative_to(ROOT)}/ - {n_pages} static doc pages")
     print(f"wrote {(OUT.parent / 'search.js').relative_to(ROOT)} - {n_search} indexed pages, {search_bytes // 1024} KB")
     print(f"wrote {(GEN / 'sitemap.xml').relative_to(ROOT)} - {n_urls} URLs")
+    print(f"wrote {BADGE_OUT.relative_to(ROOT)}/ - {n_badges} badges over {n_badge_fw} frameworks")
 
 
 if __name__ == "__main__":

--- a/site/content/docs/add-framework/_index.md
+++ b/site/content/docs/add-framework/_index.md
@@ -12,4 +12,5 @@ Adding a framework to HttpArena takes a few steps: create a Dockerfile, add meta
   {{< card link="/docs/test-profiles" title="Test Profiles" subtitle="All HTTP endpoints your framework must implement, organized by test profile." icon="code" >}}
   {{< card link="meta-json" title="meta.json" subtitle="Framework metadata - display name, language, type, and which tests to participate in." icon="document-text" >}}
   {{< card link="implementation-rules" title="Implementation Rules" subtitle="Rules for keeping benchmarks realistic - use framework APIs, production settings only, standard libraries." icon="shield-check" >}}
+  {{< card link="badges" title="README Badge" subtitle="Publish your entry's rank in your own README - one live badge per protocol family." icon="badge-check" >}}
 {{< /cards >}}

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -1,0 +1,74 @@
+---
+title: README Badge
+seo_title: "HttpArena README Badge — publish your framework's rank"
+description: "Add a live HttpArena rank badge to your project's README: one URL per protocol family, updated every time the leaderboard is republished."
+weight: 5
+---
+
+Once your framework has results on the board, it gets a badge for every protocol
+family it scored in. The badge reports where the entry ranks, and it re-renders
+itself each time the leaderboard is republished — you paste it once.
+
+> **HTTP Arena H/1.1** · `#6 of 71`
+
+## Paste it
+
+```md
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
+```
+
+Replace `actix` with your entry and `h1` with the family you want. The exact
+line for your framework, already assembled and deep-linked to the right view of
+the board, is in [`/badge/index.json`](https://www.http-arena.com/badge/index.json)
+under `markdown`.
+
+## Families
+
+| Family | `<family>` | What the composite covers |
+|---|---|---|
+| HTTP/1.1 | `h1` | Connection, Workload, Database and Multi-endpoint profiles |
+| HTTP/2 | `h2` | the HTTP/2 profiles |
+| HTTP/3 | `h3` | the HTTP/3 profiles |
+| Gateway | `gw` | reverse-proxy and production-stack profiles |
+| gRPC | `grpc` | unary and streaming, plaintext and TLS |
+| WebSocket | `ws` | the echo profiles |
+
+`<framework>` is your entry's board name, lowercased, with anything outside
+`A-Z a-z 0-9 . _ -` replaced by `-`. It is the same name as your file under
+`site/data/results/`, so `aspnet-minimal + nginx` becomes
+`aspnet-minimal-nginx`.
+
+## What the number means
+
+The rank comes from the [composite score](/docs/scoring/composite-score/) for
+that family — the same sum of normalized per-profile scores the board shows,
+computed the same way, at the board's default settings. Following the badge
+lands you on the view it was taken from.
+
+**You are ranked inside your own tier.** `flagship` and `emerging` entries rank
+together as one field, because that is the board's default view. `engine`
+entries rank among engines, over the smaller profile subset engines are scored
+on. Keeping the tiers apart is what stops a framework's 100 from being set by an
+engine's result, or the reverse.
+
+**A badge only exists where you scored.** No result in a family means no badge
+for that family. A family where your tier holds a single entry publishes
+nothing — a rank is worth showing once there was somebody to beat.
+
+## Freshness
+
+The endpoints are regenerated whenever the site deploys. After that, GitHub
+serves README images through its Camo proxy, which caches them, so a changed
+rank can take a few hours to appear on GitHub itself.
+
+## Styling
+
+The endpoints are plain [shields.io](https://shields.io) documents, so shields'
+own options work — append `&style=flat-square`, `&logo=rust`, `&labelColor=…` to
+the `img.shields.io` URL.
+
+## The static badges
+
+If you want the plain "Benchmarked by HttpArena" wordmark instead of a rank, the
+variants are listed in the
+[project README](https://github.com/MDA2AV/HttpArena#add-the-badge).


### PR DESCRIPTION
Implements the badge idea from #1119 — a badge a maintainer puts in their own README that says how their entry did, not just that it was benchmarked. The static wordmark badges stay exactly as they are; this adds a live one next to them.

> **HTTP Arena H/1.1** · `#6 of 71`

## How a maintainer uses it

Paste one line, swapping in your entry and the family you want:

```md
[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
```

That's the whole thing. It re-renders itself every time the site deploys — nobody edits a README when the board moves.

| Family | `<family>` | What the composite covers |
|---|---|---|
| HTTP/1.1 | `h1` | Connection, Workload, Database, Multi-endpoint |
| HTTP/2 | `h2` | the HTTP/2 profiles |
| HTTP/3 | `h3` | the HTTP/3 profiles |
| Gateway | `gw` | reverse-proxy and production-stack |
| gRPC | `grpc` | unary and streaming, plaintext and TLS |
| WebSocket | `ws` | the echo profiles |

`<framework>` is the entry's board name lowercased, with anything outside `A-Z a-z 0-9 . _ -` replaced by `-` — the same name as its file in `site/data/results/`, so `aspnet-minimal + nginx` becomes `aspnet-minimal-nginx`.

Nobody should have to assemble any of that by hand, so **`/badge/index.json` carries the finished line per entry**, already deep-linked to the view the number came from:

```json
"ioxide": {
  "framework": "ioxide",
  "scopes": {
    "h1": {
      "rank": 1, "of": 30, "score": 381.0,
      "link": "https://www.http-arena.com/#type=engine&q=ioxide",
      "markdown": "[![HTTP Arena H/1.1](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/ioxide/h1.json)](https://www.http-arena.com/#type=engine&q=ioxide)"
    }
  }
}
```

Note the `type=engine` in there. An engine entry linking to the default board would land visitors on a table it isn't in — the generator works that out so the maintainer can't get it wrong.

Shields' own options still work: append `&style=flat-square`, `&logo=rust`, `&labelColor=…`.

## What the rank means

It's the composite for that family — the same sum of normalized per-profile scores the board shows, at the board's default settings.

**Ranked inside its own tier.** `flagship` and `emerging` rank together as one field, because that is the board's default view. `engine` entries rank among engines over the engineScored subset. That's what stops a framework's 100 being set by an engine's result, or the reverse.

**Only where the entry scored.** No result in a family, no badge for it. And a family where a tier holds a single entry publishes nothing — three would have qualified, and "#1 of 1" reads as a boast about an empty room.

**Colour scales to the field size**, not to absolute rank, so a 4-entry gateway field isn't graded like the 71-entry h1 one. Gold for #1, then decile / quartile / half.

Current output: **210 badges over 123 frameworks.**

## Keeping it honest

The catch: composite scoring lives in the board's client-side JS, so publishing a rank means a second copy of the formula in Python. Two copies of one formula drift, and the drift is silent — the badge keeps rendering, it just stops agreeing with the page it links to.

So `scripts/check_badge_parity.js` doesn't reimplement anything. It lifts the scoring functions **verbatim** out of `site/leaderboard/index.html` by regex, evaluates them in Node against the same `data.js` the browser gets, and diffs every rank:

```
badge parity ok — 210 ranks match site/leaderboard/index.html
```

I confirmed it actually bites rather than passing vacuously — disabling the json-comp bandwidth penalty in the Python port produced 99 disagreements and exit 1. If an anchor it greps for is renamed, it exits 2 and says so instead of quietly checking nothing.

The deploy runs it before assembling the site, so a drifted port fails the deploy. A badge that contradicts the board is worse than no badge.

## Two notes

**Gateway is included.** The ask was five families; the board's `SCOPES` already has six, so `gw` comes along — excluding it would have meant writing code to exclude it.

**The live shields.io render can only be confirmed after this deploys**, since the endpoints have to be publicly reachable for shields to fetch them. In place of that I validated all 210 documents against the endpoint schema — `schemaVersion`, required non-empty `message`, colour format, `cacheSeconds >= 300`, no unknown fields — all clean. Worth a glance at one badge once it's live.

## Files

| | |
|---|---|
| `scripts/gen_leaderboard_data.py` | generates the endpoints + `index.json` |
| `scripts/check_badge_parity.js` | diffs every rank against the board's own JS |
| `.github/workflows/deploy.yml` | parity gate, and copies `generated/badge` → `public/badge` |
| `README.md`, `docs/add-framework/badges.md` | the maintainer-facing instructions |

`data.js` / `search.js` are deliberately not in this diff. Regenerating them picks up 53 result views and 13 meta entries that have drifted into `site/data/` since they were last committed — real, harmless (the deploy regenerates both), and entirely unrelated to badges. Folding a 613KB refresh in here would only make this harder to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
