### PR TITLE
Badges: link to the whole field, not the single entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Add your GitHub username to the `maintainers` array in your framework's `meta.js
 Benchmarked here? Put your rank in your own README. It re-renders itself every
 time the board is republished, so you paste it once and never touch it again:
 
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
 
 ```md
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
 ```
 
 Swap `actix` for your entry and `h1` for the family you want:
@@ -121,7 +121,8 @@ A few things worth knowing before you paste it:
   is worth showing once there was somebody to beat.
 - **It follows the default board.** Same scoring as the page it links to, with
   the memory-efficiency and rescale toggles off. Follow the link and you land on
-  the view the number came from.
+  the field the rank was measured against — the whole league, not your row on
+  its own, so `#6 of 83` arrives with the other 82 around it.
 - **It updates on deploy, then when GitHub's cache lets it.** README images are
   proxied through Camo, so a new rank can take a few hours to show up.
 

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -22,7 +22,6 @@ import shutil
 import posixpath
 import html as _html
 from pathlib import Path
-from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA = ROOT / "site" / "data"
@@ -1080,16 +1079,27 @@ def badge_composite(agg, profiles, meta, scope, types):
     return rows
 
 
-def _badge_link(fw, scope, types):
-    """Deep link to the exact board view the rank came from. Parameter order and
-    the omit-the-default rule follow writeHash() in index.html, so the URL the
-    badge points at is the one the board would write for that view itself."""
+def _badge_link(scope, types):
+    """Deep link to the board view the rank was taken in — the whole field, not
+    the one entry. Following a badge should show what "#6 of 83" was measured
+    against; filtering to the framework alone just restates the badge.
+
+    Every parameter is written out even where it matches a default, which is
+    where this deliberately parts company with writeHash(). The board restores
+    lb-types and lb-showtuned from localStorage *before* restoreFromHash() runs
+    (index.html:1321-1325), and the hash only overrides what it actually
+    carries — so a link that omits type= lands a returning visitor on whatever
+    league they last filtered to, which for a flagship badge can be a table its
+    framework is not in. Spelling it out costs a few characters and makes the
+    destination independent of the visitor.
+
+    Parameter order still follows writeHash(): scope, type, tuned.
+    """
     parts = []
     if scope != "h1":
         parts.append("scope=" + scope)
-    if sorted(types) != ["emerging", "flagship"]:
-        parts.append("type=" + ",".join(sorted(types)))
-    parts.append("q=" + quote(fw, safe=""))
+    parts.append("type=" + ",".join(sorted(types)))
+    parts.append("tuned=1")
     return SITE + "/#" + "&".join(parts)
 
 
@@ -1147,7 +1157,7 @@ def write_badges(profiles, results, meta):
                 # The maintainer should not have to assemble any of this: the
                 # index carries the finished line to paste, deep-linked to the
                 # view that produced the number.
-                link = _badge_link(fw, scope, types)
+                link = _badge_link(scope, types)
                 shield = ("https://img.shields.io/endpoint?url="
                           f"{SITE}/badge/{slug}/{scope}.json")
                 e = index.setdefault(slug, {"framework": fw, "scopes": {}})

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -14,7 +14,7 @@ itself each time the leaderboard is republished — you paste it once.
 ## Paste it
 
 ```md
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#q=actix)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
 ```
 
 Replace `actix` with your entry and `h1` with the family you want. The exact
@@ -43,7 +43,8 @@ under `markdown`.
 The rank comes from the [composite score](/docs/scoring/composite-score/) for
 that family — the same sum of normalized per-profile scores the board shows,
 computed the same way, at the board's default settings. Following the badge
-lands you on the view it was taken from.
+lands you on the field it was measured against — the whole league for that
+family, not your entry on its own, so `#6 of 83` has the other 82 next to it.
 
 **You are ranked inside your own tier.** `flagship` and `emerging` entries rank
 together as one field, because that is the board's default view. `engine`


### PR DESCRIPTION
The badge linked to `#q=<framework>`, which filters the board down to one row. That restates the badge and hides the thing it's a claim about — `#6 of 83` is only worth following if the other 82 are there.

The link now carries no search filter, so it lands on the league the rank was measured in: **flagship + emerging with tuned shown**, or **all engines** for an engine entry.

| | before | after |
|---|---|---|
| flagship, h1 | `#q=actix` | `#type=emerging,flagship&tuned=1` |
| flagship, h2 | `#scope=h2&q=actix` | `#scope=h2&type=emerging,flagship&tuned=1` |
| engine, h1 | `#type=engine&q=ioxide` | `#type=engine&tuned=1` |
| engine, h3 | `#scope=h3&type=engine&q=ioxide` | `#scope=h3&type=engine&tuned=1` |

Links are now per (family, league) rather than per framework — 14 distinct URLs across all 222 badges.

## Why dropping `q=` alone wasn't enough

The board restores `lb-types` and `lb-showtuned` from localStorage **before** `restoreFromHash()` runs (`index.html:1321-1325`), and the hash only overrides the parameters it actually carries. A link that omitted `type=` would leave a returning visitor in whatever league they last filtered to — so a flagship framework's badge could land someone on the engine table, which its entry isn't in.

So `type=` and `tuned=1` are written out even where they match a default. That's a deliberate departure from `writeHash()`, which omits defaults; the reasoning is in the `_badge_link()` docstring so the next person doesn't "simplify" it back. A few extra characters buys a destination that doesn't depend on the visitor.

## Verified

Not by reading the code — by running it. I lifted `restoreFromHash()` verbatim out of `index.html` and resolved every link shape against the worst-case persisted state (`lb-types=[engine]`, `lb-showtuned=0`):

```
flagship h1  -> scope=h1  types=[emerging,flagship] tuned=true q=""
flagship h2  -> scope=h2  types=[emerging,flagship] tuned=true q=""
engine h1    -> scope=h1  types=[engine]            tuned=true q=""
engine h3    -> scope=h3  types=[engine]            tuned=true q=""
```

Scoring is untouched — parity still clean at 222 badges over 135 frameworks.

README and the badge doc are updated too, since maintainers copy the snippet from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)