### PR TITLE
Badges: optional rank among the same language

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ outside `A-Z a-z 0-9 . _ -` turned into `-` — the same name as your file in
 with every rank in it, is at
 [`/badge/index.json`](https://www.http-arena.com/badge/index.json).
 
+### Ranked among your own language
+
+Optional. Append `-<language>` to the family for a badge reading
+**`#1 of 6 (Rust)`** — same scores and same order, counting only entries in your
+language:
+
+```md
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1&lang=Rust)
+```
+
+The language is lowercased, with `#` spelled `sharp` and `++` spelled `pp` — so
+`C#` is `csharp`, `C++` is `cpp`, `TS` is `ts`. It links to the board filtered to
+that language, so the field is the one you can count there. Your line is in
+`index.json` under `scopes.<family>.byLanguage.markdown`.
+
 The two halves say different things. The right half is how you placed — gold for
 first, then shading down by how far into the field you are. The left half is
 which tier you competed in, in the same colours the board uses for the little

--- a/scripts/check_badge_parity.js
+++ b/scripts/check_badge_parity.js
@@ -56,13 +56,17 @@ const D = window.LB_DATA;
 // Everything the lifted code reaches for that lives elsewhere in the page.
 // state is pinned to the board's defaults — the view a visitor lands on when
 // they follow the badge and touch nothing.
+// langOf is real here, not a stub returning '': the board's state.lang filter
+// goes through it, and the language rank badges are checked against that filter.
 const stubs = `
   var PROF = {}; D.profiles.forEach(function(p){ PROF[p.id]=p; });
+  var FWLANG = {};
+  Object.keys(D.results).forEach(function(k){ D.results[k].forEach(function(r){ if(r.lang) FWLANG[r.fw]=r.lang; }); });
   function typeOf(fw){ return (D.meta[fw] && D.meta[fw].type) || 'emerging'; }
   function modeOf(fw){ return (D.meta[fw] && D.meta[fw].mode) || 'standard'; }
-  function langOf(fw){ return ''; }
+  function langOf(fw){ return FWLANG[fw] || ''; }
   function matchQ(fw){ return true; }              // state.q is '' — no search filter
-  var state = { useMem:false, rescale:false, showTuned:true, q:'', scope:'h1', types:[] };
+  var state = { useMem:false, rescale:false, showTuned:true, q:'', lang:'', scope:'h1', types:[] };
 `;
 const run = new Function('D', `
   ${stubs}
@@ -70,8 +74,8 @@ const run = new Function('D', `
   ${memFn}
   ${bwFn}
   ${composite}
-  return function(scope, types){
-    state.scope = scope; state.types = types;   // AGG is state-independent, so its cache is safe
+  return function(scope, types, lang){
+    state.scope = scope; state.types = types; state.lang = lang || '';   // AGG is state-independent, so its cache is safe
     return computeComposite();
   };
 `)(D);
@@ -86,8 +90,8 @@ const MIN_FIELD = 2;
 // compared a filtered board against an identically-filtered port and passed
 // while the published field was one short of the board's. Whatever the board
 // renders as a row is the field, and that is what gets compared.
-function ranked(scope, types) {
-  const rows = run(scope, types).rows
+function ranked(scope, types, lang) {
+  const rows = run(scope, types, lang).rows
     .sort((a, b) => (b.score - a.score) || (a.fw < b.fw ? -1 : a.fw > b.fw ? 1 : 0));
   const out = new Map();
   let prevScore = null, prevRank = 0;
@@ -98,6 +102,11 @@ function ranked(scope, types) {
   });
   return out;
 }
+
+// Every language present, from the same rows the board reads it from.
+const FWLANG = {};
+Object.keys(D.results).forEach(k => D.results[k].forEach(r => { if (r.lang) FWLANG[r.fw] = r.lang; }));
+const LANGS = [...new Set(Object.values(FWLANG))].sort();
 
 // Same rule as _slug() in gen_leaderboard_data.py / rebuild_site_data.py.
 const slug = n => (n.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'unnamed').toLowerCase();
@@ -128,6 +137,26 @@ for (const scope of FAMILIES) {
       }
       if (Math.abs(got.score - e.score) > 0.05) {
         problems.push(`${fw} ${scope}: badge score ${got.score}, board score ${e.score.toFixed(1)}`);
+      }
+    }
+
+    // The language variant, checked against the board's own lang= filter rather
+    // than against a subset this script computes — otherwise "#1 of 6 (Rust)"
+    // would only ever be compared with itself.
+    for (const lang of LANGS) {
+      const expect = ranked(scope, types, lang);
+      for (const [fw, e] of expect) {
+        const got = emitted[slug(fw)] && emitted[slug(fw)].scopes[scope]
+                 && emitted[slug(fw)].scopes[scope].byLanguage;
+        if (e.of < MIN_FIELD || e.score <= 0) {
+          if (got) problems.push(`${fw} ${scope} (${lang}): badge emitted for a field of ${e.of}, score ${e.score.toFixed(1)}`);
+          continue;
+        }
+        checked++;
+        if (!got) { problems.push(`${fw} ${scope} (${lang}): board ranks it #${e.rank} of ${e.of}, no language badge emitted`); continue; }
+        if (got.rank !== e.rank || got.of !== e.of) {
+          problems.push(`${fw} ${scope} (${lang}): badge says #${got.rank} of ${got.of}, board says #${e.rank} of ${e.of}`);
+        }
       }
     }
   }

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -22,6 +22,7 @@ import shutil
 import posixpath
 import html as _html
 from pathlib import Path
+from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA = ROOT / "site" / "data"
@@ -1103,7 +1104,25 @@ def badge_composite(agg, profiles, meta, scope, types):
     return rows
 
 
-def _badge_link(scope, types):
+def _lang_slug(lang):
+    """URL segment for a language name. Not _slug(): that maps C, C# and C++ all
+    onto "c", so a C# entry's badge would sit at .../h1-c.json. The punctuation
+    is spelled out first, which is also how these read aloud."""
+    s = lang.lower().replace("++", "pp").replace("#", "sharp")
+    return re.sub(r"[^a-z0-9._-]+", "-", s).strip("-") or "unknown"
+
+
+def _fw_languages(results):
+    """framework -> language, from the result rows the board itself reads."""
+    lang = {}
+    for rows in results.values():
+        for r in rows:
+            if r.get("lang"):
+                lang[r["fw"]] = r["lang"]
+    return lang
+
+
+def _badge_link(scope, types, lang=None):
     """Deep link to the board view the rank was taken in — the whole field, not
     the one entry. Following a badge should show what "#6 of 83" was measured
     against; filtering to the framework alone just restates the badge.
@@ -1124,6 +1143,11 @@ def _badge_link(scope, types):
         parts.append("scope=" + scope)
     parts.append("type=" + ",".join(sorted(types)))
     parts.append("tuned=1")
+    if lang:
+        # lang=, not q=. The search box matches substrings across name, language
+        # and engine, so q=C pulls in 73 of 78 entries and q=V pulls 33 — the
+        # denominator would not survive being counted.
+        parts.append("lang=" + quote(lang, safe=""))
     return SITE + "/#" + "&".join(parts)
 
 
@@ -1143,61 +1167,101 @@ def _badge_color(rank, total):
 
 
 def write_badges(profiles, results, meta):
-    """One shields.io endpoint document per (framework, family) it ranks in,
-    at /badge/<framework>/<family>.json, plus an index of everything written."""
+    """shields.io endpoint documents, plus an index of everything written.
+
+    Two badges per (framework, family): the overall rank in its tier at
+    /badge/<framework>/<family>.json, and — optional, for maintainers who want
+    it — its rank among entries in the same language, at
+    /badge/<framework>/<family>-<language>.json, reading "#1 of 17 (JS)".
+
+    The language variant is a filter, not a rescore: same scores, same order,
+    counting only same-language entries. That is what the board does with a
+    language filter and rescale off, so the two still agree.
+    """
     if BADGE_OUT.exists():
         shutil.rmtree(BADGE_OUT)
     agg = badge_aggregate(profiles, results)
+    fw_lang = _fw_languages(results)
+
+    # A language added later must not land on an existing slug — two languages
+    # sharing one would silently overwrite each other's badges.
+    by_slug = {}
+    for lang in sorted(set(fw_lang.values())):
+        by_slug.setdefault(_lang_slug(lang), []).append(lang)
+    clashes = {s: v for s, v in by_slug.items() if len(v) > 1}
+    if clashes:
+        raise SystemExit(f"badge: languages share a URL slug, fix _lang_slug(): {clashes}")
 
     index, written = {}, 0
+
+    def emit(fw, slug, tier, scope, types, rank, total, score, lang=None):
+        """One endpoint document + its index entry."""
+        nonlocal written
+        suffix = f"-{_lang_slug(lang)}" if lang else ""
+        name = f"{scope}{suffix}"
+        doc = {
+            "schemaVersion": 1,
+            "label": "HTTP Arena " + FAMILY_LABEL[scope],
+            "message": f"#{rank} of {total}" + (f" ({lang})" if lang else ""),
+            "color": _badge_color(rank, total),
+            "labelColor": TYPE_COLOR.get(tier, TYPE_COLOR_FALLBACK),
+            "cacheSeconds": 3600,
+        }
+        path = BADGE_OUT / slug / f"{name}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc, separators=(",", ":")) + "\n", encoding="utf-8")
+        written += 1
+        # The maintainer should not have to assemble any of this: the index
+        # carries the finished line to paste, deep-linked to the view that
+        # produced the number.
+        link = _badge_link(scope, types, lang)
+        shield = f"https://img.shields.io/endpoint?url={SITE}/badge/{slug}/{name}.json"
+        e = index.setdefault(slug, {"framework": fw, "type": tier,
+                                    "language": fw_lang.get(fw, ""), "scopes": {}})
+        entry = {"rank": rank, "of": total, "score": round(score, 1), "link": link,
+                 "markdown": f"[![HTTP Arena {FAMILY_LABEL[scope]}]({shield})]({link})"}
+        if lang:
+            e["scopes"].setdefault(scope, {})["byLanguage"] = entry
+        else:
+            entry["byLanguage"] = e["scopes"].get(scope, {}).get("byLanguage")
+            if entry["byLanguage"] is None:
+                del entry["byLanguage"]
+            e["scopes"][scope] = entry
+
+    def ranked(rows):
+        """(fw, rank, total, score) with competition ranking — ties share a rank."""
+        out, prev_score, prev_rank = [], None, 0
+        for i, (fw, score) in enumerate(rows):
+            rank = prev_rank if (prev_score is not None and abs(prev_score - score) < 1e-9) else i + 1
+            prev_score, prev_rank = score, rank
+            out.append((fw, rank, len(rows), score))
+        return out
+
     for scope in FAMILY_LABEL:
         for types in LEAGUES:
             rows = badge_composite(agg, profiles, meta, scope, types)
-            total = len(rows)
-            if total < BADGE_MIN_FIELD:
-                continue    # "#1 of 1" says nothing; skip until the field fills out
-            prev_score, prev_rank = None, 0
-            for i, (fw, score) in enumerate(rows):
-                # Competition ranking: equal scores share a rank (1, 2, 2, 4).
-                if prev_score is not None and abs(prev_score - score) < 1e-9:
-                    rank = prev_rank
-                else:
-                    rank = i + 1
-                prev_score, prev_rank = score, rank
-                # Counted in the field above, but no badge of its own: a 0 here
-                # means the entry ran nothing that scores in this family, so a
-                # "#31 of 31" would read as a placing it never competed for.
-                if score <= 0:
+            if len(rows) >= BADGE_MIN_FIELD:
+                for fw, rank, total, score in ranked(rows):
+                    # Counted in the field above, but no badge of its own: a 0
+                    # means the entry ran nothing that scores in this family, so
+                    # "#31 of 31" would read as a placing it never competed for.
+                    if score <= 0:
+                        continue
+                    emit(fw, _slug(fw), meta.get(fw, {}).get("type", "emerging"),
+                         scope, types, rank, total, score)
+
+            # Same league, same scores, narrowed to one language — re-ranked
+            # within that subset rather than rescored, so a language badge and
+            # the overall one can never disagree about who is ahead of whom.
+            for lang in sorted({fw_lang.get(fw, "") for fw, _ in rows} - {""}):
+                sub = [(fw, sc) for fw, sc in rows if fw_lang.get(fw) == lang]
+                if len(sub) < BADGE_MIN_FIELD:
                     continue
-                slug = _slug(fw)
-                # Two independent readings: the label side is which tier the
-                # entry competes in, the message side is how it placed there.
-                tier = meta.get(fw, {}).get("type", "emerging")
-                doc = {
-                    "schemaVersion": 1,
-                    "label": "HTTP Arena " + FAMILY_LABEL[scope],
-                    "message": f"#{rank} of {total}",
-                    "color": _badge_color(rank, total),
-                    "labelColor": TYPE_COLOR.get(tier, TYPE_COLOR_FALLBACK),
-                    "cacheSeconds": 3600,
-                }
-                path = BADGE_OUT / slug / f"{scope}.json"
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(json.dumps(doc, separators=(",", ":")) + "\n",
-                                encoding="utf-8")
-                written += 1
-                # The maintainer should not have to assemble any of this: the
-                # index carries the finished line to paste, deep-linked to the
-                # view that produced the number.
-                link = _badge_link(scope, types)
-                shield = ("https://img.shields.io/endpoint?url="
-                          f"{SITE}/badge/{slug}/{scope}.json")
-                e = index.setdefault(slug, {"framework": fw, "type": tier, "scopes": {}})
-                e["scopes"][scope] = {
-                    "rank": rank, "of": total, "score": round(score, 1),
-                    "link": link,
-                    "markdown": f"[![HTTP Arena {FAMILY_LABEL[scope]}]({shield})]({link})",
-                }
+                for fw, rank, total, score in ranked(sub):
+                    if score <= 0:
+                        continue
+                    emit(fw, _slug(fw), meta.get(fw, {}).get("type", "emerging"),
+                         scope, types, rank, total, score, lang)
 
     BADGE_OUT.mkdir(parents=True, exist_ok=True)
     (BADGE_OUT / "index.json").write_text(

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -38,6 +38,27 @@ under `markdown`.
 `site/data/results/`, so `aspnet-minimal + nginx` becomes
 `aspnet-minimal-nginx`.
 
+## Ranked among your own language
+
+Optional, and a second badge rather than a replacement. Append `-<language>` to
+the family and the badge reads **`#1 of 6 (Rust)`**:
+
+```md
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1&lang=Rust)
+```
+
+The language segment is the board's own language name, lowercased, with `#`
+spelled out as `sharp` and `++` as `pp`: `C#` → `csharp`, `C++` → `cpp`,
+`TS` → `ts`, `JS` → `js`. Your ready-made line is in
+[`/badge/index.json`](https://www.http-arena.com/badge/index.json) under
+`scopes.<family>.byLanguage.markdown`.
+
+This is a **filter, not a rescore**. Scores and order are identical to the
+overall badge; only the field is narrowed, so the two can never disagree about
+who is ahead of whom. The link opens the board filtered to that language —
+`#lang=Rust` — which is an exact match, unlike the search box, so the field on
+the page is the field the badge claims.
+
 ## What the colours mean
 
 The two halves are read separately. The **right** half is placement — gold for

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -503,7 +503,12 @@
   function familyOf(p){ return {'Gateway':'gw','HTTP/2':'h2','HTTP/3':'h3','gRPC':'grpc','WebSocket':'ws'}[p.category]||'h1'; }
   var FAMILIES=[{k:'h1',label:'HTTP/1.1',cats:['Connection','Workload','Database','Multi-endpoint']},{k:'h2',label:'HTTP/2',cats:['HTTP/2']},{k:'h3',label:'HTTP/3',cats:['HTTP/3']},{k:'gw',label:'Gateway',cats:['Gateway']},{k:'grpc',label:'gRPC',cats:['gRPC']},{k:'ws',label:'WebSocket',cats:['WebSocket']}];
   var expanded=new Set(['composite']);
-  var state = { view:'composite', profile:null, conns:null, sortKey:'rps', sortDir:-1, types:['flagship','emerging'], q:'', useMem:false, scope:'h1', showTuned:true, rescale:false };
+  // state.lang is an exact language filter, distinct from the q search box: q
+  // matches substrings across name/language/engine, which is fine for typing but
+  // useless as an addressable filter - q=C matches 73 of 78 entries, q=V matches
+  // 33. The language rank badges link here, so the field they claim has to be
+  // the field the page shows.
+  var state = { view:'composite', profile:null, conns:null, sortKey:'rps', sortDir:-1, types:['flagship','emerging'], q:'', lang:'', useMem:false, scope:'h1', showTuned:true, rescale:false };
 
   // ── parsing helpers ──────────────────────────────────────
   function lat(s){ if(!s) return Infinity; var m=String(s).match(/([\d.]+)\s*(us|ms|s)/); if(!m) return Infinity; var v=parseFloat(m[1]); return m[2]==='us'?v:m[2]==='ms'?v*1e3:v*1e6; }
@@ -887,7 +892,7 @@
   }
 
   function pickScope(scope){
-    state.view='composite'; state.scope=scope; state.sortKey='score'; state.sortDir=-1; state.q=''; document.getElementById('q').value='';
+    state.view='composite'; state.scope=scope; state.sortKey='score'; state.sortDir=-1; state.q=''; state.lang=''; document.getElementById('q').value='';
     expanded.add('composite');
     buildNav(); renderHead(); render();
   }
@@ -933,6 +938,16 @@
       rs.setAttribute('data-tip','Off: each profile is worth 100 to the best entry in the whole field, so scores stay comparable while you filter. On: rescale to the frameworks currently shown, to compare a subset against itself.');
       rs.onclick=function(){ state.rescale=!state.rescale; rs.classList.toggle('on', state.rescale); render(); };
       ctl.appendChild(rs);
+      // Arriving on #lang=X (from a language rank badge) filters the board to
+      // one language. Say so, and make it one click to leave - a filter with no
+      // visible cause reads as missing data.
+      if(state.lang){
+        var lf=document.createElement('div'); lf.className='toggle on';
+        lf.innerHTML='<span class="sw"><i></i></span> '+esc(state.lang)+' only';
+        lf.setAttribute('data-tip','Showing only '+esc(state.lang)+' entries. Click to show every language again.');
+        lf.onclick=function(){ state.lang=''; renderHead(); render(); };
+        ctl.appendChild(lf);
+      }
     } else {
       var p=PROF[state.profile];
       cat.textContent=p.category; title.textContent=p.label;
@@ -1047,7 +1062,7 @@
     // once filtered to Ruby). The `rescale` toggle restores that behaviour for
     // when comparing a subset against itself is the point.
     function outOfLeague(fw){ return state.types.indexOf(typeOf(fw))<0; }
-    function hidden(fw){ if(!state.showTuned && modeOf(fw)==='tuned') return true; return !matchQ(fw); }
+    function hidden(fw){ if(!state.showTuned && modeOf(fw)==='tuned') return true; if(state.lang && langOf(fw)!==state.lang) return true; return !matchQ(fw); }
     function excl(fw){ return outOfLeague(fw) || hidden(fw); }
     var exclFromScale = state.rescale ? excl : outOfLeague;
     var minBpr=null;
@@ -1121,6 +1136,7 @@
     if(!defSort) p.push('sort='+state.sortKey+':'+state.sortDir);
     var ts=state.types.slice().sort().join(','); if(ts!=='emerging,flagship') p.push('type='+ts);
     if(!state.showTuned) p.push('tuned=0');
+    if(state.lang) p.push('lang='+encodeURIComponent(state.lang));
     if(state.q) p.push('q='+encodeURIComponent(state.q));
     var nh=p.length?('#'+p.join('&')):'';
     if(location.hash!==nh){ try{ history.replaceState(null,'', nh||(location.pathname+location.search)); }catch(e){} }
@@ -1132,6 +1148,7 @@
     if(p.doc){ location.replace(docUrl(p.doc)); return; }   // legacy #doc=x bookmark -> /docs/x/
     if(p.type){ var ts=p.type.split(',').filter(Boolean); if(ts.length) state.types=ts; }
     if(p.hasOwnProperty('tuned')) state.showTuned = p.tuned!=='0';
+    state.lang = p.lang || '';
     state.q = p.q || '';
     if(p.p && PROF[p.p]){
       state.view='profile'; state.profile=p.p;


### PR DESCRIPTION
A second badge per family, reading **`#1 of 6 (Rust)`**. Opt-in — the overall badge is unchanged and nobody has to move.

```md
[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1&lang=Rust)
```

404 badges now, up from 222. The language segment is the board's own name lowercased — the data already stores `JS`, `TS`, `C#`, so no abbreviations had to be invented.

**It's a filter, not a rescore.** Same scores, same order, counting only same-language entries. So the language badge and the overall one can never disagree about who is ahead of whom.

## The board needed an exact language filter

The obvious link is `#q=Rust`, and it doesn't work. `matchQ` matches substrings across name, language *and* engine, so as an addressable filter it's unusable:

```
language   exact   q=<lang> matches
C            3  ->  73     +actix, aleph, aspnet-minimal, aspnet-mvc …
V            7  ->  33     +bjoern, Cardigan, django, fastapi …
TS           5  ->   9     +fastendpoints, fulmine, ultimate-express …
JS           7  ->  10     +elysia, hono-bun, nestjs
Go           6  ->   8     +django, drogon
```

A badge claiming "of 6" has to land somewhere you can count six — that's the #1153 lesson. So `state.lang` is a new **exact** filter: separate from the search box, round-trips through the hash, cleared by any nav click, and rendered as a labelled toggle so an arriving visitor sees *why* the board is filtered and can leave in one click. A filter with no visible cause reads as missing data.

Verified by running the board's own `restoreFromHash()` + `writeHash()`:

```
#type=engine&tuned=1&lang=C%23  ->  lang="C#" scope=h1 types=[engine] tuned=true
                                out: #type=engine&lang=C%23
```

## A slug trap

Language URLs deliberately don't use `_slug()`. It maps `C`, `C#` and `C++` all onto `"c"` — a C# entry's badge would have sat at `.../h1-c.json`. `_lang_slug` spells the punctuation out (`csharp`, `cpp`), and generation now **aborts** if two languages ever collide on one slug, so adding a language can't silently overwrite another's badges.

No file collision existed (badges are per-framework directories), but the URL would have been a lie.

## Parity

The language ranks are checked against **the board's own `lang=` filter**, not against a subset this script computes — otherwise `#1 of 6 (Rust)` would only ever be compared with itself, which is the trap the checker fell into in #1153. Its `langOf` stub is now the real one rather than `() => ''`.

```
badge parity ok — 404 ranks match site/leaderboard/index.html
```

Confirmed it bites: making a language badge report the overall field size produces 180 disagreements and exit 1.

```
genhttp-11-ioxide h1 (C#): badge says #1 of 83, board says #1 of 14
```

## Note

This touches `site/leaderboard/index.html`, which every other badge depends on through the parity check — worth a look at the `lang=` toggle in the UI before merging, since that's the part I can verify logically but not visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)