### PR TITLE
Badges: exclude tuned entries by default (re-targets #1155 at main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Add your GitHub username to the `maintainers` array in your framework's `meta.js
 Benchmarked here? Put your rank in your own README. It re-renders itself every
 time the board is republished, so you paste it once and never touch it again:
 
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=0)
 
 ```md
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=0)
 ```
 
 Swap `actix` for your entry and `h1` for the family you want:
@@ -117,13 +117,30 @@ Optional. Append `-<language>` to the family for a badge reading
 language:
 
 ```md
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1&lang=Rust)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=0&lang=Rust)
 ```
 
 The language is lowercased, with `#` spelled `sharp` and `++` spelled `pp` — so
 `C#` is `csharp`, `C++` is `cpp`, `TS` is `ts`. It links to the board filtered to
 that language, so the field is the one you can count there. Your line is in
 `index.json` under `scopes.<family>.byLanguage.markdown`.
+
+### Counting tuned entries in
+
+Also optional. By default the field is **standard configurations only**, so the
+number compares like for like. Append `-with-tuned` to count tuned entries too:
+
+```md
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-with-tuned.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
+```
+
+It combines with the language suffix — `h1-rust-with-tuned.json`. Every variant
+is in `index.json` under `scopes.<family>`, keyed `default`, `withTuned`,
+`byLanguage` and `byLanguageWithTuned`.
+
+If your own entry is tuned, its default URL already counts tuned entries — it
+cannot be ranked in a field it is excluded from — so `h1.json` and
+`h1-with-tuned.json` give it the same number.
 
 The two halves say different things. The right half is how you placed — gold for
 first, then shading down by how far into the field you are. The left half is

--- a/scripts/check_badge_parity.js
+++ b/scripts/check_badge_parity.js
@@ -74,8 +74,11 @@ const run = new Function('D', `
   ${memFn}
   ${bwFn}
   ${composite}
-  return function(scope, types, lang){
-    state.scope = scope; state.types = types; state.lang = lang || '';   // AGG is state-independent, so its cache is safe
+  return function(scope, types, lang, showTuned){
+    // AGG is state-independent, so its cache survives these being flipped.
+    state.scope = scope; state.types = types;
+    state.lang = lang || '';
+    state.showTuned = !!showTuned;
     return computeComposite();
   };
 `)(D);
@@ -90,8 +93,8 @@ const MIN_FIELD = 2;
 // compared a filtered board against an identically-filtered port and passed
 // while the published field was one short of the board's. Whatever the board
 // renders as a row is the field, and that is what gets compared.
-function ranked(scope, types, lang) {
-  const rows = run(scope, types, lang).rows
+function ranked(scope, types, lang, showTuned) {
+  const rows = run(scope, types, lang, showTuned).rows
     .sort((a, b) => (b.score - a.score) || (a.fw < b.fw ? -1 : a.fw > b.fw ? 1 : 0));
   const out = new Map();
   let prevScore = null, prevRank = 0;
@@ -112,63 +115,65 @@ const LANGS = [...new Set(Object.values(FWLANG))].sort();
 const slug = n => (n.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'unnamed').toLowerCase();
 
 const emitted = JSON.parse(fs.readFileSync(INDEX, 'utf8'));
+const isTuned = fw => (D.meta[fw] && D.meta[fw].mode) === 'tuned';
 const problems = [];
 let checked = 0;
 
+// Which key in index.json a given (language, tuned) combination should land on.
+function indexKey(lang, withTuned) {
+  if (lang) return withTuned ? 'byLanguageWithTuned' : 'byLanguage';
+  return withTuned ? 'withTuned' : 'default';
+}
+
+// Every published combination, checked against the board configured the same
+// way. The board is the authority for all four — nothing here recomputes a
+// subset of its own, which is how the field count went wrong in #1153.
 for (const scope of FAMILIES) {
   for (const types of LEAGUES) {
-    const expect = ranked(scope, types);
-    for (const [fw, e] of expect) {
-      const got = emitted[slug(fw)] && emitted[slug(fw)].scopes[scope];
-      if (e.of < MIN_FIELD) {
-        if (got) problems.push(`${fw} ${scope}: badge emitted for a field of ${e.of} (min ${MIN_FIELD})`);
-        continue;
-      }
-      // Counted in the field, but deliberately given no badge of its own —
-      // nothing it ran scores in this family, so it has no placing to claim.
-      if (e.score <= 0) {
-        if (got) problems.push(`${fw} ${scope}: badge emitted for an entry scoring 0`);
-        continue;
-      }
-      checked++;
-      if (!got) { problems.push(`${fw} ${scope}: board ranks it #${e.rank} of ${e.of}, no badge emitted`); continue; }
-      if (got.rank !== e.rank || got.of !== e.of) {
-        problems.push(`${fw} ${scope}: badge says #${got.rank} of ${got.of}, board says #${e.rank} of ${e.of}`);
-      }
-      if (Math.abs(got.score - e.score) > 0.05) {
-        problems.push(`${fw} ${scope}: badge score ${got.score}, board score ${e.score.toFixed(1)}`);
-      }
-    }
-
-    // The language variant, checked against the board's own lang= filter rather
-    // than against a subset this script computes — otherwise "#1 of 6 (Rust)"
-    // would only ever be compared with itself.
-    for (const lang of LANGS) {
-      const expect = ranked(scope, types, lang);
-      for (const [fw, e] of expect) {
-        const got = emitted[slug(fw)] && emitted[slug(fw)].scopes[scope]
-                 && emitted[slug(fw)].scopes[scope].byLanguage;
-        if (e.of < MIN_FIELD || e.score <= 0) {
-          if (got) problems.push(`${fw} ${scope} (${lang}): badge emitted for a field of ${e.of}, score ${e.score.toFixed(1)}`);
-          continue;
-        }
-        checked++;
-        if (!got) { problems.push(`${fw} ${scope} (${lang}): board ranks it #${e.rank} of ${e.of}, no language badge emitted`); continue; }
-        if (got.rank !== e.rank || got.of !== e.of) {
-          problems.push(`${fw} ${scope} (${lang}): badge says #${got.rank} of ${got.of}, board says #${e.rank} of ${e.of}`);
+    for (const withTuned of [false, true]) {
+      for (const lang of [null, ...LANGS]) {
+        const expect = ranked(scope, types, lang, withTuned);
+        const where = `${scope}${lang ? ` (${lang})` : ''}${withTuned ? ' [with-tuned]' : ''}`;
+        for (const [fw, e] of expect) {
+          const sc = emitted[slug(fw)] && emitted[slug(fw)].scopes[scope];
+          const got = sc && sc[indexKey(lang, withTuned)];
+          if (e.of < MIN_FIELD || e.score <= 0) {
+            if (got) problems.push(`${fw} ${where}: badge emitted for a field of ${e.of}, score ${e.score.toFixed(1)}`);
+            continue;
+          }
+          checked++;
+          if (!got) { problems.push(`${fw} ${where}: board ranks it #${e.rank} of ${e.of}, no badge emitted`); continue; }
+          if (got.rank !== e.rank || got.of !== e.of) {
+            problems.push(`${fw} ${where}: badge says #${got.rank} of ${got.of}, board says #${e.rank} of ${e.of}`);
+          }
+          if (Math.abs(got.score - e.score) > 0.05) {
+            problems.push(`${fw} ${where}: badge score ${got.score}, board score ${e.score.toFixed(1)}`);
+          }
         }
       }
     }
   }
 }
 
-// And the other direction — a badge the board would not produce at all.
+// A tuned entry is absent from the default (tuned-excluded) field, so its
+// default URL is served from the tuned-inclusive ranking instead of 404ing.
+// Check that alias really does mirror the with-tuned number.
 for (const [s, entry] of Object.entries(emitted)) {
-  for (const scope of Object.keys(entry.scopes)) {
-    const seen = LEAGUES.some(types => ranked(scope, types).has(entry.framework));
-    if (!seen) problems.push(`${entry.framework} ${scope}: badge emitted but the board ranks no such entry`);
+  if (!isTuned(entry.framework)) continue;
+  for (const [scope, sc] of Object.entries(entry.scopes)) {
+    if (!sc.default) continue;
+    if (!sc.withTuned) { problems.push(`${entry.framework} ${scope}: tuned entry has a default badge but no with-tuned ranking to alias`); continue; }
+    if (sc.default.rank !== sc.withTuned.rank || sc.default.of !== sc.withTuned.of) {
+      problems.push(`${entry.framework} ${scope}: tuned entry default says #${sc.default.rank} of ${sc.default.of}, with-tuned says #${sc.withTuned.rank} of ${sc.withTuned.of}`);
+    }
   }
 }
+
+// Nothing else is needed to prove tuned entries are excluded from the default
+// field: the loop above already resolves the `default` key against the board
+// run with showTuned=false, so a default badge carrying the tuned-inclusive
+// field shows up there as a plain rank mismatch. A league with no tuned entries
+// in it legitimately has both fields the same size.
 
 if (problems.length) {
   console.error(`badge parity: ${problems.length} disagreement(s) with site/leaderboard/index.html\n`);

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -1024,13 +1024,16 @@ def badge_aggregate(profiles, results):
     return {"avg": avg, "mem": amem, "bw": abw, "tpl": atpl}
 
 
-def badge_composite(agg, profiles, meta, scope, types):
+def badge_composite(agg, profiles, meta, scope, types, show_tuned=True, lang=None,
+                    fw_lang=None):
     """Composite scores for one family and one league, best first.
 
-    Port of computeComposite() at the board's default state. Returns
-    [(framework, score)] for entries that actually scored in this family;
-    an entry present only through a reference-only profile (pipelined,
-    fortunes) sums to 0 and is dropped — there is no rank to report.
+    Port of computeComposite(). `show_tuned` and `lang` are the board's two
+    display filters, and they behave here the way they behave there with rescale
+    off: they narrow *who is listed*, never what anyone scored. The normalizing
+    maxima below are deliberately taken over the whole league — that is what
+    keeps a framework's number identical whether or not tuned entries are in
+    view, and what stops the badge disagreeing with the page it links to.
     """
     prof = {p["id"]: p for p in profiles}
     pids = [p["id"] for p in profiles
@@ -1039,7 +1042,18 @@ def badge_composite(agg, profiles, meta, scope, types):
         return []
 
     A = agg
+    fw_lang = fw_lang or {}
+    # outOfLeague in index.html: a separate competition, so excluded from the
+    # normalizing maxima as well as from the listing.
     in_league = lambda fw: meta.get(fw, {}).get("type", "emerging") in types
+
+    def shown(fw):
+        """hidden() in index.html — display only, never touches the maxima."""
+        if not show_tuned and meta.get(fw, {}).get("mode", "standard") == "tuned":
+            return False
+        if lang and fw_lang.get(fw) != lang:
+            return False
+        return True
 
     def is_scored(pid, fw):
         p = prof[pid]
@@ -1082,7 +1096,7 @@ def badge_composite(agg, profiles, meta, scope, types):
     rows = []
     fwset = {fw for pid in pids for fw in A["avg"].get(pid, {})}
     for fw in fwset:
-        if not in_league(fw):
+        if not in_league(fw) or not shown(fw):
             continue
         score, any_result = 0.0, False
         for pid in pids:
@@ -1122,7 +1136,7 @@ def _fw_languages(results):
     return lang
 
 
-def _badge_link(scope, types, lang=None):
+def _badge_link(scope, types, lang=None, show_tuned=False):
     """Deep link to the board view the rank was taken in — the whole field, not
     the one entry. Following a badge should show what "#6 of 83" was measured
     against; filtering to the framework alone just restates the badge.
@@ -1142,7 +1156,7 @@ def _badge_link(scope, types, lang=None):
     if scope != "h1":
         parts.append("scope=" + scope)
     parts.append("type=" + ",".join(sorted(types)))
-    parts.append("tuned=1")
+    parts.append("tuned=1" if show_tuned else "tuned=0")
     if lang:
         # lang=, not q=. The search box matches substrings across name, language
         # and engine, so q=C pulls in 73 of 78 entries and q=V pulls 33 — the
@@ -1169,14 +1183,22 @@ def _badge_color(rank, total):
 def write_badges(profiles, results, meta):
     """shields.io endpoint documents, plus an index of everything written.
 
-    Two badges per (framework, family): the overall rank in its tier at
-    /badge/<framework>/<family>.json, and — optional, for maintainers who want
-    it — its rank among entries in the same language, at
-    /badge/<framework>/<family>-<language>.json, reading "#1 of 17 (JS)".
+    Path is /badge/<framework>/<family>[-<language>][-with-tuned].json:
 
-    The language variant is a filter, not a rescore: same scores, same order,
-    counting only same-language entries. That is what the board does with a
-    language filter and rescale off, so the two still agree.
+        h1.json                  rank among standard entries      (the default)
+        h1-with-tuned.json       rank with tuned entries counted
+        h1-rust.json             ...same, narrowed to one language
+        h1-rust-with-tuned.json
+
+    Both suffixes are filters, not rescores: same scores, same order, a smaller
+    field. That is what the board does with rescale off, so a badge and the page
+    it links to never disagree about who is ahead of whom.
+
+    The default excludes tuned entries, so the number compares like-for-like
+    against stock configurations. A tuned entry has no place in that field, so
+    for those the default *is* the tuned-inclusive ranking — the smallest field
+    the entry actually belongs to. Otherwise /badge/<tuned-entry>/h1.json would
+    have to 404, and it is a URL people have already pasted.
     """
     if BADGE_OUT.exists():
         shutil.rmtree(BADGE_OUT)
@@ -1194,11 +1216,19 @@ def write_badges(profiles, results, meta):
 
     index, written = {}, 0
 
-    def emit(fw, slug, tier, scope, types, rank, total, score, lang=None):
-        """One endpoint document + its index entry."""
+    is_tuned = lambda fw: meta.get(fw, {}).get("mode", "standard") == "tuned"
+
+    def emit(fw, scope, types, rank, total, score, lang=None, with_tuned=False,
+             alias=False):
+        """One endpoint document + its index entry.
+
+        `alias` writes the default filename for a tuned entry, whose ranking can
+        only come from the tuned-inclusive field.
+        """
         nonlocal written
-        suffix = f"-{_lang_slug(lang)}" if lang else ""
-        name = f"{scope}{suffix}"
+        slug, tier = _slug(fw), meta.get(fw, {}).get("type", "emerging")
+        name = scope + (f"-{_lang_slug(lang)}" if lang else "") \
+                     + ("-with-tuned" if with_tuned and not alias else "")
         doc = {
             "schemaVersion": 1,
             "label": "HTTP Arena " + FAMILY_LABEL[scope],
@@ -1214,19 +1244,17 @@ def write_badges(profiles, results, meta):
         # The maintainer should not have to assemble any of this: the index
         # carries the finished line to paste, deep-linked to the view that
         # produced the number.
-        link = _badge_link(scope, types, lang)
+        link = _badge_link(scope, types, lang, with_tuned)
         shield = f"https://img.shields.io/endpoint?url={SITE}/badge/{slug}/{name}.json"
         e = index.setdefault(slug, {"framework": fw, "type": tier,
-                                    "language": fw_lang.get(fw, ""), "scopes": {}})
+                                    "language": fw_lang.get(fw, ""),
+                                    "tuned": is_tuned(fw), "scopes": {}})
         entry = {"rank": rank, "of": total, "score": round(score, 1), "link": link,
                  "markdown": f"[![HTTP Arena {FAMILY_LABEL[scope]}]({shield})]({link})"}
+        key = ("withTuned" if with_tuned and not alias else "default")
         if lang:
-            e["scopes"].setdefault(scope, {})["byLanguage"] = entry
-        else:
-            entry["byLanguage"] = e["scopes"].get(scope, {}).get("byLanguage")
-            if entry["byLanguage"] is None:
-                del entry["byLanguage"]
-            e["scopes"][scope] = entry
+            key = "byLanguage" + ("WithTuned" if with_tuned and not alias else "")
+        e["scopes"].setdefault(scope, {})[key] = entry
 
     def ranked(rows):
         """(fw, rank, total, score) with competition ranking — ties share a rank."""
@@ -1237,31 +1265,33 @@ def write_badges(profiles, results, meta):
             out.append((fw, rank, len(rows), score))
         return out
 
+    def publish(rows, scope, types, lang, with_tuned):
+        if len(rows) < BADGE_MIN_FIELD:
+            return
+        for fw, rank, total, score in ranked(rows):
+            # Counted in the field above, but no badge of its own: a 0 means the
+            # entry ran nothing that scores in this family, so "#31 of 31" would
+            # read as a placing it never competed for.
+            if score <= 0:
+                continue
+            # A tuned entry is absent from the default field entirely, so its
+            # place in the tuned-inclusive one is also what its default URL
+            # serves. Written twice rather than left to 404.
+            if with_tuned and is_tuned(fw):
+                emit(fw, scope, types, rank, total, score, lang, True, alias=True)
+            emit(fw, scope, types, rank, total, score, lang, with_tuned)
+
     for scope in FAMILY_LABEL:
         for types in LEAGUES:
-            rows = badge_composite(agg, profiles, meta, scope, types)
-            if len(rows) >= BADGE_MIN_FIELD:
-                for fw, rank, total, score in ranked(rows):
-                    # Counted in the field above, but no badge of its own: a 0
-                    # means the entry ran nothing that scores in this family, so
-                    # "#31 of 31" would read as a placing it never competed for.
-                    if score <= 0:
-                        continue
-                    emit(fw, _slug(fw), meta.get(fw, {}).get("type", "emerging"),
-                         scope, types, rank, total, score)
-
-            # Same league, same scores, narrowed to one language — re-ranked
-            # within that subset rather than rescored, so a language badge and
-            # the overall one can never disagree about who is ahead of whom.
-            for lang in sorted({fw_lang.get(fw, "") for fw, _ in rows} - {""}):
-                sub = [(fw, sc) for fw, sc in rows if fw_lang.get(fw) == lang]
-                if len(sub) < BADGE_MIN_FIELD:
-                    continue
-                for fw, rank, total, score in ranked(sub):
-                    if score <= 0:
-                        continue
-                    emit(fw, _slug(fw), meta.get(fw, {}).get("type", "emerging"),
-                         scope, types, rank, total, score, lang)
+            for with_tuned in (False, True):
+                rows = badge_composite(agg, profiles, meta, scope, types,
+                                       show_tuned=with_tuned)
+                publish(rows, scope, types, None, with_tuned)
+                for lang in sorted({fw_lang.get(fw, "") for fw, _ in rows} - {""}):
+                    sub = badge_composite(agg, profiles, meta, scope, types,
+                                          show_tuned=with_tuned, lang=lang,
+                                          fw_lang=fw_lang)
+                    publish(sub, scope, types, lang, with_tuned)
 
     BADGE_OUT.mkdir(parents=True, exist_ok=True)
     (BADGE_OUT / "index.json").write_text(

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -14,13 +14,13 @@ itself each time the leaderboard is republished — you paste it once.
 ## Paste it
 
 ```md
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=0)
 ```
 
 Replace `actix` with your entry and `h1` with the family you want. The exact
 line for your framework, already assembled and deep-linked to the right view of
 the board, is in [`/badge/index.json`](https://www.http-arena.com/badge/index.json)
-under `markdown`.
+under `scopes.<family>.default.markdown`.
 
 ## Families
 
@@ -44,7 +44,7 @@ Optional, and a second badge rather than a replacement. Append `-<language>` to
 the family and the badge reads **`#1 of 6 (Rust)`**:
 
 ```md
-[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1&lang=Rust)
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-rust.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=0&lang=Rust)
 ```
 
 The language segment is the board's own language name, lowercased, with `#`
@@ -52,6 +52,34 @@ spelled out as `sharp` and `++` as `pp`: `C#` → `csharp`, `C++` → `cpp`,
 `TS` → `ts`, `JS` → `js`. Your ready-made line is in
 [`/badge/index.json`](https://www.http-arena.com/badge/index.json) under
 `scopes.<family>.byLanguage.markdown`.
+
+## Counting tuned entries in
+
+Also optional. The default field is **standard configurations only**, so the
+number compares like for like — a stock server is not ranked against someone
+else's hand-tuned build. Append `-with-tuned` to count tuned entries as well:
+
+```md
+[![HTTP Arena](https://img.shields.io/endpoint?url=https://www.http-arena.com/badge/actix/h1-with-tuned.json)](https://www.http-arena.com/#type=emerging,flagship&tuned=1)
+```
+
+The suffixes combine, so the full set for one family is:
+
+| File | Field |
+|---|---|
+| `h1.json` | standard entries |
+| `h1-with-tuned.json` | standard + tuned |
+| `h1-rust.json` | standard, one language |
+| `h1-rust-with-tuned.json` | standard + tuned, one language |
+
+Each is in [`/badge/index.json`](https://www.http-arena.com/badge/index.json)
+under `scopes.<family>`, keyed `default`, `withTuned`, `byLanguage` and
+`byLanguageWithTuned`.
+
+**If your entry is itself tuned**, it has no place in the standard-only field,
+so its default URL serves the tuned-inclusive ranking instead — `h1.json` and
+`h1-with-tuned.json` give it the same number. Nothing to change, and no URL
+stops working.
 
 This is a **filter, not a rescore**. Scores and order are identical to the
 overall badge; only the field is narrowed, so the two can never disagree about


### PR DESCRIPTION
**Re-opens #1155 against `main`.** That PR was stacked on `feat/badge-language-rank`, and the two got merged nine seconds apart — #1154 into `main` at 15:10:04, then #1155 into `feat/badge-language-rank` at 15:10:13. By then that branch was already superseded, so the tuned-filter change never reached `main`. Same commit, cherry-picked onto current `main`, no conflicts.

My fault for setting a stacked base rather than waiting; nothing was lost.

---

The default field is now **standard configurations only**, so a stock server isn't ranked against someone else's hand-tuned build. Counting tuned entries back in is a suffix, and it composes with the language one:

| File | Field |
|---|---|
| `h1.json` | standard entries — **the default** |
| `h1-with-tuned.json` | standard + tuned |
| `h1-rust.json` | standard, one language |
| `h1-rust-with-tuned.json` | both |

798 badges over 135 frameworks.

**This moves the numbers, which is the point.** Tuned entries hold four of the top five h1 places:

```
actix          default #2 of 61    with-tuned #6 of 83
simplew-tuned  default #4 of 83    with-tuned #4 of 83
```

Both suffixes are filters, not rescores — `show_tuned` and `lang` narrow *who is listed* and never touch the normalizing maxima, mirroring the board with rescale off. So every variant agrees with the others, and with the page it links to, about who is ahead of whom.

## Tuned entries keep their default URL

A tuned entry has no place in the standard-only field, so for those the default *is* the tuned-inclusive ranking — the smallest field it actually belongs to (see `simplew-tuned` above). Without that, `/badge/<tuned-entry>/h1.json` would 404, and **28 of those are URLs already handed out**; a 404 renders as "resource not found" in their README.

## Parity

All four combinations resolve against the board configured the same way — **689 ranks**, up from 404.

Wiring `showTuned` into the checker's runner fixed the first 179 disagreements: it had been comparing a tuned-excluded badge against a tuned-included board, which is exactly what the check exists to catch.

I also removed a check I'd written asserting the two field sizes must differ — it fired 53 times on engine and experimental entries, which contain no tuned entries, so equal sizes are correct there. The main loop already proves exclusion by construction. Confirmed the real check still bites: making the default field include tuned produces 107 disagreements.

Verified on this branch after the cherry-pick: `798 badges`, `badge parity ok — 689 ranks match`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)