### PR TITLE
Badges: drop the shields cache from an hour to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,9 @@ A few things worth knowing before you paste it:
   the memory-efficiency and rescale toggles off. Follow the link and you land on
   the field the rank was measured against — the whole league, not your row on
   its own, so `#6 of 83` arrives with the other 82 around it.
-- **It updates on deploy, then when GitHub's cache lets it.** README images are
-  proxied through Camo, so a new rank can take a few hours to show up.
+- **It updates on deploy, then when the caches let it.** shields holds a rank
+  for 5 minutes, and GitHub proxies README images through Camo, which holds
+  one for a few hours. Nothing to re-paste either way.
 
 Shields' usual styling works — append `&style=flat-square`, `&logo=rust`, and so
 on to the `img.shields.io` URL.

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -957,6 +957,14 @@ LEAGUES = [("flagship", "emerging"), ("engine",), ("experimental",)]
 # A rank is only worth publishing if something was beaten to earn it.
 BADGE_MIN_FIELD = 2
 
+# How long shields.io may hold a rendered badge. 300 is its floor — lower values
+# are clamped back up to it. This was an hour, which put a stale rank in front of
+# every embed for up to an hour after a deploy on top of GitHub's own Camo cache.
+# The extra cost is shields re-reading a ~130-byte static file on Pages twelve
+# times as often, which is nothing; on GitHub, Camo still dominates, but anywhere
+# outside it (docs sites, dashboards) the badge is now near-live.
+BADGE_CACHE_SECONDS = 300
+
 # Label-side colour, carrying the entry's tier. Same four hues as the board's
 # type swatch next to every framework name, but in the darker tone the board
 # uses for type *text* (.b-* / .type-filter .on in index.html) rather than the
@@ -1235,7 +1243,7 @@ def write_badges(profiles, results, meta):
             "message": f"#{rank} of {total}" + (f" ({lang})" if lang else ""),
             "color": _badge_color(rank, total),
             "labelColor": TYPE_COLOR.get(tier, TYPE_COLOR_FALLBACK),
-            "cacheSeconds": 3600,
+            "cacheSeconds": BADGE_CACHE_SECONDS,
         }
         path = BADGE_OUT / slug / f"{name}.json"
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/site/content/docs/add-framework/badges.md
+++ b/site/content/docs/add-framework/badges.md
@@ -131,9 +131,19 @@ but get no badge of their own: there is no placing to claim.
 
 ## Freshness
 
-The endpoints are regenerated whenever the site deploys. After that, GitHub
-serves README images through its Camo proxy, which caches them, so a changed
-rank can take a few hours to appear on GitHub itself.
+The endpoints are regenerated whenever the site deploys — including every time
+a benchmark result is saved, since results live under `site/`. Two caches sit in
+front of that:
+
+| | Holds a stale rank for |
+|---|---|
+| shields.io | 5 minutes (`cacheSeconds`, at its floor) |
+| GitHub Camo | a few hours |
+
+So a new rank is visible almost immediately wherever the badge is embedded
+directly, and takes a few hours to turn over inside a GitHub README. Nothing to
+re-paste either way. To see the current value straight away, add any parameter
+to the shields URL — `&style=flat-square` — which makes a fresh cache key.
 
 ## Styling
 


### PR DESCRIPTION
`cacheSeconds` was `3600`, and shields returns it verbatim as `max-age`, so a rank could sit an hour stale *before* GitHub's Camo cache even started counting. Caught while chasing why a README still showed `#6 of 83` after #1156 had deployed:

```
our endpoint   #2 of 61     ✓ correct
shields.io     #6 of 83     age: 2862 / max-age: 3600
```

`300` is the floor shields honours — lower values are clamped back up. All 798 badges now carry it.

**Cost:** shields re-reads a ~130-byte static file on GitHub Pages twelve times as often. Nothing.

**Effect:** on GitHub, Camo still dominates and little visibly changes. Anywhere the badge is embedded directly — docs sites, dashboards, anything outside Camo — it's now near-live.

Also fixes the docs, which blamed Camo alone. Both layers are now named, along with the trick for reading the current value immediately (append any parameter, e.g. `&style=flat-square`, to make a fresh shields cache key):

| | Holds a stale rank for |
|---|---|
| shields.io | 5 minutes |
| GitHub Camo | a few hours |

Parity unaffected — `798 badges`, `689 ranks match`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)