### PR TITLE
Badges: count the field the way the board does

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ A few things worth knowing before you paste it:
 - **It only exists where you scored.** No result in a family means no badge for
   it, and a family with a single entry in your tier publishes nothing — a rank
   is worth showing once there was somebody to beat.
+- **The field is every row the board lists.** `of 31` is what you get counting
+  engine rows on the linked page, including any entry sitting at 0 because
+  nothing it ran scores for its tier. Those occupy a place in the field but get
+  no badge of their own.
 - **It follows the default board.** Same scoring as the page it links to, with
   the memory-efficiency and rescale toggles off. Follow the link and you land on
   the field the rank was measured against — the whole league, not your row on

--- a/scripts/check_badge_parity.js
+++ b/scripts/check_badge_parity.js
@@ -81,9 +81,13 @@ const FAMILIES = ['h1', 'h2', 'h3', 'gw', 'grpc', 'ws'];
 const LEAGUES = [['flagship', 'emerging'], ['engine'], ['experimental']];
 const MIN_FIELD = 2;
 
+// NO score filter here. An earlier version dropped rows scoring 0 before
+// comparing, which is exactly what the generator was doing wrong — so the check
+// compared a filtered board against an identically-filtered port and passed
+// while the published field was one short of the board's. Whatever the board
+// renders as a row is the field, and that is what gets compared.
 function ranked(scope, types) {
   const rows = run(scope, types).rows
-    .filter(r => r.score > 0)
     .sort((a, b) => (b.score - a.score) || (a.fw < b.fw ? -1 : a.fw > b.fw ? 1 : 0));
   const out = new Map();
   let prevScore = null, prevRank = 0;
@@ -109,6 +113,12 @@ for (const scope of FAMILIES) {
       const got = emitted[slug(fw)] && emitted[slug(fw)].scopes[scope];
       if (e.of < MIN_FIELD) {
         if (got) problems.push(`${fw} ${scope}: badge emitted for a field of ${e.of} (min ${MIN_FIELD})`);
+        continue;
+      }
+      // Counted in the field, but deliberately given no badge of its own —
+      // nothing it ran scores in this family, so it has no placing to claim.
+      if (e.score <= 0) {
+        if (got) problems.push(`${fw} ${scope}: badge emitted for an entry scoring 0`);
         continue;
       }
       checked++;

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -1083,12 +1083,21 @@ def badge_composite(agg, profiles, meta, scope, types):
     for fw in fwset:
         if not in_league(fw):
             continue
-        score = 0.0
+        score, any_result = 0.0, False
         for pid in pids:
             rps = A["avg"].get(pid, {}).get(fw, 0)
-            if rps > 0 and max_r[pid] > 0 and is_scored(pid, fw):
-                score += (eff(pid, fw) / max_r[pid]) * 100
-        if score > 0:
+            if rps > 0 and max_r[pid] > 0:
+                # `any_result` is the board's row test and is deliberately wider
+                # than the score: an entry whose only results in this family sit
+                # on profiles that do not count for its tier still occupies a
+                # row, at 0. pico is one — an engine whose h1 results are json
+                # (not engineScored) and pipelined (reference-only). Dropping
+                # those rows here made the badge's field one short of what the
+                # board renders, which is a number people can count (#1149).
+                any_result = True
+                if is_scored(pid, fw):
+                    score += (eff(pid, fw) / max_r[pid]) * 100
+        if any_result:
             rows.append((fw, score))
     rows.sort(key=lambda r: (-r[1], r[0]))
     return rows
@@ -1155,6 +1164,11 @@ def write_badges(profiles, results, meta):
                 else:
                     rank = i + 1
                 prev_score, prev_rank = score, rank
+                # Counted in the field above, but no badge of its own: a 0 here
+                # means the entry ran nothing that scores in this family, so a
+                # "#31 of 31" would read as a placing it never competed for.
+                if score <= 0:
+                    continue
                 slug = _slug(fw)
                 # Two independent readings: the label side is which tier the
                 # entry competes in, the message side is how it placed there.

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -73,6 +73,13 @@ engine's result, or the reverse.
 for that family. A family where your tier holds a single entry publishes
 nothing — a rank is worth showing once there was somebody to beat.
 
+**The field is every row the board lists.** `#1 of 31` is the number you get
+counting rows in that league on the linked page. That includes entries sitting
+at 0 because nothing they ran counts for their tier — an engine whose only
+HTTP/1.1 results are `json` (not scored for engines) and `pipelined`
+(reference-only) still holds a place in the field. Those entries are counted,
+but get no badge of their own: there is no placing to claim.
+
 ## Freshness
 
 The endpoints are regenerated whenever the site deploys. After that, GitHub


### PR DESCRIPTION
`ioxide`'s badge read **#1 of 30** while the engine column on the page it links to has **31 rows**. Reported by @MDA2AV after pasting it into [MDA2AV/ioxide](https://github.com/MDA2AV/ioxide) — the denominator is a number people can count, and it didn't match.

## The 31st row

`pico`. An engine whose only HTTP/1.1 results are:

- `json` — a scored profile, but `engineScored: false`, so it doesn't count for an engine
- `pipelined` — reference-only, doesn't count for anyone

So it sums to 0. The board still lists it, because a row appears once an entry has *any* result in the family (`any` in `computeComposite()`). The generator counted only entries that scored, so its field came up one short.

The field is now what the board renders. Entries at 0 are **counted but still get no badge**: nothing they ran scores in that family, so `#31 of 31` would read as a placing they never competed for. That rule is now stated in the README and the doc rather than being an unexplained off-by-one in the other direction.

Only `h1`/engine changes today — 30 badges, `of 30` → `of 31`. No rank moves.

## The parity check was passing vacuously

Worth flagging, because it's the more useful half of this. `check_badge_parity.js` had the **same `score > 0` filter** as the generator:

```js
const rows = run(scope, types).rows
  .filter(r => r.score > 0)      // ← the exact bug, on both sides
```

So it compared a filtered board against an identically-filtered port and reported `222 ranks match` while the published field was wrong. A check that shares its subject's assumption isn't a check.

The filter is gone; whatever the board renders as a row is now the field being compared. The publish-nothing-at-0 rule is **asserted separately** — `if (e.score <= 0) { if (got) problem(...) }` — rather than filtered out, so the exclusion is verified instead of assumed.

Confirmed it now bites: restoring the old field rule produces 30 disagreements and exit 1.

```
ioxide h1: badge says #1 of 30, board says #1 of 31
sark   h1: badge says #2 of 30, board says #2 of 31
... 28 more
```

Clean after the fix — 222 badges over 135 frameworks, `pico` counted in the field and absent from the index.

## After merge

The deploy regenerates on push, but GitHub's Camo cache means the 30 affected READMEs will keep showing `of 30` for a few hours. Nothing to do; it corrects itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)