### PR TITLE
site: move the Frameworks button beside the round selector, answer the question language pages get asked

### DIFF
--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -693,7 +693,7 @@ _SHARED_EXACT = {
     ":root", "html", "body", "a", "*",
     ".top", ".brand", ".brand-name", ".brand-name b", ".brand-name:hover",
     ".icon-btn", ".icon-btn:hover", ".icon-btn svg", ".top-links",
-    ".top-link", ".top-link:hover",
+    ".fw-btn", ".fw-btn svg", ".fw-btn:hover",
 }
 _SHARED_PREFIX = (".doc-", ".type-rules", ".tr-sq", ".nav", ".ns-box", ".caret")
 
@@ -737,16 +737,22 @@ def board_chrome():
     brand = re.search(r'<div class="brand">(.*?)</div>', html, re.S)
     links = re.search(r'<div class="top-links">(.*?)</div>', html, re.S)
     style = re.search(r"<style>(.*?)</style>", html, re.S)
-    if not (brand and links and style):
+    # The Frameworks button lives beside the board's round selector, which no
+    # generated page has, so it is lifted separately rather than riding along
+    # inside .top-links. Same rule as the rest of the chrome: read the board,
+    # never retype it.
+    fwbtn = re.search(r'<a class="fw-btn".*?</a>', html, re.S)
+    if not (brand and links and style and fwbtn):
         raise SystemExit(f"gen: cannot read site chrome from {BOARD.relative_to(ROOT)} - "
-                         "expected .brand, .top-links and a <style> block")
+                         "expected .brand, .top-links, .fw-btn and a <style> block")
     shared = [r for r in _top_level_rules(style.group(1)) if _is_shared(r)]
     if len(shared) < 40:
         raise SystemExit(f"gen: only {len(shared)} shared CSS rules found in "
                          f"{BOARD.relative_to(ROOT)} - the selector list is stale")
     # the board's brand link drives its in-page router; on a doc page it goes home
     brand_html = brand.group(1).strip().replace('href="#" id="brandHome"', 'href="/"')
-    return brand_html, links.group(1).strip(), "\n".join(shared)
+    return (brand_html, links.group(1).strip(), "\n".join(shared),
+            fwbtn.group(0).strip())
 
 
 # Resolved once at import: the board's chrome, shared by every generated page.
@@ -864,7 +870,8 @@ def _doc_page(did, title, body_html, tree, seo_title="", description="",
     header = ('<body><header class="top">'
               '<div class="brand">' + _CHROME[0] + '</div>'
               '<a class="brand-sub" href="/docs/">Knowledge Base</a>'
-              '<div class="top-links">' + _CHROME[1] + '</div>'
+              + _CHROME[3]
+              + '<div class="top-links">' + _CHROME[1] + '</div>'
               '</header>')
     body = ('<div class="docs-layout">'
             '<aside class="nav">' + _sidebar(tree, did) + '</aside>'
@@ -898,6 +905,8 @@ def _docs_css():
 .fw-kind{color:var(--muted);font-size:.78rem}
 /* the "compare these N entries" line under each language heading on /frameworks/ */
 .fw-compare{margin:-.4rem 0 .6rem;font-size:.85rem}
+/* the one-sentence answer at the top of a language page, before any table */
+.lead-answer{font-size:1.02rem;line-height:1.6;padding:.85rem 1rem;margin:0 0 1rem;border-left:3px solid var(--accent);background:var(--panel-2);border-radius:0 8px 8px 0}
 .doc-main{min-width:0;padding:1.6rem 2rem 4rem;max-width:900px}
 .doc-wrap{max-width:none}
 .nav-grp-link{display:block;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:inherit;font:inherit;text-decoration:none}
@@ -1888,6 +1897,16 @@ def kind_has_mode(kind):
     return kind in MODE_TYPES
 
 
+# What an entry of this tier is, in a sentence. Used where prose would otherwise
+# call a reverse proxy a web framework.
+_KIND_NOUN = {"engine": "an HTTP engine",
+              "infrastructure": "a reverse proxy or static-file server"}
+
+
+def _a_kind(kind):
+    return _KIND_NOUN.get(kind, "a web framework")
+
+
 def _fw_url(fw):
     return "/frameworks/" + _slug(fw) + "/"
 
@@ -2055,6 +2074,73 @@ def _fw_page(fw, m, lang, ranks, runs, round_name, og_url, lang_url=""):
     return head + header + body + _THEME_TOGGLE + "</body></html>"
 
 
+def _lang_faq(lang, scopes, n_entries, round_name):
+    """[(question, answer)] for one language, generated from its own rows.
+
+    "fastest <language> web framework" is the question these pages exist to
+    answer, and it is a question people type and assistants get asked. Neither
+    reads a table cell: they quote a sentence. So the answers are written out as
+    sentences, from the same rows the tables are built from, and emitted again
+    as FAQPage data so a machine reading the markup gets the same numbers.
+
+    "Fastest" is the word people use; the composite is what is actually being
+    compared, so each answer names it rather than letting the word stand alone.
+    """
+    e = _html.escape
+    qa = []
+    lead = scopes.get(DEFAULT_SCOPE) or (next(iter(scopes.values())) if scopes else None)
+    if lead:
+        fw, kind, tuned, score, rank, of, _link, lrank, lof = lead[0]
+        # nginx is not a C web framework and swerver is not a Zig one. Ask the
+        # question the leader can actually answer, and answer the framework one
+        # separately with the quickest entry that is a framework.
+        is_fw = kind_has_mode(kind)
+        qa.append((
+            f"What is the fastest {lang} web framework?" if is_fw
+            else f"What is the fastest {lang} HTTP server?",
+            f"{fw}"
+            + ("" if is_fw else f", {_a_kind(kind)},")
+            + f" leads the {lang} entries in HttpArena with a composite score of "
+              f"{score:.0f} on {SCOPE_NAME[DEFAULT_SCOPE]}, measured over {round_name}. "
+              f"The composite sums a normalized score across the profiles of a family, "
+              f"where the leader of each profile scores 100. Against every language, "
+              f"{fw} ranks {rank} of {of} in its own league."
+            + (f" It is a tuned entry, so it is ranked in the field that includes "
+               f"tuned configurations." if tuned else "")))
+        if not is_fw:
+            top_fw = next((r for r in lead if kind_has_mode(r[1])), None)
+            if top_fw:
+                qa.append((
+                    f"What is the fastest {lang} web framework?",
+                    f"{top_fw[0]}, with a composite of {top_fw[3]:.0f} on "
+                    f"{SCOPE_NAME[DEFAULT_SCOPE]}. {fw} scores higher but is "
+                    f"{_a_kind(kind)}, not a framework, and is ranked in its own league."))
+    for scope, rows in scopes.items():
+        if scope == DEFAULT_SCOPE or not rows:
+            continue
+        fw, _k, _t, score, rank, of, _l, _lr, _lo = rows[0]
+        qa.append((
+            f"What is the fastest {lang} {SCOPE_NAME[scope]} server?",
+            f"{fw}, with a composite of {score:.0f} on {SCOPE_NAME[scope]} and "
+            f"{rank} of {of} against all languages in its league."))
+    qa.append((
+        f"How many {lang} web frameworks are benchmarked?",
+        f"{n_entries} {lang} " + ("entry is" if n_entries == 1 else "entries are")
+        + f" measured, covering {', '.join(SCOPE_NAME[s] for s in scopes) or 'no family'}"
+          f". Every one runs on the same machine, in the same round ({round_name}), "
+          f"against the same profiles."))
+    if lead:
+        fw = lead[0][0]
+        qa.append((
+            f"Is {lang} fast for web servers?",
+            f"The quickest {lang} entry, {fw}, places {lead[0][4]} of {lead[0][5]} on "
+            f"{SCOPE_NAME[DEFAULT_SCOPE]} across every language in its league, so that "
+            f"placing is the honest answer for {lang} at its best rather than for "
+            f"{lang} in general. The tables below show the spread across all "
+            f"{n_entries} " + ("entry" if n_entries == 1 else "entries") + "."))
+    return [(e(q), e(a)) for q, a in qa]
+
+
 def _lang_page(lang, scopes, all_entries, round_name):
     """/frameworks/lang/<language>/ - one language's entries, compared family by family.
 
@@ -2069,8 +2155,18 @@ def _lang_page(lang, scopes, all_entries, round_name):
     title = lang + " web framework benchmarks"
     n = len(all_entries)
     fams = ", ".join(SCOPE_NAME[s] for s in scopes)
-    desc = (f"{n} {lang} web framework{'s' if n != 1 else ''} benchmarked by HttpArena, "
-            f"compared on {fams}: composite score, rank overall and rank among {lang}.")
+    faq = _lang_faq(lang, scopes, n, round_name)
+    lead_row = (scopes.get(DEFAULT_SCOPE) or (next(iter(scopes.values())) if scopes else None))
+    lead_fw = lead_row[0][0] if lead_row else ""
+    # Description leads with the answer rather than describing the page: it is
+    # the search snippet, and the first line an assistant reads.
+    desc = ((f"The fastest {lang} "
+             + ("web framework" if kind_has_mode(lead_row[0][1]) else "HTTP server")
+             + f" in HttpArena is {lead_fw} "
+               f"(composite {lead_row[0][3]:.0f} on {SCOPE_NAME[DEFAULT_SCOPE]}). "
+             if lead_row else "")
+            + f"All {n} {lang} entr{'y' if n == 1 else 'ies'} compared on {fams}: "
+              f"composite score, rank overall and rank among {lang}.")
 
     tables = []
     for scope, rows in scopes.items():
@@ -2103,7 +2199,10 @@ def _lang_page(lang, scopes, all_entries, round_name):
             {"@type": "ListItem", "position": 1, "name": "Frameworks",
              "item": SITE + "/frameworks/"},
             {"@type": "ListItem", "position": 2, "name": lang, "item": url}]},
-    ] + _org_nodes()
+    ] + ([{"@type": "FAQPage", "@id": url + "#faq", "mainEntity": [
+            {"@type": "Question", "name": q,
+             "acceptedAnswer": {"@type": "Answer", "text": a}} for q, a in faq]}]
+         if faq else []) + _org_nodes()
     head = ('<!doctype html><html lang="en" data-theme=""><head>'
             '<meta charset="utf-8">'
             '<meta name="viewport" content="width=device-width, initial-scale=1">'
@@ -2126,6 +2225,27 @@ def _lang_page(lang, scopes, all_entries, round_name):
               '<a class="brand-sub" href="/frameworks/">Frameworks</a>'
               '<div class="top-links">' + _CHROME[1] + '</div>'
               '</header>')
+    # The answer first, in a sentence, before any table. Both a reader skimming
+    # and an assistant summarising take the first paragraph.
+    answer = ""
+    if lead_row:
+        fw, kind, tuned, score, rank, of, link, _lr, _lo = lead_row[0]
+        is_fw = kind_has_mode(kind)
+        extra = ""
+        if not is_fw:
+            top_fw = next((r for r in lead_row if kind_has_mode(r[1])), None)
+            if top_fw:
+                extra = (' The quickest %s <i>framework</i> is <a href="%s"><b>%s</b></a>, '
+                         'at %.0f.' % (e(lang), _fw_url(top_fw[0]), e(top_fw[0]), top_fw[3]))
+        answer = ('<p class="lead-answer">The fastest %s %s in HttpArena is '
+                  '<a href="%s"><b>%s</b></a>%s, with a composite of %.0f on %s &mdash; '
+                  '<a href="%s">%d of %d</a> against every language in its league. '
+                  'Measured over %s, every entry on the same machine.%s%s</p>'
+                  % (e(lang), "web framework" if is_fw else "HTTP server",
+                     _fw_url(fw), e(fw), "" if is_fw else " (%s)" % e(_a_kind(kind)),
+                     score, e(SCOPE_NAME[DEFAULT_SCOPE]),
+                     e(link), rank, of, e(round_name),
+                     " This is a tuned entry." if tuned else "", extra))
     intro = ("<p>Every %s entry in the benchmark, compared on the composite score of each "
              "family. The composite sums a normalized score over the profiles of that family, "
              "where the leader of each profile scores 100. Rank overall is the entry's place in "
@@ -2148,7 +2268,9 @@ def _lang_page(lang, scopes, all_entries, round_name):
                      "it is listed" if len(rest) == 1 else "they are listed"))
     body = ('<div class="docs-layout one-col"><main class="doc-main">'
             '<article class="doc-wrap"><h1 class="doc-title">' + e(title) + "</h1>"
-            '<div class="doc-body">' + intro + "".join(tables)
+            '<div class="doc-body">' + answer + intro + "".join(tables)
+            + ("<h2 id=\"faq\">Questions</h2>"
+               + "".join('<h3>%s</h3><p>%s</p>' % (q, a) for q, a in faq) if faq else "")
             + "<h2>Every " + e(lang) + " entry</h2><ul>" + every + "</ul>"
             + '<p>' + e(round_name) + ' · <a href="/frameworks/">All languages</a> · '
               '<a href="/">Open the leaderboard</a></p>'

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -71,11 +71,12 @@
   .chip{font-size:.66rem; color:var(--muted); white-space:nowrap}
   .chip b{color:var(--text-2); font-weight:650}
   .top-links{display:flex; align-items:center; gap:.25rem}
-  /* Text link in the header, alongside the icon buttons. Shared with every
-     generated page through board_chrome(), so /frameworks/ is reachable from
-     the board, the docs and the entry pages alike. */
-  .top-link{display:inline-flex; align-items:center; height:34px; padding:0 .6rem; margin-right:.15rem; border-radius:8px; border:1px solid var(--line); background:var(--panel); color:var(--text-2); font-size:.8rem; font-weight:650; white-space:nowrap; text-decoration:none}
-  .top-link:hover{color:var(--text); border-color:var(--text-2)}
+  /* Sits beside the round selector and matches its geometry, but filled with
+     the accent rather than the panel: it is the one header control that leaves
+     the board, and as a quiet outline nobody found it. */
+  .fw-btn{display:flex; align-items:center; gap:.42rem; flex:none; padding:.34rem .7rem; border-radius:10px; border:1px solid var(--accent); background:var(--accent-weak); color:var(--accent); font-size:.82rem; font-weight:700; white-space:nowrap; text-decoration:none; transition:background .12s ease, color .12s ease, box-shadow .12s ease}
+  .fw-btn svg{width:15px; height:15px; flex:none}
+  .fw-btn:hover, .fw-btn:focus-visible{background:var(--accent); color:var(--bg); box-shadow:var(--shadow)}
   .icon-btn{display:inline-flex; align-items:center; justify-content:center; width:34px; height:34px; border-radius:8px; border:1px solid var(--line); background:var(--panel); color:var(--text-2); cursor:pointer; font-size:.9rem}
   .icon-btn:hover{color:var(--text); border-color:var(--accent)}
   .icon-btn svg{width:17px; height:17px}
@@ -455,9 +456,9 @@
       <button id="tunedToggle" type="button" class="on" data-tip="Show tuned entries - non-default configuration / optimizations (marked with a yellow ring).">Tuned</button>
     </div>
     <div class="round" id="round"></div>
+    <a class="fw-btn" href="/frameworks/" data-tip="A results page for every entry, grouped by language, plus a summary comparing the entries of each language."><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg><span>Frameworks</span></a>
     <div class="hw" id="hw"></div>
     <div class="top-links">
-      <a class="top-link" href="/frameworks/" title="A results page for every entry, grouped by language">Frameworks</a>
       <a class="icon-btn" href="https://github.com/MDA2AV/HttpArena" target="_blank" rel="noopener" title="GitHub" aria-label="GitHub"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></a>
       <a class="icon-btn" href="https://discord.gg/H84B5ZqDXR" target="_blank" rel="noopener" title="Discord" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg></a>
       <button class="icon-btn" id="theme" title="Toggle theme">◐</button>


### PR DESCRIPTION
Two follow-ups to #1186.

## The Frameworks button

It was a quiet outline among the header's icon buttons and nobody found it. It now sits **beside the round selector**, matching its geometry but filled with the accent instead of the panel, with a grid glyph and a tooltip.

`board_chrome()` lifts it out of the board the same way it already lifts the brand and the top links, so the docs pages get the identical button rather than a retyped copy. The entry and language pages keep their "Frameworks" breadcrumb and don't need it twice.

## Language pages now answer the question

They compared entries but never said what they showed. *"fastest C# web framework"* is the query these pages exist to answer, and neither a person skimming nor an assistant summarising reads a table cell — both take the first paragraph.

So each page opens with the answer:

> The fastest C# web framework in HttpArena is **genhttp-11-ioxide**, with a composite of 967 on HTTP/1.1 — 1 of 97 against every language in its league. Measured over Alpha Round, every entry on the same machine. This is a tuned entry.

and carries a **Questions** section generated from the same rows the tables are built from:

- what is the fastest &lt;language&gt; web framework — and the same per family (`fastest C# HTTP/2 server`, `HTTP/3`, `gRPC`, …)
- how many entries are measured, over which families
- is &lt;language&gt; fast for web servers — answered with the leader's placing against all languages, rather than a claim about the language

The same pairs go out as **`FAQPage`** structured data, so a machine reading the markup gets the numbers the page shows. The meta description leads with the answer too, since that is the search snippet.

## The wording follows the tier

Four languages are led by something that is not a framework — nginx is not a C web framework and swerver is not a Zig one. Those pages ask *"what is the fastest C HTTP server"*, name what the leader actually is, and where a framework-tier entry is also ranked they name it separately:

> The fastest C HTTP server in HttpArena is **nginx** (a reverse proxy or static-file server), with a composite of 678 on HTTP/1.1…

Where a language has only engines ranked, as Zig does, no framework claim is made at all.

"Fastest" is the word people type; the composite is what is actually being compared, so every answer names it rather than letting the word stand alone.

## Verified

- `check_badge_parity.js` — 776/776
- all 315 generated pages crawl with **no broken internal link**
- every JSON-LD block parses; all 27 `FAQPage` nodes carry questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)