### PR TITLE
Nginx using debian trixie

### DIFF
--- a/frameworks/nginx/Dockerfile
+++ b/frameworks/nginx/Dockerfile
@@ -1,19 +1,14 @@
-ARG NGINX_VERSION=1.30.0
+ARG NGINX_VERSION=1.31.3
 
-FROM debian:bookworm AS build
+FROM debian:trixie AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential libpcre2-dev zlib1g-dev wget ca-certificates git perl cmake
+    build-essential libpcre2-dev libssl-dev zlib1g-dev libgd-dev curl ca-certificates gnupg wget git perl cmake -y
 
 # Build quictls (OpenSSL fork with QUIC support). Pinned to the same tag as
 # docker/h2load-h3.Dockerfile — the 3.1.5+quic branch this used to track no
 # longer configures on current bookworm (perl aborts in Configure).
 WORKDIR /tmp
-RUN git clone --depth 1 -b openssl-3.3.0-quic1 https://github.com/quictls/openssl.git quictls && \
-    cd quictls && \
-    ./config --prefix=/opt/quictls --libdir=lib no-tests && \
-    make -j$(nproc) && \
-    make install_sw
 
 # Download nginx source
 ARG NGINX_VERSION
@@ -40,25 +35,20 @@ RUN ./configure \
     --with-http_gzip_static_module \
     --add-module=/tmp/ngx_brotli \
     --add-module=/tmp/module \
-    --with-cc-opt="-O3 -march=native -DNDEBUG -I/opt/quictls/include" \
-    --with-ld-opt="-lm -L/opt/quictls/lib -Wl,-rpath,/opt/quictls/lib" && \
+    --with-cc-opt="-O3 -march=native -DNDEBUG" && \
     make -j$(nproc)
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpcre2-8-0 && \
     rm -rf /var/lib/apt/lists/*
-# Copy the install tree rather than naming versioned sonames: make install_sw
-# already lays down the right symlinks, and hand-written ones broke the moment
-# the quictls pin moved.
-COPY --from=build /opt/quictls/lib/ /opt/quictls/lib/
-RUN ldconfig /opt/quictls/lib
+
 ARG NGINX_VERSION
 COPY --from=build /tmp/nginx-${NGINX_VERSION}/objs/nginx /usr/sbin/nginx
 RUN mkdir -p /usr/local/nginx/logs
 
 COPY nginx.conf /usr/local/nginx/conf/nginx.conf
 
-EXPOSE 8080 8081 8443/tcp 8443/udp
+EXPOSE 8080 8081 8082 8443/tcp 8443/udp
 
 CMD ["nginx"]

--- a/frameworks/nginx/meta.json
+++ b/frameworks/nginx/meta.json
@@ -16,6 +16,8 @@
     "static-tls",
     "baseline-h2",
     "static-h2",
+    "baseline-h2c",
+    "json-h2c",
     "baseline-h3",
     "static-h3"
   ],

--- a/frameworks/nginx/meta.json
+++ b/frameworks/nginx/meta.json
@@ -16,8 +16,6 @@
     "static-tls",
     "baseline-h2",
     "static-h2",
-    "baseline-h2c",
-    "json-h2c",
     "baseline-h3",
     "static-h3"
   ],

--- a/frameworks/nginx/nginx.conf
+++ b/frameworks/nginx/nginx.conf
@@ -96,6 +96,15 @@ http {
     }
 
     server {
+        listen 8082 reuseport;
+        http2 on;
+        
+        location / {
+            httparena;
+        }
+    }
+
+    server {
         listen 8443 ssl reuseport;
         listen 8443 quic reuseport;
         http2 on;

--- a/frameworks/nginx/nginx.conf
+++ b/frameworks/nginx/nginx.conf
@@ -95,14 +95,14 @@ http {
         }
     }
 
-    server {
-        listen 8082 reuseport;
-        http2 on;
+    #server {
+    #    listen 8082 reuseport;
+    #    http2 on;
         
-        location / {
-            httparena;
-        }
-    }
+    #    location / {
+    #        httparena;
+    #    }
+    #}
 
     server {
         listen 8443 ssl reuseport;


### PR DESCRIPTION
## Description
Using debian trixie, we can simplify the docker file, as use Openssl 3.5 and don't need to compile a third ssl lib.

Also update nginx to v1.31.3 and add h2c tests.


---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run every test the framework subscribes to |
| `/benchmark -f <framework> -t <test>` | Run one test only |
| `/benchmark -f <framework> --save` | Run and save results (updates the leaderboard on merge) |
| `/benchmark -f <framework> -t <test> --save` | Run one test and save results |
| `/benchmark -f <framework> --compare <other>` | Measure the deltas against another framework instead of this one |
| `/benchmark-multiple -f <fw1>,<fw2>,...` | Benchmark several frameworks in one run — takes `-t` and `--save` too; saved results land in a single commit |
| `/benchmark-multiple --save` | No `-f` needed: benchmark and save every framework the PR touches |
| `/benchmark-test -t <test>` | Benchmark **all** enabled frameworks subscribed to `<test>` and save the results |

For `/benchmark`, always specify `-f <framework>`; the flags combine in any order. Results come back as a comment with a per-profile table of RPS, p99, CPU and memory — one table per framework on multi runs. A new benchmark comment while a run is in flight queues behind it (one deep) instead of cancelling it. For multi-framework PRs (dependency bumps, same-language refactors) prefer `/benchmark-multiple`, which runs everything in a single job and commits all saved results together, so no run overwrites another. `--compare` works on single-framework runs only.

**What the deltas are measured against.** By default, this framework's own results published on `main` - answering *"did this change help?"*. When you are tuning a variant or a successor entry, `--compare` re-bases them on another entry instead:

```
/benchmark -f genhttp-11 --compare genhttp
```

The reply states which baseline it used, and profiles the other framework does not run show `n/a` rather than a delta.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk, ghz) are built as self-contained Docker images on first run.

</details>
