### PR TITLE
README: drop the old static badges, keep only the rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,34 +84,10 @@ Add your GitHub username to the `maintainers` array in your framework's `meta.js
 
 ## Add the badge
 
-Benchmarked on HttpArena? Add the badge to your project's README — it links to the live leaderboard and adapts to light & dark themes automatically.
+Benchmarked here? Put your rank in your own README. It re-renders itself every
+time the board is republished, so you paste it once and never touch it again:
 
-```md
-[![Benchmarked by HttpArena](https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/wordmark.svg)](https://www.http-arena.com/)
-```
-
-Prefer HTML, e.g. to set the size:
-
-```html
-<a href="https://www.http-arena.com/">
-  <img src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/wordmark.svg" alt="Benchmarked by HttpArena" height="44">
-</a>
-```
-
-Another badge variants:
-- Http/1.1: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-h1.svg`
-- Http/2: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-h2.svg`
-- Http/3: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-h3.svg`
-- Gateway: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-gateway.svg`
-- WebSocket: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-websocket.svg`
-- gRPC: `https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-grpc.svg`
-
-### Rank badge
-
-The badges above say you were benchmarked. This one says how you did, and it
-re-renders itself every time the board is republished:
-
-> **HTTP Arena H/1.1** · `#6 of 71`
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
 
 ```md
 [![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
@@ -151,51 +127,3 @@ A few things worth knowing before you paste it:
 
 Shields' usual styling works — append `&style=flat-square`, `&logo=rust`, and so
 on to the `img.shields.io` URL.
-
----
-
-<div align="left">
-  <a href="https://www.http-arena.com/">
-    <img alt="Benchmarked by HttpArena" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/wordmark.svg" width="235">
-  </a>
-</div>
-
-<br>
-
-
-<table>
-  <tr>
-    <td align="">
-      <a href="https://www.http-arena.com/#sort=rps:-1&type=flagship&tuned=0">
-        <img alt="Benchmarked by HttpArena H/1.1" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-h1.svg" width="235">
-      </a>
-    </td>
-    <td align="">
-      <a href="https://www.http-arena.com/#scope=h2&type=flagship&tuned=0">
-        <img alt="Benchmarked by HttpArena H/1.1" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-h2.svg" width="235">
-      </a>
-    </td>
-    <td align="">
-      <a href="https://www.http-arena.com/#scope=h3&type=flagship&tuned=0">
-        <img alt="Benchmarked by HttpArena H/1.1" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-h3.svg" width="235">
-      </a>
-    </td>
-  </tr>
-  <tr>
-    <td align="">
-      <a href="https://www.http-arena.com/#scope=gw&type=flagship&tuned=0">
-        <img alt="Benchmarked by HttpArena H/1.1" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-gateway.svg" width="235">
-      </a>
-    </td>
-    <td align="">
-      <a href="https://www.http-arena.com/#scope=grpc&type=flagship&tuned=0">
-        <img alt="Benchmarked by HttpArena H/1.1" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-grpc.svg" width="235">
-      </a>
-    </td>
-    <td align="">
-      <a href="https://www.http-arena.com/#scope=ws&type=flagship&tuned=0">
-        <img alt="Benchmarked by HttpArena H/1.1" src="https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/httparena-badge-websocket.svg" width="235">
-      </a>
-    </td>
-  </tr>
-</table> 

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -66,9 +66,3 @@ rank can take a few hours to appear on GitHub itself.
 The endpoints are plain [shields.io](https://shields.io) documents, so shields'
 own options work — append `&style=flat-square`, `&logo=rust`, `&labelColor=…` to
 the `img.shields.io` URL.
-
-## The static badges
-
-If you want the plain "Benchmarked by HttpArena" wordmark instead of a rank, the
-variants are listed in the
-[project README](https://github.com/MDA2AV/HttpArena#add-the-badge).


### PR DESCRIPTION
`## Add the badge` was carrying two badge systems at once after #1149 — the jsDelivr wordmark and its six per-protocol SVGs, then the rank badge underneath, opening with "the badges above say you were benchmarked". A maintainer had to read both to work out which one to paste, and the README ended with a large HTML table rendering the old set a second time.

Only the rank badge survives. It says everything the static ones said and adds the number, so removing them loses nothing.

## What changed

- **Removed** the wordmark markdown + HTML snippets, the six `httparena-badge-*.svg` variants, and the `<table>` block at the end of the README.
- **The example is now the live badge**, not a mock-up of one. The README previously showed a blockquote reading `#6 of 71`, hardcoded — the h1 field is **83** today, so it was already wrong. It now renders the real endpoint directly above the snippet that produces it, and can't go stale again.
- **Dropped the "static badges" section** from `docs/add-framework/badges.md`, which pointed at the README anchor this deletes.

Nothing else in the repo referenced the old badges — checked `httparena-badge`, `jsdelivr`, `wordmark` and `add-the-badge` across the tree; the only remaining jsDelivr hits are Swoole's own logo in two framework READMEs.

The badge repo `MDA2AV/httparena-badge` and its jsDelivr URLs are untouched, so anyone who already pasted a wordmark keeps a working image — this only stops us recommending it.

## Verified

`gen_leaderboard_data.py` + `check_badge_parity.js` still clean on current main:

```
wrote site/generated/badge/ - 222 badges over 135 frameworks
badge parity ok — 222 ranks match site/leaderboard/index.html
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)