### PR TITLE
site(seo): pages per framework, pre-rendered board, social cards, JSON-LD, llms.txt and more

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Only the og:image cards need it. The generator runs fine without it and
+      # simply leaves the cards (and the tags pointing at them) out, so a local
+      # run still produces the whole site.
+      - name: Install Pillow (social cards)
+        run: python3 -m pip install --quiet --disable-pip-version-check pillow
+
       - name: Generate leaderboard data
         run: python3 scripts/gen_leaderboard_data.py
 
@@ -39,7 +45,7 @@ jobs:
         working-directory: site
         run: |
           rm -rf public && mkdir public
-          cp leaderboard/index.html public/index.html
+          cp generated/index.html public/index.html                                 # the board with its default view pre-rendered into #rows (leaderboard/index.html is the source)
           cp leaderboard/data.js public/data.js
           cp leaderboard/search.js public/search.js                                  # plain-text Knowledge Base index for the board's page search
           cp -r static/logs public/logs                                             # run logs, served at /logs/
@@ -48,6 +54,9 @@ jobs:
           cp -r generated/docs public/docs                                          # pre-rendered Knowledge Base pages (real /docs/<id>/ URLs) + docs.css
           cp generated/sitemap.xml public/sitemap.xml                               # root + every /docs/<id>/ (generated, replaces the old static one)
           cp -r generated/badge public/badge                                        # shields.io endpoints behind the README badges, /badge/<fw>/<family>.json
+          cp generated/data.json public/data.json                                   # every result as plain JSON: what the Dataset structured data points at
+          cp generated/llms.txt generated/llms-full.txt public/                     # the ranking and the Knowledge Base as text, for readers that never run JS
+          if [ -f generated/og.png ]; then cp generated/og.png public/og.png; fi    # social card for the board; the per-doc ones ride along inside generated/docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,12 @@ jobs:
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
+      # Full history: the sitemap dates each page from the last commit that
+      # touched its source, and a shallow clone can only say "today" for
+      # everything. Without it the generator drops lastmod rather than guess.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       # Only the og:image cards need it. The generator runs fine without it and
       # simply leaves the cards (and the tags pointing at them) out, so a local
@@ -54,6 +59,7 @@ jobs:
           cp -r generated/docs public/docs                                          # pre-rendered Knowledge Base pages (real /docs/<id>/ URLs) + docs.css
           cp generated/sitemap.xml public/sitemap.xml                               # root + every /docs/<id>/ (generated, replaces the old static one)
           cp -r generated/badge public/badge                                        # shields.io endpoints behind the README badges, /badge/<fw>/<family>.json
+          cp -r generated/frameworks public/frameworks                              # a real page per entry at /frameworks/<slug>/, plus the index over them
           cp generated/data.json public/data.json                                   # every result as plain JSON: what the Dataset structured data points at
           cp generated/llms.txt generated/llms-full.txt public/                     # the ranking and the Knowledge Base as text, for readers that never run JS
           if [ -f generated/og.png ]; then cp generated/og.png public/og.png; fi    # social card for the board; the per-doc ones ride along inside generated/docs

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import re
 import shutil
+import subprocess
 import posixpath
 import html as _html
 from pathlib import Path
@@ -752,15 +753,23 @@ _CHROME = board_chrome()
 
 _THEME_INIT = ("<script>try{var t=localStorage.getItem('lb-theme');"
                "if(t)document.documentElement.setAttribute('data-theme',t);}catch(e){}</script>")
-_NAV_JS = ("<script src=\"/search.js\"></script>"
-           "<script>(function(){"
+# search.js is the whole Knowledge Base as text - 290KB - and it was loaded on
+# every doc page for a search box most readers never open. It is fetched on the
+# first use of the box instead.
+_NAV_JS = ("<script>(function(){"
            # accordion: same behaviour as the board's toggleGrp
            "document.querySelectorAll('.nav-grp-h .caret').forEach(function(c){"
            "c.onclick=function(e){e.preventDefault();e.stopPropagation();"
            "c.closest('.nav-grp').classList.toggle('open');};});"
            # page search over the index the generator emits
            "var inp=document.getElementById('navq'),box=document.getElementById('navResults'),"
-           "tree=document.getElementById('navTree');if(!inp||!window.LB_SEARCH)return;"
+           "tree=document.getElementById('navTree');if(!inp)return;"
+           "var req=null,cb=null;"
+           "function need(f){if(window.LB_SEARCH){f();return;}cb=f;if(req)return;"
+           "req=document.createElement('script');req.src='/search.js';"
+           "req.onload=function(){var g=cb;cb=null;if(g)g();};"
+           "req.onerror=function(){req=null;};document.head.appendChild(req);}"
+           "inp.addEventListener('focus',function(){need(function(){});},{once:true});"
            "function esc(s){return String(s).replace(/[&<>\"]/g,function(c){"
            "return {'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}[c];});}"
            "function snip(x,t){var i=x.toLowerCase().indexOf(t);if(i<0)return esc(x.slice(0,110));"
@@ -786,7 +795,8 @@ _NAV_JS = ("<script src=\"/search.js\"></script>"
            "+'<span class=\"nav-res-c\">'+esc(e.c||'')+'</span>'"
            "+'<span class=\"nav-res-s\">'+snip((e.d||'')+' '+(e.x||''),terms[0])+'</span></a>';});"
            "box.innerHTML=h;}"
-           "var t;inp.addEventListener('input',function(){clearTimeout(t);t=setTimeout(run,90);});"
+           "var t;inp.addEventListener('input',function(){clearTimeout(t);"
+           "t=setTimeout(function(){if(!inp.value.trim())run();else need(run);},90);});"
            "inp.addEventListener('keydown',function(e){if(e.key==='Escape'){inp.value='';run();inp.blur();}});"
            "})();</script>")
 
@@ -874,6 +884,10 @@ def _docs_css():
 /* wider than the board's 264px rail: this tree goes five levels deep and
    each level costs .8rem of indent, so names would truncate. */
 .docs-layout{display:grid;grid-template-columns:320px 1fr;align-items:start}
+/* framework pages have no sidebar to sit next to */
+.docs-layout.one-col{grid-template-columns:1fr;justify-items:center}
+.docs-layout.one-col .doc-main{width:100%}
+.fw-kind{color:var(--muted);font-size:.78rem}
 .doc-main{min-width:0;padding:1.6rem 2rem 4rem;max-width:900px}
 .doc-wrap{max-width:none}
 .nav-grp-link{display:block;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:inherit;font:inherit;text-decoration:none}
@@ -936,21 +950,76 @@ def write_search_index(tree, content):
     # <script src>, and the deploy copies them to the site root the same way.
     out = OUT.parent / "search.js"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text("window.LB_SEARCH = " + json.dumps(entries, separators=(",", ":")) + ";\n",
-                   encoding="utf-8")
+    out.write_text(js_payload("LB_SEARCH", entries), encoding="utf-8")
     return len(entries), out.stat().st_size
 
 
-def write_sitemap(content):
-    """Root + every /docs/<id>/. Replaces the old Hugo-generated /old/ sitemap."""
-    urls = [SITE + "/"] + [SITE + _doc_url(did) for did in sorted(content.keys())]
-    body = "".join("<url><loc>%s</loc></url>" % u for u in urls)
+def _last_commit_dates(*prefixes):
+    """path -> the date it was last committed, in one `git log` pass.
+
+    Wanted for <lastmod>, which is only worth publishing if it is true: a crawler
+    that is told a page changed and finds it did not learns to ignore the field.
+    A shallow clone cannot answer this - it holds one commit and would date the
+    whole site to the last deploy - so it answers nothing and the sitemap goes
+    out without lastmod rather than with a lie."""
+    try:
+        shallow = _git(["git", "rev-parse", "--is-shallow-repository"])
+        if shallow.strip() == "true":
+            print("[warn] shallow clone - sitemap goes out without lastmod "
+                  "(set fetch-depth: 0 to get it)")
+            return {}
+        out = _git(["git", "log", "--pretty=format:%cI", "--name-only",
+                               "--", *prefixes])
+    except Exception as exc:                                   # no git, no history
+        print(f"[warn] no git dates for the sitemap: {exc}")
+        return {}
+
+    dates, when = {}, None
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line[:1].isdigit() and "T" in line and "/" not in line:
+            when = line[:10]
+        elif when:
+            dates.setdefault(line, when)                       # newest commit first
+    return dates
+
+
+def _git(args):
+    return subprocess.run(args, cwd=ROOT, capture_output=True, text=True,
+                          encoding="utf-8", check=True).stdout
+
+
+def _doc_source_path(did):
+    """The markdown a doc id came from, for its commit date."""
+    section = DOCS / did / "_index.md" if did else DOCS / "_index.md"
+    page = DOCS / (did + ".md")
+    src = section if section.exists() else page
+    return src.relative_to(ROOT).as_posix()
+
+
+def write_sitemap(content, fw_entries=()):
+    """Root, /frameworks/, every framework and every /docs/<id>/."""
+    dates = _last_commit_dates("site/content/docs", "site/data/results")
+    newest = max(dates.values(), default=None)
+
+    urls = [(SITE + "/", newest), (SITE + "/frameworks/", newest)]
+    for fw, _lang, _kind in fw_entries:
+        urls.append((SITE + _fw_url(fw),
+                     dates.get(f"site/data/results/{_slug(fw)}.json", newest)))
+    for did in sorted(content):
+        urls.append((SITE + _doc_url(did), dates.get(_doc_source_path(did))))
+
+    body = "".join("<url><loc>%s</loc>%s</url>"
+                   % (loc, f"<lastmod>{mod}</lastmod>" if mod else "")
+                   for loc, mod in urls)
     GEN.mkdir(parents=True, exist_ok=True)
     (GEN / "sitemap.xml").write_text(
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' + body + "</urlset>\n",
         encoding="utf-8")
-    return len(urls)
+    return len(urls), sum(1 for _, mod in urls if mod)
 
 
 # ── README badges (shields.io endpoint) ──────────────────────────────────────
@@ -1573,6 +1642,24 @@ def _ranking_node(scope, rows):
     }
 
 
+def js_payload(name, payload):
+    """`window.<name> = JSON.parse('...')`, the form the board's data ships in.
+
+    V8 parses a JSON string roughly three times faster than the equivalent
+    object literal: measured on this payload, compile plus execute went from
+    18.1ms to 5.6ms (medians of nine cold runs, node 26). It is main-thread time
+    on every visit and it costs nothing to save.
+
+    The JSON goes inside single quotes, because it is full of double ones and
+    escaping them all is what makes this trick cost 16% of the file elsewhere.
+    ensure_ascii keeps the output free of raw line terminators, so a backslash
+    and an apostrophe are the only characters left to escape - 62 of them in
+    722KB, and the file comes out byte for byte the same size as the literal.
+    """
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
+    return f"window.{name} = JSON.parse('" + body.replace("\\", "\\\\").replace("'", "\\'") + "');\n"
+
+
 def write_data_json(payload):
     """The same document data.js assigns to window.LB_DATA, as plain JSON.
 
@@ -1590,7 +1677,7 @@ def _rank_lines(rows, fw_lang, limit=None):
             for i, (fw, score) in enumerate(rows[:limit] if limit else rows)]
 
 
-def write_llms_txt(tree, content, families, fw_lang, current, round_name):
+def write_llms_txt(tree, content, families, fw_lang, current, round_name, fw_entries=()):
     """/llms.txt and /llms-full.txt.
 
     Same reason as the prerender, for the readers the prerender cannot reach:
@@ -1623,6 +1710,15 @@ def write_llms_txt(tree, content, families, fw_lang, current, round_name):
             short += [f"Full field: {SITE}/llms-full.txt", ""]
         full += [title, "", "```", *_rank_lines(rows, fw_lang), "```", ""]
 
+    frameworks = []
+    if fw_entries:
+        frameworks = [f"## Frameworks ({len(fw_entries)} entries, one results page each)", ""]
+        for fw, lang, kind in fw_entries:
+            frameworks.append(f"- [{fw}]({SITE}{_fw_url(fw)}): "
+                              + ", ".join(x for x in [lang, TYPE_LABEL.get(kind, kind)] if x)
+                              + ". Rank per family and every per-profile number.")
+        frameworks.append("")
+
     docs = ["## Documentation", ""]
     for did in sorted(content):
         d = content[did]
@@ -1640,10 +1736,10 @@ def write_llms_txt(tree, content, families, fw_lang, current, round_name):
             "every server implementation, Dockerfile and validation rule.",
             ""]
 
-    short += docs + data + ["## Full text", "",
-                            f"- [llms-full.txt]({SITE}/llms-full.txt): the whole Knowledge Base "
-                            "and the full ranking of every family.", ""]
-    full += data + ["## Knowledge Base", ""]
+    short += frameworks + docs + data + ["## Full text", "",
+                                         f"- [llms-full.txt]({SITE}/llms-full.txt): the whole "
+                                         "Knowledge Base and the full ranking of every family.", ""]
+    full += frameworks + data + ["## Knowledge Base", ""]
     for did in sorted(content):
         d = content[did]
         text = _html.unescape(re.sub(r"<[^>]+>", " ", d["html"]))
@@ -1663,17 +1759,20 @@ def _static_board(rows, fw_lang, round_name):
     body = []
     for i, (fw, score) in enumerate(rows):
         rank = i + 1
-        body.append('<tr><td class="n%s">%d</td><td>%s</td><td class="sb-lang">%s</td>'
-                    '<td class="n">%.0f</td></tr>'
-                    % (" r%d" % rank if rank <= 3 else "", rank,
+        # the name links to the entry's own page: the only internal links to
+        # those pages that exist without running a script
+        body.append('<tr><td class="n%s">%d</td><td><a href="%s">%s</a></td>'
+                    '<td class="sb-lang">%s</td><td class="n">%.0f</td></tr>'
+                    % (" r%d" % rank if rank <= 3 else "", rank, _fw_url(fw),
                        _html.escape(fw), _html.escape(fw_lang.get(fw, "") or ""), score))
     others = ", ".join(SCOPE_NAME[s] for s in SCOPE_NAME if s != DEFAULT_SCOPE)
     return ('<table class="sb"><thead><tr><th>#</th><th>Framework</th><th>Language</th>'
             '<th class="n">Composite</th></tr></thead><tbody>' + "".join(body) + "</tbody></table>"
             '<p class="sb-note">' + _html.escape(round_name) + ", " + str(len(rows)) +
             " entries, best first. The interactive board - per-profile numbers, memory efficiency, "
-            "the other families (" + _html.escape(others) + ") - needs JavaScript; the same "
-            'rankings are also published as text at <a href="/llms.txt">/llms.txt</a>.</p>')
+            "the other families (" + _html.escape(others) + ") - needs JavaScript; every entry has "
+            'a <a href="/frameworks/">page of its own</a>, and the same rankings are published as '
+            'text at <a href="/llms.txt">/llms.txt</a>.</p>')
 
 
 def build_index_page(rows, fw_lang, current, round_name, n_profiles, og_url):
@@ -1725,6 +1824,262 @@ def build_index_page(rows, fw_lang, current, round_name, n_profiles, og_url):
     GEN.mkdir(parents=True, exist_ok=True)
     (GEN / "index.html").write_text(out, encoding="utf-8")
     return (GEN / "index.html").stat().st_size
+
+
+# ── a page per framework ─────────────────────────────────────────────────────
+# The board is one URL. Every state it can be in is a #hash, and a hash is not a
+# page: "axum benchmark" has nowhere to land, and a framework that is in here has
+# nothing of its own to be found by. These pages are that missing half - one URL
+# per entry, carrying its rank in every family it runs and every number behind
+# it, from the same data the board draws.
+
+FW_OUT = GEN / "frameworks"
+
+TYPE_LABEL = {"flagship": "Flagship", "emerging": "Emerging",
+              "experimental": "Experimental", "engine": "Engine",
+              "infrastructure": "Infrastructure"}
+
+
+def _fw_url(fw):
+    return "/frameworks/" + _slug(fw) + "/"
+
+
+def _league_of(kind):
+    for league in LEAGUES:
+        if kind in league:
+            return league
+    return LEAGUES[0]
+
+
+def fw_rankings(agg, profiles, meta, fw_lang):
+    """(family, league) -> ordered rows. A page has to quote the rank of its own
+    league: an engine is not scored against frameworks and saying otherwise would
+    contradict both the board and the badge."""
+    out = {}
+    for scope in SCOPE_NAME:
+        for league in LEAGUES:
+            rows = badge_composite(agg, profiles, meta, scope, league,
+                                   show_tuned=True, fw_lang=fw_lang)
+            if rows:
+                out[(scope, league)] = rows
+    return out
+
+
+def _fw_ranks(fw, kind, rankings):
+    """[(family, rank, field size, score)] over the families this entry runs."""
+    league, out = _league_of(kind), []
+    for scope in SCOPE_NAME:
+        rows = rankings.get((scope, league)) or []
+        for i, (name, score) in enumerate(rows):
+            if name == fw:
+                out.append((scope, i + 1, len(rows), score))
+                break
+    return out
+
+
+def _fw_results(fw, profiles, results):
+    """[(profile, conns, row)] in catalog order - every run this entry has."""
+    out = []
+    for p in profiles:
+        for c in p["conns"]:
+            for r in results.get(f"{p['id']}-{c}", []):
+                if r["fw"] == fw:
+                    out.append((p, c, r))
+                    break
+    return out
+
+
+def _fw_body(fw, m, lang, ranks, runs, round_name):
+    e = _html.escape
+    facts = [TYPE_LABEL.get(m.get("type", "emerging"), m.get("type", "")), lang]
+    if m.get("engine") and m["engine"] != fw:
+        facts.append("engine: " + m["engine"])
+    facts.append("tuned configuration" if m.get("mode") == "tuned" else "standard configuration")
+    out = ["<p>" + e(" · ".join(x for x in facts if x)) + "</p>"]
+    if m.get("desc"):
+        out.append("<p>" + e(m["desc"]) + "</p>")
+
+    links = []
+    if m.get("repo"):
+        links.append('<li><a href="%s" rel="noopener">Official repository</a></li>' % e(m["repo"]))
+    links.append('<li><a href="https://github.com/MDA2AV/HttpArena/tree/main/frameworks/%s" '
+                 'rel="noopener">Benchmark implementation</a></li>' % quote(m.get("dir") or fw))
+    links.append('<li><a href="/">Open the leaderboard</a></li>')
+    out.append("<ul>" + "".join(links) + "</ul>")
+
+    if ranks:
+        out.append('<h2 id="rank">Composite rank</h2>')
+        out.append("<p>Each profile of a family is worth 100 to the entry that leads it, and the "
+                   "composite is the sum over the family. The field is this entry's own league: "
+                   "engines and reverse proxies are scored apart from frameworks. "
+                   '<a href="/docs/scoring/composite-score/">How it works</a>.</p>')
+        rows = "".join(
+            '<tr><td><a href="/#scope=%s">%s</a></td><td>%d of %d</td><td>%.0f</td></tr>'
+            % (scope, e(SCOPE_NAME[scope]), rank, field, score)
+            for scope, rank, field, score in ranks)
+        out.append("<table><thead><tr><th>Family</th><th>Rank</th><th>Composite</th></tr></thead>"
+                   "<tbody>" + rows + "</tbody></table>")
+
+    if runs:
+        out.append('<h2 id="results">Every result</h2>')
+        out.append("<p>%s, %d runs. Requests per second is the best of three; latency, CPU and "
+                   "memory come from that run.</p>" % (e(round_name), len(runs)))
+        body = "".join(
+            "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td>"
+            "<td>%s</td></tr>"
+            % (e(p["category"]), e(p["label"]), f"{c:,}",
+               f"{round(r.get('rps') or 0):,}" if r.get("rps") else "-",
+               e(r.get("avg_latency") or "-"), e(r.get("p99_latency") or "-"),
+               e(r.get("cpu") or "-"), e(r.get("memory") or "-"))
+            for p, c, r in runs)
+        out.append("<table><thead><tr><th>Category</th><th>Profile</th><th>Conns</th>"
+                   "<th>Req/sec</th><th>Avg</th><th>p99</th><th>CPU</th><th>Memory</th></tr></thead>"
+                   "<tbody>" + body + "</tbody></table>")
+
+    out.append('<p><a href="/docs/">How the benchmark is run</a> · '
+               '<a href="/docs/hardware/">The machine</a> · '
+               '<a href="/docs/add-framework/">Add or fix an entry</a></p>')
+    return '<div class="doc-body">' + "".join(out) + "</div>"
+
+
+def _fw_page(fw, m, lang, ranks, runs, round_name, og_url):
+    e = _html.escape
+    url = SITE + _fw_url(fw)
+    title = f"{fw} benchmark results"
+    # the main family when the entry runs it, its first one otherwise. Quoting
+    # whichever rank happens to be best would read as picked, and be picked
+    lead = next((r for r in ranks if r[0] == DEFAULT_SCOPE), ranks[0] if ranks else None)
+    desc = (f"{fw}" + (f" ({lang})" if lang else "") + " in the HttpArena benchmark: "
+            + (f"ranked {lead[1]} of {lead[2]} on {SCOPE_NAME[lead[0]]}, " if lead else "")
+            + f"throughput, latency, CPU and memory over {len(runs)} runs on the same machine.")
+    graph = [
+        {"@type": "WebPage", "@id": url + "#page", "name": title, "description": desc,
+         "url": url, "inLanguage": "en", "isPartOf": {"@id": SITE + "/#website"},
+         "publisher": {"@id": SITE + "/#org"}, "about": {"@id": url + "#software"},
+         "mainEntityOfPage": url},
+        {"@type": "SoftwareApplication", "@id": url + "#software", "name": fw,
+         "applicationCategory": "DeveloperApplication",
+         **({"programmingLanguage": lang} if lang else {}),
+         **({"codeRepository": m["repo"]} if m.get("repo") else {}),
+         **({"description": m["desc"]} if m.get("desc") else {})},
+        {"@type": "BreadcrumbList", "@id": url + "#crumbs", "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Frameworks",
+             "item": SITE + "/frameworks/"},
+            {"@type": "ListItem", "position": 2, "name": fw, "item": url}]},
+    ] + _org_nodes()
+    head = ('<!doctype html><html lang="en" data-theme=""><head>'
+            '<meta charset="utf-8">'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">'
+            + _THEME_INIT
+            + "<title>" + e(title) + " – HttpArena</title>"
+            + '<meta name="description" content="' + e(desc) + '">'
+            + '<link rel="canonical" href="' + url + '">'
+            + '<link rel="icon" href="/favicon.ico" sizes="any">'
+            + '<link rel="icon" href="/favicon.svg" type="image/svg+xml">'
+            + '<meta property="og:type" content="article">'
+            + '<meta property="og:site_name" content="HttpArena">'
+            + '<meta property="og:title" content="' + e(title) + '">'
+            + '<meta property="og:description" content="' + e(desc) + '">'
+            + '<meta property="og:url" content="' + url + '">'
+            + _og_meta(og_url)
+            + _jsonld({"@context": "https://schema.org", "@graph": graph})
+            + '<link rel="stylesheet" href="/docs/docs.css">'
+            + "</head>")
+    header = ('<body><header class="top">'
+              '<div class="brand">' + _CHROME[0] + '</div>'
+              '<a class="brand-sub" href="/frameworks/">Frameworks</a>'
+              '<div class="top-links">' + _CHROME[1] + '</div>'
+              '</header>')
+    body = ('<div class="docs-layout one-col"><main class="doc-main">'
+            '<article class="doc-wrap"><h1 class="doc-title">' + e(fw) + "</h1>"
+            + _fw_body(fw, m, lang, ranks, runs, round_name)
+            + "</article></main></div>")
+    return head + header + body + _THEME_TOGGLE + "</body></html>"
+
+
+def _fw_index_page(entries):
+    """/frameworks/ - one link per entry, grouped by language. Also the page that
+    makes every framework page reachable by following links from the board."""
+    e = _html.escape
+    url = SITE + "/frameworks/"
+    title = "Every framework in the benchmark"
+    desc = (f"All {len(entries)} frameworks, HTTP engines and reverse proxies measured by "
+            "HttpArena, with a results page each.")
+    by_lang = {}
+    for fw, lang, kind in entries:
+        by_lang.setdefault(lang or "Other", []).append((fw, kind))
+    sections = []
+    for lang in sorted(by_lang, key=lambda x: (x == "Other", x.lower())):
+        items = "".join('<li><a href="%s">%s</a> <span class="fw-kind">%s</span></li>'
+                        % (_fw_url(fw), e(fw), e(TYPE_LABEL.get(kind, kind)))
+                        for fw, kind in sorted(by_lang[lang], key=lambda x: x[0].lower()))
+        sections.append("<h2>" + e(lang) + "</h2><ul>" + items + "</ul>")
+    graph = [
+        {"@type": "CollectionPage", "@id": url + "#page", "name": title, "description": desc,
+         "url": url, "inLanguage": "en", "isPartOf": {"@id": SITE + "/#website"},
+         "publisher": {"@id": SITE + "/#org"}},
+    ] + _org_nodes()
+    head = ('<!doctype html><html lang="en" data-theme=""><head>'
+            '<meta charset="utf-8">'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">'
+            + _THEME_INIT
+            + "<title>" + e(title) + " – HttpArena</title>"
+            + '<meta name="description" content="' + e(desc) + '">'
+            + '<link rel="canonical" href="' + url + '">'
+            + '<link rel="icon" href="/favicon.ico" sizes="any">'
+            + '<link rel="icon" href="/favicon.svg" type="image/svg+xml">'
+            + '<meta property="og:type" content="website">'
+            + '<meta property="og:site_name" content="HttpArena">'
+            + '<meta property="og:title" content="' + e(title) + '">'
+            + '<meta property="og:description" content="' + e(desc) + '">'
+            + '<meta property="og:url" content="' + url + '">'
+            + _jsonld({"@context": "https://schema.org", "@graph": graph})
+            + '<link rel="stylesheet" href="/docs/docs.css">'
+            + "</head>")
+    header = ('<body><header class="top">'
+              '<div class="brand">' + _CHROME[0] + '</div>'
+              '<a class="brand-sub" href="/frameworks/">Frameworks</a>'
+              '<div class="top-links">' + _CHROME[1] + '</div>'
+              '</header>')
+    body = ('<div class="docs-layout one-col"><main class="doc-main">'
+            '<article class="doc-wrap"><h1 class="doc-title">' + e(title) + "</h1>"
+            '<div class="doc-body"><p>' + e(desc) + " Ranks and every per-profile number live on "
+            'the page of each entry; the <a href="/">leaderboard</a> compares them.</p>'
+            + "".join(sections) + "</div></article></main></div>")
+    return head + header + body + _THEME_TOGGLE + "</body></html>"
+
+
+def build_fw_pages(profiles, results, meta, fw_lang, rankings, round_name, with_og):
+    """A page per framework that has results, plus the index over them."""
+    if FW_OUT.exists():
+        shutil.rmtree(FW_OUT)
+    FW_OUT.mkdir(parents=True, exist_ok=True)
+
+    named = sorted({r["fw"] for rows in results.values() for r in rows})
+    entries, cards = [], 0
+    for fw in named:
+        m = meta.get(fw, {})
+        kind = m.get("type", "emerging")
+        lang = fw_lang.get(fw) or m.get("language", "")
+        ranks = _fw_ranks(fw, kind, rankings)
+        runs = _fw_results(fw, profiles, results)
+        og_url = (_fw_url(fw) + "og.png") if with_og else ""
+        dest = FW_OUT / _slug(fw)
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "index.html").write_text(
+            _fw_page(fw, m, lang, ranks, runs, round_name, og_url), encoding="utf-8")
+        if with_og:
+            _og_card(dest / "og.png", "Benchmark results", fw,
+                     [(SCOPE_NAME[s], "#%d of %d" % (rank, field))
+                      for s, rank, field, _ in ranks],
+                     " · ".join(x for x in [lang, TYPE_LABEL.get(kind, kind),
+                                            round_name, "www.http-arena.com"] if x),
+                     blurb=m.get("desc", ""))
+            cards += 1
+        entries.append((fw, lang, kind))
+
+    (FW_OUT / "index.html").write_text(_fw_index_page(entries), encoding="utf-8")
+    return entries, cards
 
 
 def build_og_images(content, trails, rows, fw_lang, round_name):
@@ -1814,15 +2169,15 @@ def main():
                "profiles": profiles, "results": results, "docs": docs_tree,
                "rounds": build_rounds()}
     OUT.parent.mkdir(parents=True, exist_ok=True)
-    OUT.write_text("window.LB_DATA = " + json.dumps(payload, separators=(",", ":")) + ";\n")
+    OUT.write_text(js_payload("LB_DATA", payload))
 
     # Docs are pre-rendered to real /docs/<id>/ pages (SEO); the SPA links out to
     # them. LB_DATA still carries the docs *tree* for the sidebar labels, but the
     # doc *content* is no longer shipped as docs.js.
+    has_og = _og_ready()
     trails = _crumb_trails(docs_tree)
-    n_pages = build_doc_pages(docs_tree, docs_content, trails, with_og=_og_ready())
+    n_pages = build_doc_pages(docs_tree, docs_content, trails, with_og=has_og)
     n_search, search_bytes = write_search_index(docs_tree, docs_content)
-    n_urls = write_sitemap(docs_content)
     n_badges, n_badge_fw = write_badges(profiles, results, meta)
 
     # The board's default view, and the same view for the other five families.
@@ -1836,28 +2191,36 @@ def main():
     board = dict(families)[DEFAULT_SCOPE]
     round_name = payload["rounds"]["name"]
 
+    rankings = fw_rankings(agg, profiles, meta, fw_lang)
+    fw_entries, n_fw_cards = build_fw_pages(profiles, results, meta, fw_lang, rankings,
+                                            round_name, has_og)
+    n_urls, n_dated = write_sitemap(docs_content, fw_entries)
+
     # og cards go in after build_doc_pages: that one clears site/generated/docs/
     # before it writes, and the per-doc cards live inside it.
     og_url, n_cards = build_og_images(docs_content, trails, board, fw_lang, round_name)
     json_bytes = write_data_json(payload)
     index_bytes = build_index_page(board, fw_lang, current, round_name, len(profiles), og_url)
     llms_bytes, llms_full_bytes = write_llms_txt(docs_tree, docs_content, families,
-                                                 fw_lang, current, round_name)
+                                                 fw_lang, current, round_name, fw_entries)
 
     n_rows = sum(len(v) for v in results.values())
     print(f"wrote {OUT.relative_to(ROOT)} - {len(profiles)} profiles, "
           f"{len(results)} views, {n_rows} rows, {OUT.stat().st_size // 1024} KB")
     print(f"wrote {DOCS_OUT.relative_to(ROOT)}/ - {n_pages} static doc pages")
     print(f"wrote {(OUT.parent / 'search.js').relative_to(ROOT)} - {n_search} indexed pages, {search_bytes // 1024} KB")
-    print(f"wrote {(GEN / 'sitemap.xml').relative_to(ROOT)} - {n_urls} URLs")
+    print(f"wrote {(GEN / 'sitemap.xml').relative_to(ROOT)} - {n_urls} URLs, "
+          f"{n_dated} with lastmod")
     print(f"wrote {BADGE_OUT.relative_to(ROOT)}/ - {n_badges} badges over {n_badge_fw} frameworks")
+    print(f"wrote {FW_OUT.relative_to(ROOT)}/ - {len(fw_entries)} framework pages + index")
     print(f"wrote {(GEN / 'index.html').relative_to(ROOT)} - board with the "
           f"{SCOPE_NAME[DEFAULT_SCOPE]} composite ({len(board)} entries) pre-rendered, "
           f"{index_bytes // 1024} KB")
     print(f"wrote {(GEN / 'data.json').relative_to(ROOT)} - {json_bytes // 1024} KB")
     print(f"wrote {(GEN / 'llms.txt').relative_to(ROOT)} - {llms_bytes // 1024} KB, "
           f"llms-full.txt {llms_full_bytes // 1024} KB")
-    print(f"wrote {n_cards} og:image cards" if n_cards else "no og:image cards (Pillow missing)")
+    print(f"wrote {n_cards + n_fw_cards} og:image cards"
+          if n_cards else "no og:image cards (Pillow missing)")
 
 
 if __name__ == "__main__":

--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -797,13 +797,30 @@ _THEME_TOGGLE = ("<script>var b=document.getElementById('theme');if(b)b.onclick=
                  "try{localStorage.setItem('lb-theme',n);}catch(e){}};</script>")
 
 
-def _doc_page(did, title, body_html, tree, seo_title="", description=""):
+def _doc_page(did, title, body_html, tree, seo_title="", description="",
+              crumbs=None, og_url=""):
     url = SITE + _doc_url(did)
     # Authored metadata wins; the scraped first paragraph stays as the fallback
     # so a page that hasn't been given frontmatter yet still renders sensibly.
     desc = description or _meta_desc(body_html)
     t = _html.escape(seo_title or title)
     d = _html.escape(desc)
+    # A doc is an article by one publisher, sitting somewhere in a tree. The
+    # breadcrumb is the half that shows: search results print the trail instead
+    # of the bare URL, which is what tells a reader that a page five levels deep
+    # is documentation and not a stray file.
+    graph = [
+        {"@type": "TechArticle", "@id": url + "#article", "headline": seo_title or title,
+         "name": title, "description": desc, "url": url, "inLanguage": "en",
+         "mainEntityOfPage": url, "isPartOf": {"@id": SITE + "/#website"},
+         "publisher": {"@id": SITE + "/#org"},
+         "about": {"@id": SITE + "/#dataset"}},
+    ] + _org_nodes()
+    if crumbs:
+        graph.append({"@type": "BreadcrumbList", "@id": url + "#crumbs",
+                      "itemListElement": [{"@type": "ListItem", "position": i + 1,
+                                           "name": name, "item": SITE + href}
+                                          for i, (name, href) in enumerate(crumbs)]})
     head = ('<!doctype html><html lang="en" data-theme=""><head>'
             '<meta charset="utf-8">'
             '<meta name="viewport" content="width=device-width, initial-scale=1">'
@@ -818,6 +835,8 @@ def _doc_page(did, title, body_html, tree, seo_title="", description=""):
             + '<meta property="og:title" content="' + t + '">'
             + '<meta property="og:description" content="' + d + '">'
             + '<meta property="og:url" content="' + url + '">'
+            + _og_meta(og_url)
+            + _jsonld({"@context": "https://schema.org", "@graph": graph})
             + '<link rel="stylesheet" href="/docs/docs.css">'
             + "</head>")
     # Same markup and classes as the board's header, so crossing between /
@@ -862,7 +881,7 @@ def _docs_css():
 """
 
 
-def build_doc_pages(tree, content):
+def build_doc_pages(tree, content, trails=None, with_og=False):
     """Write a real static page per doc under site/generated/docs/<id>/index.html."""
     if not tree:
         return 0
@@ -870,9 +889,12 @@ def build_doc_pages(tree, content):
         shutil.rmtree(DOCS_OUT)
     DOCS_OUT.mkdir(parents=True, exist_ok=True)
     (DOCS_OUT / "docs.css").write_text(_docs_css(), encoding="utf-8")
+    trails = trails or {}
     for did, d in content.items():
         page = _doc_page(did, d["t"] or "Knowledge Base", d["html"], tree,
-                         seo_title=d.get("st", ""), description=d.get("d", ""))
+                         seo_title=d.get("st", ""), description=d.get("d", ""),
+                         crumbs=trails.get(did),
+                         og_url=(_doc_url(did) + "og.png") if with_og else "")
         dest = (DOCS_OUT / did / "index.html") if did else (DOCS_OUT / "index.html")
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(page, encoding="utf-8")
@@ -1328,6 +1350,412 @@ def write_badges(profiles, results, meta):
     return written, len(index)
 
 
+# ── off-site visibility: social cards, structured data, llms.txt, prerender ──
+# The board is drawn by data.js, so whatever does not run JavaScript arrives on
+# an empty page. Google renders and catches up; the crawlers behind the AI
+# answers do not, and neither does a single link unfurler on X, Reddit, Discord
+# or Slack. The ranking, which is the whole reason the site exists, is invisible
+# to all of them, and so is every framework name in it.
+#
+# Three things fix that and none of them change what a visitor sees:
+#   - the default view (H/1.1 composite, the same one the badges are pinned to)
+#     is written into index.html at build time and overwritten by renderComposite
+#     on boot, so the page has its ranking in the HTML;
+#   - every page gets an og:image and a JSON-LD node, so a shared link unfurls
+#     and the results are declared as a Dataset;
+#   - /llms.txt and /llms-full.txt carry the same ranking and the Knowledge Base
+#     as plain text, for readers that will never run a script.
+
+OG_SIZE = (1200, 630)
+OG_BG = (26, 27, 30)
+OG_ACCENT = (138, 180, 248)
+OG_TEXT = (232, 234, 237)
+OG_MUTED = (154, 160, 166)
+
+SCOPE_NAME = {"h1": "HTTP/1.1", "h2": "HTTP/2", "h3": "HTTP/3",
+              "gw": "Gateway", "grpc": "gRPC", "ws": "WebSocket"}
+SCOPE_BLURB = {"h1": "all HTTP/1.1 profiles", "h2": "all HTTP/2 profiles",
+               "h3": "all HTTP/3 profiles", "gw": "the gateway & production-stack profiles",
+               "grpc": "all gRPC profiles", "ws": "all WebSocket profiles"}
+# The board's own default: view=composite, scope=h1, flagship+emerging, tuned
+# shown, useMem and rescale off. Prerendering anything else would show a crawler
+# a page no visitor lands on.
+DEFAULT_SCOPE = "h1"
+DEFAULT_TYPES = ("flagship", "emerging")
+
+SITE_DESC = ("Independent webserver benchmarks across every major framework and protocol "
+             "(H1, H2, H3, gRPC, WebSocket) in multiple categories.")
+
+
+def _og_ready():
+    """Whether this machine can draw the cards. Pillow is a deploy-time
+    dependency and a local run without it should still produce a site: the
+    pages simply come out without og:image rather than not at all."""
+    try:
+        import PIL  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _og_font(size, bold=False):
+    from PIL import ImageFont
+    names = ("DejaVuSans-Bold.ttf", "LiberationSans-Bold.ttf") if bold else \
+            ("DejaVuSans.ttf", "LiberationSans-Regular.ttf")
+    for base in ("/usr/share/fonts/truetype/dejavu/",
+                 "/usr/share/fonts/truetype/liberation/", ""):
+        for n in names:
+            try:
+                return ImageFont.truetype(base + n, size)
+            except OSError:
+                continue
+    try:
+        return ImageFont.load_default(size=size)   # Pillow >= 10.1: scalable
+    except TypeError:
+        return ImageFont.load_default()
+
+
+def _og_wrap(draw, text, font, width, maxlines):
+    lines, cur = [], ""
+    for word in str(text).split():
+        nxt = (cur + " " + word).strip()
+        if cur and draw.textlength(nxt, font=font) > width:
+            lines.append(cur)
+            cur = word
+            if len(lines) == maxlines:
+                lines[-1] = lines[-1].rstrip(" .") + "…"
+                return lines
+        else:
+            cur = nxt
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def _og_card(dest, kicker, title, rows, footer, blurb=""):
+    """A 1200x630 card in the board's dark palette: wordmark, kicker, title, and
+    an optional monospaced block (the top of the ranking, on the root card)."""
+    from PIL import Image, ImageDraw
+    img = Image.new("RGB", OG_SIZE, OG_BG)
+    d = ImageDraw.Draw(img)
+    d.rectangle([0, 0, OG_SIZE[0], 9], fill=OG_ACCENT)
+
+    mark = _og_font(36, bold=True)
+    d.text((72, 58), "Http", font=mark, fill=OG_ACCENT)
+    d.text((72 + d.textlength("Http", font=mark), 58), "Arena", font=mark, fill=OG_TEXT)
+
+    y = 158
+    if kicker:
+        f = _og_font(26)
+        d.text((72, y), _og_wrap(d, kicker, f, 1056, 1)[0], font=f, fill=OG_MUTED)
+        y += 46
+
+    # The ranking needs half the card, so a title sharing the space with one gets
+    # two lines and a smaller face; a doc title, which is alone here, gets three.
+    size, lead, maxlines = (54, 66, 2) if rows else (62, 76, 3)
+    ft = _og_font(size, bold=True)
+    for line in _og_wrap(d, title, ft, 1056, maxlines):
+        d.text((72, y), line, font=ft, fill=OG_TEXT)
+        y += lead
+
+    if blurb and not rows:
+        fb = _og_font(29)
+        y += 18
+        for line in _og_wrap(d, blurb, fb, 1056, 4):
+            d.text((72, y), line, font=fb, fill=OG_MUTED)
+            y += 40
+
+    if rows:
+        y = max(y + 22, 350)
+        fr = _og_font(29, bold=True)
+        for i, (name, right) in enumerate(rows[:5]):
+            d.text((72, y), f"{i + 1}.", font=fr, fill=OG_MUTED)
+            d.text((122, y), name, font=fr, fill=OG_TEXT)
+            d.text((1128 - d.textlength(right, font=fr), y), right, font=fr, fill=OG_ACCENT)
+            y += 40
+
+    if footer:
+        f = _og_font(23)
+        d.text((72, 566), _og_wrap(d, footer, f, 1056, 1)[0], font=f, fill=OG_MUTED)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Flat background, four ink colours and the antialiasing between them: a
+    # palette holds all of it and is a quarter of the truecolor file. 132 cards
+    # ship with the site, so it is worth the one line.
+    img = img.convert("P", palette=Image.ADAPTIVE, colors=64)
+    img.save(dest, "PNG", optimize=True)
+
+
+def _og_meta(url):
+    """og:image tags for one page, or nothing when the cards were not drawn."""
+    if not url:
+        return ""
+    return ('<meta property="og:image" content="' + SITE + url + '">'
+            '<meta property="og:image:width" content="1200">'
+            '<meta property="og:image:height" content="630">'
+            '<meta name="twitter:card" content="summary_large_image">')
+
+
+def _jsonld(payload):
+    """A ld+json block. The escape is the one thing that matters here: an
+    unescaped </script> inside the JSON ends the block early."""
+    body = json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
+    return '<script type="application/ld+json">' + body + "</script>"
+
+
+def _crumb_trails(tree):
+    """doc id -> [(title, url), ...] from the root of the Knowledge Base down to
+    the page itself. Same walk the search index does, kept separate because that
+    one only needs the label and this one needs the links too."""
+    trails = {}
+
+    def walk(node, trail):
+        here = trail + [(node["t"], _doc_url(node["u"]))]
+        trails[node["u"]] = here
+        for child in node.get("c") or []:
+            walk(child, here)
+
+    if tree:
+        walk(tree, [])
+    return trails
+
+
+def _org_nodes():
+    """The two nodes every page's graph points at, so the site is one publisher
+    and not one anonymous publisher per page."""
+    return [
+        {"@type": "Organization", "@id": SITE + "/#org", "name": "HttpArena",
+         "url": SITE + "/", "logo": SITE + "/favicon.svg",
+         "sameAs": ["https://github.com/MDA2AV/HttpArena"]},
+        {"@type": "WebSite", "@id": SITE + "/#website", "url": SITE + "/",
+         "name": "HttpArena", "inLanguage": "en",
+         "publisher": {"@id": SITE + "/#org"}},
+    ]
+
+
+def _dataset_node(current, n_frameworks, n_profiles, round_name):
+    """The results, declared as a dataset. This is the one piece of structured
+    data with a channel of its own behind it - Google Dataset Search indexes
+    Dataset nodes, and a benchmark is exactly what it is looking for."""
+    hw = " ".join(x for x in [current.get("cpu", ""), current.get("os", "")] if x)
+    return {
+        "@type": "Dataset", "@id": SITE + "/#dataset",
+        "name": "HttpArena web server benchmark results",
+        "description": (f"Throughput, latency, CPU and memory for {n_frameworks} web frameworks, "
+                        f"HTTP engines and reverse proxies over {n_profiles} benchmark profiles "
+                        f"(HTTP/1.1, HTTP/2, HTTP/3, gRPC and WebSocket), every entry run on the "
+                        f"same machine{' - ' + hw if hw else ''}."),
+        "url": SITE + "/", "isAccessibleForFree": True, "inLanguage": "en",
+        "license": "https://github.com/MDA2AV/HttpArena/blob/main/LICENSE",
+        "creator": {"@id": SITE + "/#org"}, "publisher": {"@id": SITE + "/#org"},
+        "keywords": ["web server benchmark", "http benchmark", "framework performance",
+                     "requests per second", "latency", "HTTP/2", "HTTP/3", "gRPC", "WebSocket"],
+        "measurementTechnique": ("Closed-loop load generation against containerised servers pinned "
+                                 "to dedicated cores on a single machine, one connection count per run."),
+        "variableMeasured": [{"@type": "PropertyValue", "name": n} for n in
+                             ("Requests per second", "Average latency", "p99 latency",
+                              "CPU utilisation", "Peak memory", "Bandwidth")],
+        "version": round_name,
+        "distribution": [{"@type": "DataDownload", "encodingFormat": "application/json",
+                          "contentUrl": SITE + "/data.json",
+                          "name": "Every published result, as one JSON document"}],
+    }
+
+
+def _ranking_node(scope, rows):
+    return {
+        "@type": "ItemList", "@id": SITE + "/#ranking-" + scope,
+        "name": SCOPE_NAME[scope] + " composite ranking",
+        "itemListOrder": "https://schema.org/ItemListOrderDescending",
+        "numberOfItems": len(rows),
+        "itemListElement": [{"@type": "ListItem", "position": i + 1, "name": fw}
+                            for i, (fw, _) in enumerate(rows[:20])],
+    }
+
+
+def write_data_json(payload):
+    """The same document data.js assigns to window.LB_DATA, as plain JSON.
+
+    data.js is a script and can only be consumed by running it; this is the file
+    the Dataset node above points at, and the one anybody scripting against the
+    results should read."""
+    GEN.mkdir(parents=True, exist_ok=True)
+    out = GEN / "data.json"
+    out.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+    return out.stat().st_size
+
+
+def _rank_lines(rows, fw_lang, limit=None):
+    return ["%3d. %-26s %-14s %6.0f" % (i + 1, fw, fw_lang.get(fw, "") or "-", score)
+            for i, (fw, score) in enumerate(rows[:limit] if limit else rows)]
+
+
+def write_llms_txt(tree, content, families, fw_lang, current, round_name):
+    """/llms.txt and /llms-full.txt.
+
+    Same reason as the prerender, for the readers the prerender cannot reach:
+    the board has six families and only the default one can be written into the
+    page. Here all six fit, as text, next to a link to every doc."""
+    trails = _crumb_trails(tree)
+    hw = current.get("cpu", "")
+    head = [
+        "# HttpArena",
+        "",
+        "> " + SITE_DESC,
+        "",
+        "Every entry runs in a container on the same machine"
+        + (f" ({hw}, {current.get('cores', '?')} cores)" if hw else "")
+        + ", pinned to dedicated cores, one connection count per run. Round: " + round_name + ".",
+        "",
+        "The leaderboard at " + SITE + "/ is rendered client-side, so the ranking below is the "
+        "same data as text. Scores are the composite: each profile is worth 100 to the best entry "
+        "in the field and a framework's score is the sum over the profiles of that family.",
+        "",
+    ]
+
+    short, full = list(head), list(head)
+    for scope, rows in families:
+        if not rows:
+            continue
+        title = f"## {SCOPE_NAME[scope]} composite ranking - flagship and emerging, {len(rows)} entries"
+        short += [title, "", "```", *_rank_lines(rows, fw_lang, 20), "```", ""]
+        if len(rows) > 20:
+            short += [f"Full field: {SITE}/llms-full.txt", ""]
+        full += [title, "", "```", *_rank_lines(rows, fw_lang), "```", ""]
+
+    docs = ["## Documentation", ""]
+    for did in sorted(content):
+        d = content[did]
+        crumb = " > ".join(t for t, _ in trails.get(did, [])[:-1])
+        desc = d.get("d") or _meta_desc(d["html"])
+        docs.append(f"- [{d['t'] or 'Knowledge Base'}]({SITE}{_doc_url(did)})"
+                    + (f" ({crumb})" if crumb else "") + (f": {desc}" if desc else ""))
+    docs.append("")
+
+    data = ["## Data", "",
+            f"- [data.json]({SITE}/data.json): every published result in one JSON document, "
+            "the same one the board reads.",
+            f"- [Badge endpoints]({SITE}/badge/index.json): per-framework rank, as shields.io endpoints.",
+            f"- [Source and framework entries](https://github.com/MDA2AV/HttpArena): "
+            "every server implementation, Dockerfile and validation rule.",
+            ""]
+
+    short += docs + data + ["## Full text", "",
+                            f"- [llms-full.txt]({SITE}/llms-full.txt): the whole Knowledge Base "
+                            "and the full ranking of every family.", ""]
+    full += data + ["## Knowledge Base", ""]
+    for did in sorted(content):
+        d = content[did]
+        text = _html.unescape(re.sub(r"<[^>]+>", " ", d["html"]))
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text).strip()
+        full += [f"### {d['t'] or 'Knowledge Base'}", "", f"Source: {SITE}{_doc_url(did)}", "",
+                 text, ""]
+
+    GEN.mkdir(parents=True, exist_ok=True)
+    (GEN / "llms.txt").write_text("\n".join(short), encoding="utf-8")
+    (GEN / "llms-full.txt").write_text("\n".join(full), encoding="utf-8")
+    return (GEN / "llms.txt").stat().st_size, (GEN / "llms-full.txt").stat().st_size
+
+
+def _static_board(rows, fw_lang, round_name):
+    """The default view as a plain table, for the HTML."""
+    body = []
+    for i, (fw, score) in enumerate(rows):
+        rank = i + 1
+        body.append('<tr><td class="n%s">%d</td><td>%s</td><td class="sb-lang">%s</td>'
+                    '<td class="n">%.0f</td></tr>'
+                    % (" r%d" % rank if rank <= 3 else "", rank,
+                       _html.escape(fw), _html.escape(fw_lang.get(fw, "") or ""), score))
+    others = ", ".join(SCOPE_NAME[s] for s in SCOPE_NAME if s != DEFAULT_SCOPE)
+    return ('<table class="sb"><thead><tr><th>#</th><th>Framework</th><th>Language</th>'
+            '<th class="n">Composite</th></tr></thead><tbody>' + "".join(body) + "</tbody></table>"
+            '<p class="sb-note">' + _html.escape(round_name) + ", " + str(len(rows)) +
+            " entries, best first. The interactive board - per-profile numbers, memory efficiency, "
+            "the other families (" + _html.escape(others) + ") - needs JavaScript; the same "
+            'rankings are also published as text at <a href="/llms.txt">/llms.txt</a>.</p>')
+
+
+def build_index_page(rows, fw_lang, current, round_name, n_profiles, og_url):
+    """site/generated/index.html: the board with its default view already in it.
+
+    Written from the checked-in page rather than replacing it, so the source
+    stays the thing you open locally. Every marker is required to appear exactly
+    once: if the board's markup moves, this fails the deploy instead of quietly
+    shipping an empty page again."""
+    src = (ROOT / "site" / "leaderboard" / "index.html").read_text(encoding="utf-8")
+
+    def once(html, needle, repl, what):
+        if html.count(needle) != 1:
+            raise SystemExit(f"[fatal] prerender: expected exactly one {what} in "
+                             f"site/leaderboard/index.html, found {html.count(needle)}")
+        return html.replace(needle, repl, 1)
+
+    graph = _org_nodes() + [
+        _dataset_node(current, len(rows), n_profiles, round_name),
+        _ranking_node(DEFAULT_SCOPE, rows),
+    ]
+    head = ('<meta property="og:type" content="website">'
+            '<meta property="og:site_name" content="HttpArena">'
+            '<meta property="og:title" content="HTTP Web Server Benchmarks – HttpArena">'
+            '<meta property="og:description" content="' + _html.escape(SITE_DESC) + '">'
+            '<meta property="og:url" content="' + SITE + '/">'
+            + _og_meta(og_url)
+            + _jsonld({"@context": "https://schema.org", "@graph": graph}))
+
+    # The three header fields renderHead() fills for the default view, filled
+    # with the same strings so the pre-rendered page and the rendered one say
+    # the same thing.
+    blurb = ("Normalized score summed across " + SCOPE_BLURB[DEFAULT_SCOPE] +
+             " (each profile worth 100 to its leader in the full field, so filtering does not "
+             'change the numbers), per framework type. Higher is better. '
+             '<a href="/docs/scoring/composite-score/">How it works →</a>')
+
+    out = once(src, "</head>", head + "</head>", "</head>")
+    out = once(out, '<div class="cat" id="pcat"></div>',
+               '<div class="cat" id="pcat">Composite ranking</div>', "#pcat")
+    out = once(out, '<h1 id="ptitle"></h1>',
+               '<h1 id="ptitle">' + SCOPE_NAME[DEFAULT_SCOPE] + "</h1>", "#ptitle")
+    out = once(out, '<p id="pblurb"></p>', '<p id="pblurb">' + blurb + "</p>", "#pblurb")
+    out = once(out, '<span class="count" id="count"></span>',
+               '<span class="count" id="count">' + str(len(rows)) + " frameworks</span>", "#count")
+    out = once(out, '<div id="rows"></div>',
+               '<div id="rows">' + _static_board(rows, fw_lang, round_name) + "</div>", "#rows")
+
+    GEN.mkdir(parents=True, exist_ok=True)
+    (GEN / "index.html").write_text(out, encoding="utf-8")
+    return (GEN / "index.html").stat().st_size
+
+
+def build_og_images(content, trails, rows, fw_lang, round_name):
+    """One card for the board and one per doc. Returns the root card's URL (or
+    "" when Pillow is missing), plus how many were written."""
+    if not _og_ready():
+        print("[warn] Pillow not installed - no og:image cards, pages ship without them")
+        # an earlier run's card would otherwise stay behind, with no page left
+        # pointing at it
+        (GEN / "og.png").unlink(missing_ok=True)
+        return "", 0
+
+    GEN.mkdir(parents=True, exist_ok=True)
+    top = [(fw, "%.0f" % score) for fw, score in rows[:5]]
+    _og_card(GEN / "og.png",
+             "Composite ranking · " + SCOPE_NAME[DEFAULT_SCOPE],
+             "Which web framework is actually fastest?",
+             top,
+             f"{len(rows)} entries · {round_name} · www.http-arena.com")
+    written = 1
+
+    for did, d in content.items():
+        crumb = " › ".join(t for t, _ in trails.get(did, [])[:-1]) or "Knowledge Base"
+        _og_card(DOCS_OUT / did / "og.png" if did else DOCS_OUT / "og.png",
+                 crumb, d["t"] or "Knowledge Base", [],
+                 "HttpArena Knowledge Base · www.http-arena.com",
+                 blurb=d.get("d") or _meta_desc(d["html"]))
+        written += 1
+    return "/og.png", written
+
+
 def main():
     global RESULTS
     RESULTS = load_results()
@@ -1391,10 +1819,30 @@ def main():
     # Docs are pre-rendered to real /docs/<id>/ pages (SEO); the SPA links out to
     # them. LB_DATA still carries the docs *tree* for the sidebar labels, but the
     # doc *content* is no longer shipped as docs.js.
-    n_pages = build_doc_pages(docs_tree, docs_content)
+    trails = _crumb_trails(docs_tree)
+    n_pages = build_doc_pages(docs_tree, docs_content, trails, with_og=_og_ready())
     n_search, search_bytes = write_search_index(docs_tree, docs_content)
     n_urls = write_sitemap(docs_content)
     n_badges, n_badge_fw = write_badges(profiles, results, meta)
+
+    # The board's default view, and the same view for the other five families.
+    # Same port of computeComposite() the badges use, so the ranking written into
+    # the page cannot disagree with the one the page draws over it.
+    agg = badge_aggregate(profiles, results)
+    fw_lang = _fw_languages(results)
+    families = [(scope, badge_composite(agg, profiles, meta, scope, DEFAULT_TYPES,
+                                        show_tuned=True, fw_lang=fw_lang))
+                for scope in SCOPE_NAME]
+    board = dict(families)[DEFAULT_SCOPE]
+    round_name = payload["rounds"]["name"]
+
+    # og cards go in after build_doc_pages: that one clears site/generated/docs/
+    # before it writes, and the per-doc cards live inside it.
+    og_url, n_cards = build_og_images(docs_content, trails, board, fw_lang, round_name)
+    json_bytes = write_data_json(payload)
+    index_bytes = build_index_page(board, fw_lang, current, round_name, len(profiles), og_url)
+    llms_bytes, llms_full_bytes = write_llms_txt(docs_tree, docs_content, families,
+                                                 fw_lang, current, round_name)
 
     n_rows = sum(len(v) for v in results.values())
     print(f"wrote {OUT.relative_to(ROOT)} - {len(profiles)} profiles, "
@@ -1403,6 +1851,13 @@ def main():
     print(f"wrote {(OUT.parent / 'search.js').relative_to(ROOT)} - {n_search} indexed pages, {search_bytes // 1024} KB")
     print(f"wrote {(GEN / 'sitemap.xml').relative_to(ROOT)} - {n_urls} URLs")
     print(f"wrote {BADGE_OUT.relative_to(ROOT)}/ - {n_badges} badges over {n_badge_fw} frameworks")
+    print(f"wrote {(GEN / 'index.html').relative_to(ROOT)} - board with the "
+          f"{SCOPE_NAME[DEFAULT_SCOPE]} composite ({len(board)} entries) pre-rendered, "
+          f"{index_bytes // 1024} KB")
+    print(f"wrote {(GEN / 'data.json').relative_to(ROOT)} - {json_bytes // 1024} KB")
+    print(f"wrote {(GEN / 'llms.txt').relative_to(ROOT)} - {llms_bytes // 1024} KB, "
+          f"llms-full.txt {llms_full_bytes // 1024} KB")
+    print(f"wrote {n_cards} og:image cards" if n_cards else "no og:image cards (Pillow missing)")
 
 
 if __name__ == "__main__":

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -243,6 +243,18 @@
   .tfilter button.on{background:var(--text); color:var(--bg); border-color:var(--text)}
   .count{margin-left:auto; color:var(--muted); font-size:.8rem; font-variant-numeric:tabular-nums}
 
+  /* Build-time ranking, written into #rows by gen_leaderboard_data.py and thrown
+     away by renderComposite() as soon as data.js has been parsed. It is what a
+     reader without JavaScript gets, and what paints first for everyone else. */
+  .sb{width:100%; border-collapse:collapse; font-size:.86rem}
+  .sb th,.sb td{padding:.44rem .55rem; border-bottom:1px solid var(--line-soft); text-align:left}
+  .sb th{color:var(--muted); font-size:.72rem; font-weight:650; letter-spacing:.02em; text-transform:uppercase}
+  .sb td.n,.sb th.n{text-align:right; font-family:var(--mono); font-variant-numeric:tabular-nums}
+  .sb td.r1{color:var(--gold); font-weight:700} .sb td.r2{color:var(--silver); font-weight:700} .sb td.r3{color:var(--bronze); font-weight:700}
+  .sb .sb-lang{color:var(--text-2)}
+  .sb-note{color:var(--muted); font-size:.78rem; margin:.9rem 0 0}
+  .sb-note a{color:var(--accent)}
+
   .grid{--cols:54px minmax(250px,2fr) minmax(150px,1fr) 112px 92px 92px 96px 86px}
   .thead,.row{display:grid; grid-template-columns:var(--cols); align-items:center}
   .thead{position:sticky; top:57px; z-index:10; background:var(--bg); padding:.1rem 0 .55rem; border-bottom:1px solid var(--line); font-size:.72rem; font-weight:650; color:var(--muted); letter-spacing:.02em; text-transform:uppercase}

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -498,10 +498,13 @@
     </main>
   </div>
 
-<script src="data.js"></script>
-<script src="search.js"></script>
+<!-- deferred so the browser can paint the pre-rendered ranking before it spends
+     anything parsing 700KB of results. search.js is not here at all: it is the
+     Knowledge Base index, 290KB for a search box most visits never touch, and
+     initNavSearch() fetches it the first time someone uses it. -->
+<script defer src="data.js"></script>
 <script>
-(function(){
+document.addEventListener('DOMContentLoaded', function(){
   "use strict";
   var D = window.LB_DATA;
   var LB_DOCS = window.LB_DOCS || {};
@@ -580,6 +583,9 @@
     document.addEventListener('mouseout', function(e){ var el=e.target.closest?e.target.closest('[data-tip]'):null; if(el && !el.contains(e.relatedTarget)) tip.style.display='none'; });
     document.addEventListener('scroll', function(){ tip.style.display='none'; }, true);
   }
+  // URL segment for an entry's own page under /frameworks/. Must stay in step
+  // with _slug() in gen_leaderboard_data.py, which is what names the directory.
+  function slugOf(fw){ return String(fw).replace(/[^A-Za-z0-9._-]+/g,'-').replace(/^-|-$/g,'').toLowerCase() || 'unnamed'; }
   function openModal(fw){
     var m=D.meta[fw]||{}, lang=langOf(fw)||m.language||'', c=lc(lang), t=m.type||'emerging', dir=m.dir||fw;
     var impl='https://github.com/MDA2AV/HttpArena/tree/main/frameworks/'+encodeURIComponent(dir);
@@ -589,6 +595,7 @@
       + '<div class="modal-meta">'+esc([lang, m.engine, typeAbbr(t), modeOf(fw)==='tuned'?'tuned':''].filter(Boolean).join(' · '))+'</div>';
     if(m.desc) h+='<p class="modal-desc">'+esc(m.desc)+'</p>';
     h+='<div class="modal-links">';
+    h+='<a href="/frameworks/'+encodeURIComponent(slugOf(fw))+'/"><span>Results page</span><span>→</span></a>';
     if(m.repo) h+='<a href="'+esc(m.repo)+'" target="_blank" rel="noopener"><span>Official repository</span><span>↗</span></a>';
     h+='<a href="'+impl+'" target="_blank" rel="noopener"><span>Benchmark implementation</span><span>↗</span></a>';
     if(state.view==='profile' && state.profile && state.conns){
@@ -889,13 +896,26 @@
   // Clear before navigating: pickDoc/pickProfile rebuild the tree, and the
   // user should land back on a normal menu showing where they now are.
   function openSel(i){ var hit=SHITS[i]; if(!hit) return; var go=hit.e.go; clearSearch(); go(); }
+  // The Knowledge Base index is only needed by this box, so it is fetched the
+  // first time the box is used and never on a visit that ignores it.
+  var _searchReq=null, _searchCb=null;
+  function ensureSearch(cb){
+    if(window.LB_SEARCH){ if(cb) cb(); return; }
+    _searchCb=cb;
+    if(_searchReq) return;
+    _searchReq=document.createElement('script'); _searchReq.src='search.js';
+    _searchReq.onload=function(){ var f=_searchCb; _searchCb=null; if(f) f(); };
+    _searchReq.onerror=function(){ _searchReq=null; };
+    document.head.appendChild(_searchReq);
+  }
   function initNavSearch(){
     var inp=document.getElementById('navq'), box=document.getElementById('navResults');
     if(!inp||!box) return;
     var t;
+    inp.addEventListener('focus', function(){ ensureSearch(null); }, {once:true});
     inp.addEventListener('input', function(){
       clearTimeout(t); var v=inp.value.trim();
-      t=setTimeout(function(){ renderSearch(v); }, 90);
+      t=setTimeout(function(){ if(!v) renderSearch(v); else ensureSearch(function(){ renderSearch(v); }); }, 90);
     });
     inp.addEventListener('keydown', function(e){
       if(e.key==='ArrowDown'){ e.preventDefault(); moveSel(1); }
@@ -1386,7 +1406,7 @@
   (function(){ var b=document.getElementById('brandHome'); if(b) b.onclick=function(e){ e.preventDefault(); pickScope('h1'); }; })();
   window.addEventListener('hashchange', function(){ restoreFromHash(); buildNav(); renderHead(); render(); });
   var _rz; window.addEventListener('resize', function(){ clearTimeout(_rz); _rz=setTimeout(function(){ if(state.view==='profile') render(); else if(state.view==='composite') syncTopScroll(); }, 150); });
-})();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
ref https://github.com/MDA2AV/HttpArena/issues/847

The Knowledge Base is pre-rendered, the leaderboard is not: `/` ships an empty `<h1>` and the whole ranking arrives from data.js. Google renders and catches up, but the crawlers behind the AI answers do not, and no link unfurler does. On top of that every board state is a `#hash`, and hashes are ignored, so the entire site was one indexable URL.

Everything below happens at build time and none of it changes what a visitor sees.

**A page per framework**, at `/frameworks/<slug>/`: rank in every family it runs, every per-profile number, links to its repo and to its entry here. 157 pages, plus an index at `/frameworks/`. The board links to them from the modal and from the pre-rendered table. This is the part that pays the frameworks back: a page that answers "axum benchmark" or "fiber benchmark" gets found by people searching exactly that, and the traffic lands on their entry. It is a real argument for asking a maintainer to join and to stay.

The rest:

- the default view (H/1.1 composite) is written into `#rows` and `renderComposite()` overwrites it on boot. Same Python port of `computeComposite()` the badges use, so `check_badge_parity.js` already guards it
- og:image cards for the board, every doc and every framework, drawn with Pillow. Without Pillow the cards are skipped and the site still builds
- JSON-LD: `Dataset` on the root (Google Dataset Search indexes those), `TechArticle` and `BreadcrumbList` on the docs, `SoftwareApplication` on each framework
- `/llms.txt` and `/llms-full.txt`: all six family rankings, every framework, the whole Knowledge Base as text
- `/data.json`: the same document as data.js but readable without running it, and what the `Dataset` points at
- `<lastmod>` in the sitemap, taken from the last commit that touched each page's source. It needs `fetch-depth: 0`, which this PR adds; on a shallow clone the generator drops the field instead of dating everything today
- data.js is now `JSON.parse('...')` instead of an object literal. V8 parses it about three times faster, 18.1ms against 5.6ms on this payload (medians of nine cold runs, node 26), and the file is the same size because the JSON goes in single quotes and so its double quotes need no escaping. Same change for search.js
- data.js is deferred, and search.js is no longer loaded at all until someone uses the search box. It is 290KB of Knowledge Base text that every doc page was paying for

Two things you may want to do outside the repo:

- add the site to [Google Search Console](https://search.google.com/search-console) and submit `https://www.http-arena.com/sitemap.xml` there. It is the fastest way to get 290 new URLs crawled, and it also reports which queries the framework pages start ranking for
- the site is on HTTP/2 already, but Pages has no HTTP/3 and no brotli. Free Cloudflare in front of the domain gives both. A benchmark that measures HTTP/3 may as well be served over it

One last thing: if you ever want the site itself faster, there is a framework in the arena for that. Number five on H/1.1. 🙂

<img width="818" height="261" alt="image" src="https://github.com/user-attachments/assets/d254c3b9-c087-492e-99b7-018c951c84a2" />

<img width="1283" height="710" alt="image" src="https://github.com/user-attachments/assets/abe34fa9-71ea-4c27-8c22-c2d8cfb325d8" />

<img width="1006" height="850" alt="image" src="https://github.com/user-attachments/assets/bfc30d6e-e2c6-4533-9ed3-9339d7106757" />

social card on link share

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/db2632fa-1ea7-4e47-8aa4-2ed8a15d6fc4" />
