### PR TITLE
benchmark: clear another entry's compose stack before starting one, and say why a stack failed

### DIFF
--- a/scripts/lib/gateway.sh
+++ b/scripts/lib/gateway.sh
@@ -54,6 +54,48 @@ _gateway_expected_containers() {
     esac
 }
 
+# Remove containers belonging to any *other* httparena compose stack.
+#
+# Every gateway and production stack runs network_mode: host on the same fixed
+# ports - edge 8443, authsvc 9090, server 8080 - so two of them cannot coexist.
+# The `down` in gateway_up only clears this framework's own project, which means
+# a stack left behind by another entry, or by a run killed between profiles,
+# outlives it. Whichever service loses the race then dies on bind and takes the
+# whole stack with it: in #1182 that was authsvc exiting 101 with
+# "bind 0.0.0.0:9090: Address in use", reported only as "exited (101)".
+#
+# Matches on the compose project label, so the harness's own `docker run`
+# sidecars (httparena-postgres, httparena-redis) carry no such label and are
+# left alone. Running containers only - a stopped one holds no port.
+# `|` rather than a space: an unlabelled container prints an empty field, and
+# with whitespace splitting its name would shift into the label's position and
+# match the httparena- test by accident.
+_gateway_clear_stale() {
+    local keep="$1" listing stale
+    listing=$(docker ps --format '{{.ID}}|{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null)
+    stale=$(printf '%s\n' "$listing" \
+            | awk -F'|' -v keep="$keep" '$2 ~ /^httparena-/ && $2 != keep { print $1 }')
+    [ -n "$stale" ] || return 0
+    warn "another httparena compose stack is still up; removing it so this one can bind its ports"
+    printf '%s\n' "$listing" \
+        | awk -F'|' -v keep="$keep" '$2 ~ /^httparena-/ && $2 != keep { print "  stale: " $3 }'
+    # shellcheck disable=SC2086
+    docker rm -f -v $stale >/dev/null 2>&1 || true
+}
+
+# Print what each container of the failed stack said. compose reports the exit
+# code and nothing else, so the reason - a bind conflict, a missing env var, a
+# crash loop - was never in the run log. Reuses dump_container_logs so the
+# output matches what a single-container failure already produces.
+_gateway_dump_logs() {
+    local project="$1" line id name
+    while read -r id name; do
+        [ -n "$id" ] || continue
+        dump_container_logs "$id" "$name"
+    done < <(docker ps -a --format '{{.ID}}|{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
+             | awk -F'|' -v p="$project" '$2 == p { print $1 " " $3 }')
+}
+
 gateway_up() {
     local framework="$1"
     local profile="${2:-gateway-64}"
@@ -67,13 +109,16 @@ gateway_up() {
 
     _gateway_env docker compose -f "$compose_file" -p "$GATEWAY_PROJECT" \
         down --remove-orphans 2>/dev/null || true
+    _gateway_clear_stale "$GATEWAY_PROJECT"
 
     info "starting gateway compose stack: $framework ($profile)"
     # --build forces compose to rebuild from source if any file in the
     # build context changed. Without this, an edit to a service Dockerfile
     # or Program.cs silently falls back to a stale image from the last run.
-    _gateway_env docker compose -f "$compose_file" -p "$GATEWAY_PROJECT" up --build -d \
-        || fail "gateway compose up failed"
+    if ! _gateway_env docker compose -f "$compose_file" -p "$GATEWAY_PROJECT" up --build -d; then
+        _gateway_dump_logs "$GATEWAY_PROJECT"
+        fail "gateway compose up failed"
+    fi
 
     # Discover running container IDs for stats collection.
     sleep 2


### PR DESCRIPTION
`production-stack` failed on #1182 with nothing in the log but an exit code:

```
Container httparena-fulmine-production-stack-authsvc-1 Error dependency authsvc failed to start
dependency failed to start: container ...-authsvc-1 exited (101)
[FAIL] gateway compose up failed
```

## What it was

101 is a Rust panic. I built `frameworks/_shared/authsvc` and ran it two ways:

```
clean host         → running,   "authsvc listening on 0.0.0.0:9090",  /_health 200
9090 already held  → exit 101,  "bind 0.0.0.0:9090: Address in use (os error 98)"
```

Byte-for-byte the same failure. **Nothing about it is fulmine's** — that PR is a one-line `package.json` bump, and authsvc is the shared sidecar `fulmine`, `aspnet-minimal_nginx` and `sark-production` all build.

Every gateway and production stack runs `network_mode: host` on the same fixed ports — edge 8443, authsvc 9090, server 8080 — so no two can coexist. `gateway_up` already runs `down --remove-orphans`, but **scoped to this framework's own compose project**, so a stack left behind by another entry, or by a run killed between profiles, survives it. The only broader sweep is the one `benchmark.sh` does once at startup.

## The fix

`_gateway_clear_stale()` removes running containers belonging to any *other* `httparena-*` compose project just before `up`, naming what it removed:

```
[warn] another httparena compose stack is still up; removing it so this one can bind its ports
  stale: httparena-thirdfw-gateway-64-authsvc-1
  stale: httparena-otherfw-production-stack-authsvc-1
```

It matches on the compose project label, so the harness's own `docker run` sidecars — `httparena-postgres`, `httparena-redis` — carry no such label and are left alone. The listing is split on `|` rather than whitespace: an unlabelled container prints an empty field, and with whitespace splitting its *name* would shift into the label's position and match the `httparena-` test by accident.

## And why it took a rebuild to diagnose

compose reports the exit code and nothing else, so the reason never reached the run log. `_gateway_dump_logs()` prints each container of the failed stack through the existing `dump_container_logs()`, so the next one names itself:

```
─── httparena-...-authsvc-1 — status=exited exit=101 oom=false error=
─── httparena-...-authsvc-1 — last 120 log lines ───
  | bind 0.0.0.0:9090: Address in use (os error 98)
```

## Verified

Against real containers, not by inspection: two stale stacks from other projects are found, named and removed while an unlabelled sidecar survives; and a stack whose service exits 101 has its stderr printed.

## Not changed

`authsvc` itself. Refusing to start when its port is taken is correct behaviour — the bug was the port still being taken. Making it retry or bind elsewhere would hide exactly the collision this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)