### PR TITLE
Badges: colour the label side by the entry's tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ outside `A-Z a-z 0-9 . _ -` turned into `-` — the same name as your file in
 with every rank in it, is at
 [`/badge/index.json`](https://www.http-arena.com/badge/index.json).
 
+The two halves say different things. The right half is how you placed — gold for
+first, then shading down by how far into the field you are. The left half is
+which tier you competed in, in the same colours the board uses for the little
+square next to every framework name:
+
+| | Tier | Ranked against |
+|---|---|---|
+| 🟩 | `flagship` | flagship + emerging, as one field |
+| 🟦 | `emerging` | flagship + emerging, as one field |
+| 🟧 | `experimental` | other experimental entries |
+| 🟥 | `engine` | other engines, on the profiles engines are scored on |
+
 A few things worth knowing before you paste it:
 
 - **The rank is against your own tier.** `flagship` and `emerging` rank together

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -956,6 +956,21 @@ LEAGUES = [("flagship", "emerging"), ("engine",), ("experimental",)]
 # A rank is only worth publishing if something was beaten to earn it.
 BADGE_MIN_FIELD = 2
 
+# Label-side colour, carrying the entry's tier. Same four hues as the board's
+# type swatch next to every framework name, but in the darker tone the board
+# uses for type *text* (.b-* / .type-filter .on in index.html) rather than the
+# swatch fill (.tsq-*). Shields paints badge text white and does not adapt to
+# the background, and the swatch fills fail against it — experimental worst at
+# 2.7:1, flagship 3.4:1. These four all clear 4.5:1 while staying the same
+# colour family the board taught the reader.
+TYPE_COLOR = {
+    "flagship":     "1b7a4e",   # green
+    "emerging":     "2b5694",   # blue
+    "experimental": "8a5a12",   # amber
+    "engine":       "b0463a",   # terracotta
+}
+TYPE_COLOR_FALLBACK = "1f2937"
+
 # api-4/api-16 template mix — MIXW in index.html.
 MIXW = {"baseline": 0.15, "json": 1, "upload": 10, "static": 2, "async_db": 10}
 
@@ -1141,12 +1156,15 @@ def write_badges(profiles, results, meta):
                     rank = i + 1
                 prev_score, prev_rank = score, rank
                 slug = _slug(fw)
+                # Two independent readings: the label side is which tier the
+                # entry competes in, the message side is how it placed there.
+                tier = meta.get(fw, {}).get("type", "emerging")
                 doc = {
                     "schemaVersion": 1,
                     "label": "HTTP Arena " + FAMILY_LABEL[scope],
                     "message": f"#{rank} of {total}",
                     "color": _badge_color(rank, total),
-                    "labelColor": "1f2937",
+                    "labelColor": TYPE_COLOR.get(tier, TYPE_COLOR_FALLBACK),
                     "cacheSeconds": 3600,
                 }
                 path = BADGE_OUT / slug / f"{scope}.json"
@@ -1160,7 +1178,7 @@ def write_badges(profiles, results, meta):
                 link = _badge_link(scope, types)
                 shield = ("https://img.shields.io/endpoint?url="
                           f"{SITE}/badge/{slug}/{scope}.json")
-                e = index.setdefault(slug, {"framework": fw, "scopes": {}})
+                e = index.setdefault(slug, {"framework": fw, "type": tier, "scopes": {}})
                 e["scopes"][scope] = {
                     "rank": rank, "of": total, "score": round(score, 1),
                     "link": link,

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -38,6 +38,23 @@ under `markdown`.
 `site/data/results/`, so `aspnet-minimal + nginx` becomes
 `aspnet-minimal-nginx`.
 
+## What the colours mean
+
+The two halves are read separately. The **right** half is placement — gold for
+first, then shading down by how far into the field the entry sits. The **left**
+half is the tier it competed in, in the same four colours the board uses for the
+type swatch beside every framework name:
+
+| | Tier | Ranked against |
+|---|---|---|
+| 🟩 | `flagship` | flagship + emerging, as one field |
+| 🟦 | `emerging` | flagship + emerging, as one field |
+| 🟧 | `experimental` | other experimental entries |
+| 🟥 | `engine` | other engines, on the profiles engines are scored on |
+
+The tier is also in [`/badge/index.json`](https://www.http-arena.com/badge/index.json)
+as `type`, next to each entry's ranks.
+
 ## What the number means
 
 The rank comes from the [composite score](/docs/scoring/composite-score/) for


### PR DESCRIPTION
The badge said how an entry placed but not what it placed *among*, so a `#1` read the same whether it was won against 83 flagship entries or 2 experimental ones. The label side now carries the tier, which leaves the two halves answering separate questions: **which league**, and **where in it**.

| | Tier | `labelColor` | Ranked against |
|---|---|---|---|
| 🟩 | `flagship` | `#1b7a4e` | flagship + emerging, as one field |
| 🟦 | `emerging` | `#2b5694` | flagship + emerging, as one field |
| 🟧 | `experimental` | `#8a5a12` | other experimental entries |
| 🟥 | `engine` | `#b0463a` | other engines, on the profiles engines are scored on |

Covers all 222 badges: 54 flagship, 40 emerging, 38 engine, 3 experimental.

## On the exact colours

These are the four hues the board already uses for the type swatch next to every framework name, so the badge and the row it links to agree — but in the **darker tone** the board uses for type *text* (`.b-*`), not the swatch fill (`.tsq-*`).

That's not an arbitrary substitution. Shields paints badge text white and does **not** adapt it to the background, so the swatch fills lose against it:

```
                swatch (.tsq-*)      text tone (.b-*)
flagship        #2e9e6a  3.38:1      #1b7a4e  5.33:1
emerging        #3b73c4  4.73:1      #2b5694  7.34:1
experimental    #d98e2b  2.67:1  ←   #8a5a12  5.91:1
engine          #cb5f51  3.97:1      #b0463a  5.55:1
```

WCAG wants 4.5:1 for small text. Three of the four swatch fills fail it, experimental badly. The text tones all clear it in the same hue, so the colour stays recognisable to anyone who has looked at the board.

Verified against live shields renders — the label rect comes back `fill="#1b7a4e"` etc. for each tier.

## Legend

`index.json` now carries `type` per entry, and both the README and the badge doc carry the colour key. A colour nobody can decode is decoration.

## One limitation worth naming

This is colour-only, which is not an accessible distinction on its own — the four hues are green / blue / amber / red, and deuteranopia will blur green↔amber↔red. Shields generates the badge's `aria-label` from label + message, so I can't inject the tier word into the image.

The fix, if you want it, is putting the tier in the text: `HTTP Arena H/1.1 · flagship`. That makes every badge ~60px wider, which is why I didn't do it unasked — say the word and it's a one-line change.

Scoring untouched; parity clean at 222 badges over 135 frameworks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)