### PR TITLE
site: gold, silver and bronze medals on the board and every framework page

### DIFF
--- a/scripts/gen_leaderboard_data.py
+++ b/scripts/gen_leaderboard_data.py
@@ -1168,6 +1168,66 @@ def badge_aggregate(profiles, results):
     return {"avg": avg, "mem": amem, "bw": abw, "tpl": atpl}
 
 
+def _scored_for(prof, meta, pid, fw):
+    """scoredForType() in index.html. infraScored is read before the `scored`
+    short-circuit, not behind it: the infra set is not a subset of the framework
+    set — it counts Pipelined, which frameworks do not."""
+    p = prof[pid]
+    t = meta.get(fw, {}).get("type", "emerging")
+    if t == "infrastructure":
+        return bool(p["infraScored"])
+    if not p["scored"]:
+        return False
+    if t == "engine":
+        return bool(p["engineScored"])
+    return True
+
+
+def _eff_fn(A, in_league):
+    """eff() in index.html: the number a profile is actually ranked on.
+
+    Plain average rps, except for the two profiles the board adjusts — the
+    api-4/api-16 template mix, and json-comp, which is scored on
+    bandwidth-adjusted rps: the best compressor sets the bar and everyone else
+    is penalised by the square of their size ratio. The compression bar is per
+    league, which is why this takes `in_league` rather than a finished set.
+    """
+    min_bpr = None
+    if A["avg"].get("json-comp"):
+        cand = []
+        for fw, rps in A["avg"]["json-comp"].items():
+            b = A["bw"]["json-comp"].get(fw, 0)
+            if in_league(fw) and rps > 0 and b > 0:
+                cand.append(b / rps)
+        if cand:
+            min_bpr = min(cand)
+
+    def eff(pid, fw):
+        rps = A["avg"].get(pid, {}).get(fw, 0)
+        if rps <= 0:
+            return 0.0
+        t = A["tpl"].get(pid, {}).get(fw)
+        if pid in ("api-4", "api-16") and t:
+            return sum(t[k] * w for k, w in MIXW.items())
+        if pid == "json-comp" and min_bpr is not None:
+            b = A["bw"][pid].get(fw, 0)
+            if b > 0:
+                return rps * (min_bpr / (b / rps)) ** 2
+        return rps
+
+    return eff
+
+
+def _ranked(rows):
+    """(fw, rank, total, score) with competition ranking — ties share a rank."""
+    out, prev_score, prev_rank = [], None, 0
+    for i, (fw, score) in enumerate(rows):
+        rank = prev_rank if (prev_score is not None and abs(prev_score - score) < 1e-9) else i + 1
+        prev_score, prev_rank = score, rank
+        out.append((fw, rank, len(rows), score))
+    return out
+
+
 def badge_composite(agg, profiles, meta, scope, types, show_tuned=True, lang=None,
                     fw_lang=None):
     """Composite scores for one family and one league, best first.
@@ -1199,44 +1259,8 @@ def badge_composite(agg, profiles, meta, scope, types, show_tuned=True, lang=Non
             return False
         return True
 
-    def is_scored(pid, fw):
-        """scoredForType() in index.html. infraScored is read before the
-        `scored` short-circuit, not behind it: the infra set is not a subset of
-        the framework set — it counts Pipelined, which frameworks do not."""
-        p = prof[pid]
-        t = meta.get(fw, {}).get("type", "emerging")
-        if t == "infrastructure":
-            return bool(p["infraScored"])
-        if not p["scored"]:
-            return False
-        if t == "engine":
-            return bool(p["engineScored"])
-        return True
-
-    # json-comp is scored on bandwidth-adjusted rps: the best compressor sets the
-    # bar and everyone else is penalised by the square of their size ratio.
-    min_bpr = None
-    if "json-comp" in pids and A["avg"].get("json-comp"):
-        cand = []
-        for fw, rps in A["avg"]["json-comp"].items():
-            b = A["bw"]["json-comp"].get(fw, 0)
-            if in_league(fw) and rps > 0 and b > 0:
-                cand.append(b / rps)
-        if cand:
-            min_bpr = min(cand)
-
-    def eff(pid, fw):
-        rps = A["avg"].get(pid, {}).get(fw, 0)
-        if rps <= 0:
-            return 0.0
-        t = A["tpl"].get(pid, {}).get(fw)
-        if pid in ("api-4", "api-16") and t:
-            return sum(t[k] * w for k, w in MIXW.items())
-        if pid == "json-comp" and min_bpr is not None:
-            b = A["bw"][pid].get(fw, 0)
-            if b > 0:
-                return rps * (min_bpr / (b / rps)) ** 2
-        return rps
+    is_scored = lambda pid, fw: _scored_for(prof, meta, pid, fw)
+    eff = _eff_fn(A, in_league)
 
     max_r = {}
     for pid in pids:
@@ -1406,19 +1430,10 @@ def write_badges(profiles, results, meta):
             key = "byLanguage" + ("WithTuned" if with_tuned and not alias else "")
         e["scopes"].setdefault(scope, {})[key] = entry
 
-    def ranked(rows):
-        """(fw, rank, total, score) with competition ranking — ties share a rank."""
-        out, prev_score, prev_rank = [], None, 0
-        for i, (fw, score) in enumerate(rows):
-            rank = prev_rank if (prev_score is not None and abs(prev_score - score) < 1e-9) else i + 1
-            prev_score, prev_rank = score, rank
-            out.append((fw, rank, len(rows), score))
-        return out
-
     def publish(rows, scope, types, lang, with_tuned):
         if len(rows) < BADGE_MIN_FIELD:
             return
-        for fw, rank, total, score in ranked(rows):
+        for fw, rank, total, score in _ranked(rows):
             # Counted in the field above, but no badge of its own: a 0 means the
             # entry ran nothing that scores in this family, so "#31 of 31" would
             # read as a placing it never competed for.
@@ -1447,6 +1462,109 @@ def write_badges(profiles, results, meta):
     (BADGE_OUT / "index.json").write_text(
         json.dumps(index, indent=1, sort_keys=True) + "\n", encoding="utf-8")
     return written, index
+
+
+# ── achievements ────────────────────────────────────────────────────────────
+# A medal is a top-three place in a field the site already publishes: the badge
+# index for the family composites, overall and within one language, and the
+# per-profile ranking the board draws. Nothing is rescored here, so a medal, a
+# badge and the table a visitor is looking at cannot disagree.
+#
+# Every medal is taken in the entry's own league and, for a profile, only where
+# that profile counts for its tier - an engine holds no medal on a profile it is
+# not scored on. The tuned rule is _published_rank()'s: a standard entry is
+# placed in the field without tuned entries, a tuned one in the field with them.
+MEDAL_NAME = {1: "gold", 2: "silver", 3: "bronze"}
+MEDAL_ORDER = {"gold": 0, "silver": 1, "bronze": 2}
+AXIS_ORDER = {"family": 0, "language": 1, "profile": 2}
+
+# A podium takes three, which is more than BADGE_MIN_FIELD asks of a rank: "#1
+# of 2" is a fair thing to say and a poor thing to call a gold medal.
+MEDAL_MIN_FIELD = 3
+
+
+def _medal(rank, total):
+    """A place is only a medal when someone was beaten for it, so bronze needs a
+    field of 4 - bronze of three is last place."""
+    if total < MEDAL_MIN_FIELD or rank >= total:
+        return None
+    return MEDAL_NAME.get(rank)
+
+
+def _profile_link(pid, conn, types, show_tuned):
+    """Deep link to the profile view the medal was taken in. Spelled out the way
+    _badge_link() spells it, and for the same reason: the board restores its
+    league filter from localStorage, so a link that omits it can land a visitor
+    on a table the entry is not in."""
+    return SITE + "/#" + "&".join(["p=" + pid, "conns=%d" % conn,
+                                   "type=" + ",".join(sorted(types)),
+                                   "tuned=1" if show_tuned else "tuned=0"])
+
+
+def profile_medals(agg, profiles, meta):
+    """{framework: [medal]} - top three of every profile."""
+    prof = {p["id"]: p for p in profiles}
+    is_tuned = lambda fw: meta.get(fw, {}).get("mode", "standard") == "tuned"
+    out = {}
+    for types in LEAGUES:
+        in_league = lambda fw: meta.get(fw, {}).get("type", "emerging") in types
+        eff = _eff_fn(agg, in_league)
+        for p in profiles:
+            pid = p["id"]
+            if not p["scoredConns"]:
+                continue
+            field = [(fw, eff(pid, fw)) for fw in agg["avg"].get(pid, {})
+                     if in_league(fw) and _scored_for(prof, meta, pid, fw)]
+            field = [(fw, v) for fw, v in field if v > 0]
+            for with_tuned in (False, True):
+                rows = sorted((r for r in field if with_tuned or not is_tuned(r[0])),
+                              key=lambda r: (-r[1], r[0]))
+                for fw, rank, total, _v in _ranked(rows):
+                    if is_tuned(fw) != with_tuned:
+                        continue
+                    m = _medal(rank, total)
+                    if m:
+                        out.setdefault(fw, []).append(
+                            {"medal": m, "rank": rank, "of": total, "axis": "profile",
+                             "group": p["category"], "label": p["label"],
+                             "link": _profile_link(pid, p["scoredConns"][0], types,
+                                                   with_tuned)})
+    return out
+
+
+def composite_medals(badge_index, meta):
+    """{framework: [medal]} - top three of a family composite, and top three of
+    a family among the entries written in the same language."""
+    out = {}
+    for e in badge_index.values():
+        fw = e["framework"]
+        for scope, sc in e["scopes"].items():
+            for axis, d in (("family", _published_rank(sc)),
+                            ("language", sc.get("byLanguage") or sc.get("byLanguageWithTuned"))):
+                if not d:
+                    continue
+                m = _medal(d["rank"], d["of"])
+                if not m:
+                    continue
+                group = "Composite" if axis == "family" else (
+                    e["language"] or meta.get(fw, {}).get("language", "") or "Language")
+                out.setdefault(fw, []).append(
+                    {"medal": m, "rank": d["rank"], "of": d["of"], "axis": axis,
+                     "group": group, "label": SCOPE_NAME[scope], "link": d["link"]})
+    return out
+
+
+def compute_achievements(agg, profiles, meta, badge_index):
+    """{framework: [medal]}, gold first. Fed to the board and written into every
+    framework page, so both read one list."""
+    out = {}
+    for src in (composite_medals(badge_index, meta), profile_medals(agg, profiles, meta)):
+        for fw, items in src.items():
+            out.setdefault(fw, []).extend(items)
+    for items in out.values():
+        items.sort(key=lambda a: (MEDAL_ORDER[a["medal"]], AXIS_ORDER[a["axis"]],
+                                  a["group"], a["label"]))
+    return out
 
 
 # ── off-site visibility: social cards, structured data, llms.txt, prerender ──
@@ -1974,7 +2092,40 @@ def _fw_results(fw, profiles, results):
     return out
 
 
-def _fw_body(fw, m, lang, ranks, runs, round_name, lang_url=""):
+MEDAL_ICON = {"gold": "🥇", "silver": "🥈", "bronze": "🥉"}
+MEDAL_LABEL = {"gold": "Gold", "silver": "Silver", "bronze": "Bronze"}
+AXIS_LABEL = {"family": "Family composite", "language": "Within its language",
+              "profile": "Test profile"}
+
+
+def _medal_counts(items):
+    """[(medal, how many)] gold first, medals the entry does not hold left out."""
+    return [(m, sum(1 for a in items if a["medal"] == m))
+            for m in ("gold", "silver", "bronze")
+            if any(a["medal"] == m for a in items)]
+
+
+def _fw_achievements(items):
+    """The Achievements section of a framework page."""
+    e = _html.escape
+    head = " · ".join("%s %d %s" % (MEDAL_ICON[m], n, MEDAL_LABEL[m])
+                      for m, n in _medal_counts(items))
+    rows = "".join(
+        '<tr><td>%s %s</td><td>%s</td><td>%s</td><td><a href="%s">%d of %d</a></td></tr>'
+        % (MEDAL_ICON[a["medal"]], MEDAL_LABEL[a["medal"]], e(AXIS_LABEL[a["axis"]]),
+           e(a["group"] + " · " + a["label"]), e(a["link"]), a["rank"], a["of"])
+        for a in items)
+    return ('<h2 id="achievements">Achievements</h2>'
+            "<p>" + e(head) + ". Top three of a field, taken in this entry's own league: "
+            "the family composite, the same composite among entries written in the same "
+            "language, and each test profile it is scored on. Every field is the one the "
+            "badges publish, so a medal and a badge always say the same thing. "
+            '<a href="/docs/scoring/achievements/">How medals are awarded</a>.</p>'
+            "<table><thead><tr><th>Medal</th><th>Award</th><th>Field</th><th>Rank</th>"
+            "</tr></thead><tbody>" + rows + "</tbody></table>")
+
+
+def _fw_body(fw, m, lang, ranks, runs, round_name, lang_url="", achievements=()):
     e = _html.escape
     facts = [TYPE_LABEL.get(m.get("type", "emerging"), m.get("type", "")), lang]
     if m.get("engine") and m["engine"] != fw:
@@ -2000,6 +2151,9 @@ def _fw_body(fw, m, lang, ranks, runs, round_name, lang_url=""):
                      % (lang_url, e(lang)))
     links.append('<li><a href="/">Open the leaderboard</a></li>')
     out.append("<ul>" + "".join(links) + "</ul>")
+
+    if achievements:
+        out.append(_fw_achievements(achievements))
 
     if ranks:
         out.append('<h2 id="rank">Composite rank</h2>')
@@ -2036,7 +2190,7 @@ def _fw_body(fw, m, lang, ranks, runs, round_name, lang_url=""):
     return '<div class="doc-body">' + "".join(out) + "</div>"
 
 
-def _fw_page(fw, m, lang, ranks, runs, round_name, og_url, lang_url=""):
+def _fw_page(fw, m, lang, ranks, runs, round_name, og_url, lang_url="", achievements=()):
     e = _html.escape
     url = SITE + _fw_url(fw)
     title = f"{fw} performance benchmark & ranking"
@@ -2090,7 +2244,7 @@ def _fw_page(fw, m, lang, ranks, runs, round_name, og_url, lang_url=""):
               '</header>')
     body = ('<div class="docs-layout one-col"><main class="doc-main">'
             '<article class="doc-wrap"><h1 class="doc-title">' + e(fw) + "</h1>"
-            + _fw_body(fw, m, lang, ranks, runs, round_name, lang_url)
+            + _fw_body(fw, m, lang, ranks, runs, round_name, lang_url, achievements)
             + "</article></main></div>")
     return head + header + body + _THEME_TOGGLE + "</body></html>"
 
@@ -2362,7 +2516,8 @@ def _fw_index_page(entries, lang_pages=()):
     return head + header + body + _THEME_TOGGLE + "</body></html>"
 
 
-def build_fw_pages(profiles, results, meta, fw_lang, badge_index, round_name, with_og):
+def build_fw_pages(profiles, results, meta, fw_lang, badge_index, achievements,
+                   round_name, with_og):
     """A page per framework that has results, plus the index over them."""
     if FW_OUT.exists():
         shutil.rmtree(FW_OUT)
@@ -2418,7 +2573,8 @@ def build_fw_pages(profiles, results, meta, fw_lang, badge_index, round_name, wi
         dest = FW_OUT / _slug(fw)
         dest.mkdir(parents=True, exist_ok=True)
         (dest / "index.html").write_text(
-            _fw_page(fw, m, lang, ranks, runs, round_name, og_url, lang_url), encoding="utf-8")
+            _fw_page(fw, m, lang, ranks, runs, round_name, og_url, lang_url,
+                     achievements.get(fw, ())), encoding="utf-8")
         if with_og:
             _og_card(dest / "og.png", "Benchmark results", fw,
                      [(SCOPE_NAME[s], "#%d of %d" % (rank, field))
@@ -2538,9 +2694,15 @@ def main():
                     print(f"[warn] profile '{pid}' -> implementation doc '{docid}' not found")
                 profiles.append(prof)
 
+    # Badges first: the medals are read out of the index it returns, and they
+    # ship inside the board's own payload.
+    n_badges, badge_index = write_badges(profiles, results, meta)
+    agg = badge_aggregate(profiles, results)
+    achievements = compute_achievements(agg, profiles, meta, badge_index)
+
     payload = {"current": current, "langColors": langcolors, "meta": meta,
                "profiles": profiles, "results": results, "docs": docs_tree,
-               "rounds": build_rounds()}
+               "achievements": achievements, "rounds": build_rounds()}
     OUT.parent.mkdir(parents=True, exist_ok=True)
     OUT.write_text(js_payload("LB_DATA", payload))
 
@@ -2551,12 +2713,10 @@ def main():
     trails = _crumb_trails(docs_tree)
     n_pages = build_doc_pages(docs_tree, docs_content, trails, with_og=has_og)
     n_search, search_bytes = write_search_index(docs_tree, docs_content)
-    n_badges, badge_index = write_badges(profiles, results, meta)
 
     # The board's default view, and the same view for the other five families.
     # Same port of computeComposite() the badges use, so the ranking written into
     # the page cannot disagree with the one the page draws over it.
-    agg = badge_aggregate(profiles, results)
     fw_lang = _fw_languages(results)
     families = [(scope, badge_composite(agg, profiles, meta, scope, DEFAULT_TYPES,
                                         show_tuned=True, fw_lang=fw_lang))
@@ -2565,7 +2725,8 @@ def main():
     round_name = payload["rounds"]["name"]
 
     fw_entries, n_fw_cards, lang_pages = build_fw_pages(profiles, results, meta, fw_lang,
-                                                        badge_index, round_name, has_og)
+                                                        badge_index, achievements,
+                                                        round_name, has_og)
     n_urls, n_dated = write_sitemap(docs_content, fw_entries, lang_pages)
 
     # og cards go in after build_doc_pages: that one clears site/generated/docs/

--- a/site/content/docs/scoring/_index.md
+++ b/site/content/docs/scoring/_index.md
@@ -10,4 +10,5 @@ How HttpArena computes the composite score that ranks frameworks across all test
 
 {{< cards >}}
   {{< card link="composite-score" title="Composite Score" subtitle="Sum of per-profile normalized scores (0–100 each) across all scored profiles, with an optional memory-efficiency bonus." icon="chart-bar" >}}
+  {{< card link="achievements" title="Achievements" subtitle="Gold, silver and bronze for a top three place in a family composite, in a language and on a single test profile." icon="badge-check" >}}
 {{< /cards >}}

--- a/site/content/docs/scoring/achievements.md
+++ b/site/content/docs/scoring/achievements.md
@@ -1,0 +1,32 @@
+---
+title: Achievements
+seo_title: "Achievements: how gold, silver and bronze medals are awarded"
+description: "Medals on the leaderboard: top three of a family composite, of a language and of a single test profile, always inside the entry's own league."
+weight: 10
+---
+
+An achievement is a medal for a top three place: **gold** for first, **silver** for second, **bronze** for third. Medals are shown next to the name on the composite board, in the panel that opens when you click a row, and in full on every framework page.
+
+Nothing is scored again to award them. A medal is a place in a field the site already publishes, so a medal, a rank badge and the table you are looking at always say the same thing.
+
+## The three awards
+
+| Award | Field |
+|---|---|
+| Family composite | The [composite score](composite-score) of one family: HTTP/1.1, HTTP/2, HTTP/3, Gateway, gRPC, WebSocket |
+| Within its language | The same composite, counting only entries written in the same language |
+| Test profile | One profile, on the average RPS over its scored connection counts |
+
+## The field a medal is taken in
+
+Every field is the entry's own league. Frameworks, engines and reverse proxies are three separate competitions, and a framework never places against an engine.
+
+A profile only awards a medal to an entry that is scored on it. Reference-only profiles, Pipelined and Fortunes, award nothing to frameworks, and an engine holds no medal on a profile outside the engine set.
+
+Tuned entries follow the badge rule: a standard entry is placed in the field without tuned entries, a tuned entry in the field with them. It is always the smallest published field the entry belongs to.
+
+## When a place is not a medal
+
+A field needs at least three entries, and somebody has to be beaten. So gold and silver need a field of three, bronze needs four, and last place is never a medal. The field size is written next to every medal, `1 of 71`, so you can always see what was won.
+
+Medals are not filtered by what you are looking at. Changing the league filter or the language filter changes who is listed, never who holds a medal.

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -298,6 +298,13 @@
   /* 'tuned' mode cue - yellow ring around the type square / badge */
   .tsq.tuned, .badge.tuned{position:relative}
   .tsq.tuned::after, .badge.tuned::after{content:""; position:absolute; top:0; bottom:0; right:calc(100% + 2px); width:4px; background:#c89a3c}
+  /* medals - how many golds/silvers/bronzes the entry holds. Dropped below 820px,
+     where the name column halves and the count is not worth what it would cost. */
+  .mdls{display:inline-flex; align-items:center; gap:.3rem; flex:none; cursor:default}
+  .mdl{display:inline-flex; align-items:center; gap:.1rem; font-size:.7rem; line-height:1}
+  .mdl b{font-family:var(--mono); font-size:.68rem; font-weight:700}
+  .mdl-gold b{color:var(--gold)} .mdl-silver b{color:var(--silver)} .mdl-bronze b{color:var(--bronze)}
+  @media (max-width:820px){ .mdls{display:none} }
   .fw .lang, .cm .fwcell .lang{width:3rem; flex:none; overflow:hidden; text-overflow:ellipsis}
   .b-flagship{background:rgba(46,158,106,.13); color:#1b7a4e} html[data-theme="dark"] .b-flagship{color:#5cc596}
   .b-emerging{background:rgba(59,115,196,.14); color:#2b5694} html[data-theme="dark"] .b-emerging{color:#9bbdec}
@@ -320,7 +327,7 @@
   .stattip span{display:flex; justify-content:space-between; gap:.7rem}
   .stattip b{color:var(--text); font-weight:600}
   .statwrap:hover .stattip{display:flex}
-  #tip{position:fixed; z-index:100; display:none; max-width:280px; background:var(--panel); color:var(--text); border:1px solid var(--line); border-radius:8px; box-shadow:var(--shadow); padding:.5rem .65rem; font-size:.74rem; line-height:1.45; font-weight:500; pointer-events:none}
+  #tip{position:fixed; z-index:100; display:none; white-space:pre-line; max-width:280px; background:var(--panel); color:var(--text); border:1px solid var(--line); border-radius:8px; box-shadow:var(--shadow); padding:.5rem .65rem; font-size:.74rem; line-height:1.45; font-weight:500; pointer-events:none}
 
   /* row-click info modal */
   .row, .cm tbody tr{cursor:pointer}
@@ -333,6 +340,14 @@
   .modal-h h3{margin:0; font-size:1.2rem; font-weight:750; letter-spacing:-.01em}
   .modal-meta{color:var(--text-2); font-size:.8rem; margin-bottom:.8rem}
   .modal-desc{color:var(--text-2); font-size:.86rem; line-height:1.55; margin:0 0 1.1rem}
+  .modal-sub{font-size:.68rem; font-weight:700; letter-spacing:.06em; text-transform:uppercase; color:var(--muted); margin:0 0 .45rem}
+  .modal-mdl{display:flex; flex-direction:column; gap:.15rem; margin:0 0 1.1rem; max-height:196px; overflow:auto}
+  .modal-mdl a{display:flex; align-items:center; gap:.55rem; padding:.3rem .35rem; border-radius:7px}
+  .modal-mdl a:hover{background:var(--panel-2)}
+  .modal-mdl .mi{flex:none; font-size:.9rem}
+  .modal-mdl .mw{flex:1; min-width:0; font-size:.8rem; font-weight:600; color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+  .modal-mdl .mw em{display:block; font-style:normal; font-size:.68rem; font-weight:500; color:var(--muted)}
+  .modal-mdl .mr{flex:none; font-family:var(--mono); font-size:.7rem; color:var(--text-2)}
   .modal-links{display:flex; flex-direction:column; gap:.5rem}
   .modal-links a{display:flex; align-items:center; justify-content:space-between; gap:.5rem; color:var(--accent); font-weight:600; font-size:.86rem; padding:.55rem .75rem; border:1px solid var(--line); border-radius:9px; transition:background .12s, border-color .12s}
   .modal-links a:hover{background:var(--accent-weak); border-color:var(--accent)}
@@ -388,12 +403,14 @@
   .cm tbody td.sticky{z-index:2}
   .cm .rankh,.cm .rankc{left:0; width:44px; min-width:44px; text-align:left; color:var(--muted); font-family:var(--mono); font-variant-numeric:tabular-nums}
   .cm .rankc.r1{color:var(--gold);font-weight:700} .cm .rankc.r2{color:var(--silver);font-weight:700} .cm .rankc.r3{color:var(--bronze);font-weight:700}
-  .cm .fwh,.cm .fwcell{left:44px; width:303px; min-width:303px; max-width:303px; text-align:left}
+  /* 53px wider than it was, which is what a full 🥇n 🥈n 🥉n cluster takes -
+     the name column keeps the room it had. */
+  .cm .fwh,.cm .fwcell{left:44px; width:356px; min-width:356px; max-width:356px; text-align:left}
   .cm .fwcell .fl{display:flex; align-items:center; gap:.45rem}
   .cm .fwcell .nm{font-weight:600; color:var(--text); overflow:hidden; text-overflow:ellipsis; flex:1; min-width:0}
   .cm .fwcell .lang{flex:none; font-size:.72rem; white-space:nowrap}
   .cm .fwcell .nm a:hover{color:var(--accent)}
-  .cm .scoreh,.cm .scorec{left:347px; width:104px; min-width:104px; box-shadow:7px 0 9px -5px rgba(0,0,0,.22)}
+  .cm .scoreh,.cm .scorec{left:400px; width:104px; min-width:104px; box-shadow:7px 0 9px -5px rgba(0,0,0,.22)}
   .cm .scoreh + th, .cm .scorec + td{padding-left:1.3rem}
   .cm .scorec .sc{display:flex; flex-direction:column; align-items:flex-start; gap:.12rem}
   .cm .scorec .sc b{font-weight:600; color:var(--text); font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:.80rem}
@@ -528,6 +545,11 @@ document.addEventListener('DOMContentLoaded', function(){
 
   // ── maps ─────────────────────────────────────────────────
   var PROF = {}; D.profiles.forEach(function(p){ PROF[p.id]=p; });
+  // Medals, gold first, computed at build time by gen_leaderboard_data.py out of
+  // the same fields the badges rank. Deliberately not recomputed against the
+  // filters in view: an entry holds a medal, it does not stop holding it while
+  // someone is looking at another league.
+  var ACHV = D.achievements || {};
   var FWLANG = {};
   Object.keys(D.results).forEach(function(k){ D.results[k].forEach(function(r){ if(r.lang) FWLANG[r.fw]=r.lang; }); });
 
@@ -555,6 +577,26 @@ document.addEventListener('DOMContentLoaded', function(){
   function repoOf(fw){ return D.meta[fw] && D.meta[fw].repo; }
   function langOf(fw){ return FWLANG[fw] || ''; }
   function engineOf(fw){ return (D.meta[fw] && D.meta[fw].engine) || ''; }
+
+  // ── medals ───────────────────────────────────────────────
+  var MEDALS=['gold','silver','bronze'];
+  var MEDAL_ICO={gold:'🥇',silver:'🥈',bronze:'🥉'};
+  var AXIS_LABEL={family:'Family composite', language:'Within its language', profile:'Test profile'};
+  function medalsOf(fw){ return ACHV[fw] || []; }
+  function medalTip(list){
+    var l=list.slice(0,8).map(function(a){ return MEDAL_ICO[a.medal]+' '+a.group+' · '+a.label+' - '+a.rank+' of '+a.of; });
+    if(list.length>l.length) l.push('+'+(list.length-l.length)+' more - open the entry');
+    return l.join('\n');
+  }
+  function medalChips(fw){
+    var list=medalsOf(fw); if(!list.length) return '';
+    var h='';
+    MEDALS.forEach(function(m){
+      var n=list.filter(function(a){ return a.medal===m; }).length;
+      if(n) h+='<span class="mdl mdl-'+m+'">'+MEDAL_ICO[m]+'<b>'+n+'</b></span>';
+    });
+    return '<span class="mdls" data-tip="'+esc(medalTip(list))+'">'+h+'</span>';
+  }
   // Search: comma-separated terms matched against name/language/engine. Positive
   // terms are OR'd; a "!term" excludes any match. Show if (no positive terms or
   // one matches) AND no negative term matches.
@@ -607,6 +649,16 @@ document.addEventListener('DOMContentLoaded', function(){
       + '<div class="modal-h"><span class="dot" style="background:'+c.accent+'"></span><h3>'+esc(fw)+'</h3><span class="badge b-'+t+tunedRing(fw)+'" data-tip="'+esc(typeTip(t)+tunedTip(fw))+'">'+typeAbbr(t)+'</span></div>'
       + '<div class="modal-meta">'+esc([lang, m.engine, typeAbbr(t), modeOf(fw)==='tuned'?'tuned':''].filter(Boolean).join(' · '))+'</div>';
     if(m.desc) h+='<p class="modal-desc">'+esc(m.desc)+'</p>';
+    var mdl=medalsOf(fw);
+    if(mdl.length){
+      h+='<div class="modal-sub">Achievements</div><div class="modal-mdl">';
+      mdl.forEach(function(a){
+        h+='<a href="'+esc(a.link)+'"><span class="mi">'+MEDAL_ICO[a.medal]+'</span>'
+         + '<span class="mw">'+esc(a.group+' · '+a.label)+'<em>'+esc(AXIS_LABEL[a.axis])+'</em></span>'
+         + '<span class="mr">'+a.rank+' of '+a.of+'</span></a>';
+      });
+      h+='</div>';
+    }
     h+='<div class="modal-links">';
     h+='<a href="/frameworks/'+encodeURIComponent(slugOf(fw))+'/"><span>Results page</span><span>→</span></a>';
     if(m.repo) h+='<a href="'+esc(m.repo)+'" target="_blank" rel="noopener"><span>Official repository</span><span>↗</span></a>';
@@ -1313,7 +1365,7 @@ document.addEventListener('DOMContentLoaded', function(){
       var fav=favs.has(r.fw);
       var tr='<tr class="'+(fav?'fav':'')+'" data-fw-row="'+esc(r.fw)+'">'
         + '<td class="sticky rankc'+(rank<=3?' r'+rank:'')+'">'+rank+'</td>'
-        + '<td class="sticky fwcell"><span class="fl">'+starHtml(r.fw)+'<span class="tsq tsq-'+t+tunedRing(r.fw)+'" data-tip="'+esc(typeTip(t)+tunedTip(r.fw))+'"></span><span class="lang" style="color:'+(dark?c.textDark:c.text)+'">'+esc(r.lang)+'</span><span class="nm">'+nm+'</span></span></td>'
+        + '<td class="sticky fwcell"><span class="fl">'+starHtml(r.fw)+'<span class="tsq tsq-'+t+tunedRing(r.fw)+'" data-tip="'+esc(typeTip(t)+tunedTip(r.fw))+'"></span><span class="lang" style="color:'+(dark?c.textDark:c.text)+'">'+esc(r.lang)+'</span><span class="nm">'+nm+'</span>'+medalChips(r.fw)+'</span></td>'
         + '<td class="sticky scorec" title="raw composite '+r.score.toFixed(1)+'"><span class="sc"><b>'+r.score.toFixed(0)+'</b><span class="bar"><i style="width:'+Math.max(pct,2).toFixed(0)+'%;background:rgba('+c.rgb+','+(dark?0.55:0.42)+')"></i></span></span></td>';
       pids.forEach(function(pid){
         var cell=r.cells[pid];


### PR DESCRIPTION
## Description

The board publishes a rank for every entry, but nothing says "this one leads a category". This adds achievements: gold, silver and bronze for a top three place, on three axes - the composite of a family, the same composite among entries written in the same language, and each single test profile.

Nothing is scored again. Family and language medals are read out of the badge index, profile medals use the same `eff()` and the same scored connection set the composite uses, so a medal, a badge and the table below it always agree. Every medal is taken in the entry's own league, and only on profiles that entry is scored on. A field needs three entries and somebody has to be beaten, so bronze needs four and last place is never a medal.

The board shows the counts next to the name, with the full list in the panel that opens on a row click. Every framework page gets an Achievements table, and there is a new Knowledge Base page under Scoring.

`badge_composite()` was refactored to share `eff()` and the competition ranking with the new code; the badge index it writes is byte-identical and badge parity is 776/776.

<img width="804" height="567" alt="image" src="https://github.com/user-attachments/assets/1ab9efbd-f9fb-4324-ba08-b8fdae626673" />
<img width="643" height="715" alt="image" src="https://github.com/user-attachments/assets/7328dbc2-4da9-48ef-853c-578d45d7a7db" />
<img width="1148" height="889" alt="image" src="https://github.com/user-attachments/assets/d6b0bc31-cba6-4931-a0ff-1c4eec767025" />

