### PR TITLE
[WIP] Update Ktor with 3.6.0

### DIFF
--- a/frameworks/ktor-ghost/Dockerfile
+++ b/frameworks/ktor-ghost/Dockerfile
@@ -9,7 +9,7 @@ RUN gradle buildFatJar --no-daemon -q
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/ktor-ghost-httparena.jar .
-EXPOSE 8080 8443
+EXPOSE 8080 8081 8082 8443
 ENTRYPOINT ["java", \
   "-server", \
   "-XX:+UseG1GC", \

--- a/frameworks/ktor-ghost/build.gradle.kts
+++ b/frameworks/ktor-ghost/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(ktorLibs.plugins.ktor)
+    alias(libs.plugins.ktor)
     alias(libs.plugins.kotlin.ksp)
 }
 

--- a/frameworks/ktor-ghost/gradle/libs.versions.toml
+++ b/frameworks/ktor-ghost/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ postgresql = { module = "org.postgresql:postgresql", version = "42.7.4" }
 hikaricp = { module = "com.zaxxer:HikariCP", version = "6.2.1" }
 
 [plugins]
+ktor = { id = "io.ktor.plugin", version = "3.5.2" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version = "2.3.9" }

--- a/frameworks/ktor-ghost/meta.json
+++ b/frameworks/ktor-ghost/meta.json
@@ -14,8 +14,11 @@
   "repo": "https://github.com/ktorio/ktor",
   "enabled": true,
   "tests": [
-    "baseline", "latency-1m", "latency-10k",
+    "baseline",
+    "latency-1m",
+    "latency-10k",
     "limited-conn",
+    "async",
     "pipelined",
     "json-comp",
     "json-tls",
@@ -29,7 +32,8 @@
     "baseline-h3",
     "static-h3",
     "echo-ws",
-    "echo-ws-pipeline"],
+    "echo-ws-pipeline"
+  ],
   "maintainers": [
     "bjhham",
     "juanchurtado1991"

--- a/frameworks/ktor-ghost/meta.json
+++ b/frameworks/ktor-ghost/meta.json
@@ -26,6 +26,8 @@
     "static-h2",
     "baseline-h2c",
     "json-h2c",
+    "baseline-h3",
+    "static-h3",
     "echo-ws",
     "echo-ws-pipeline"],
   "maintainers": [

--- a/frameworks/ktor-ghost/settings.gradle.kts
+++ b/frameworks/ktor-ghost/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-eap-1654")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1660")
     }
 }
 

--- a/frameworks/ktor-ghost/settings.gradle.kts
+++ b/frameworks/ktor-ghost/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1660")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1663")
     }
 }
 

--- a/frameworks/ktor-ghost/settings.gradle.kts
+++ b/frameworks/ktor-ghost/settings.gradle.kts
@@ -8,9 +8,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.5.0")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-eap-1654")
     }
 }
 

--- a/frameworks/ktor-ghost/settings.gradle.kts
+++ b/frameworks/ktor-ghost/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1665")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1666")
     }
 }
 

--- a/frameworks/ktor-ghost/settings.gradle.kts
+++ b/frameworks/ktor-ghost/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1663")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1665")
     }
 }
 

--- a/frameworks/ktor-ghost/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor-ghost/src/main/kotlin/com/httparena/Application.kt
@@ -37,12 +37,13 @@ import java.io.File
 
 fun main() {
     Ghost.prewarm()
-    println("Ktor HttpArena server starting on :8080 (HTTP/1.1) and :8443 (HTTPS/HTTP+2)")
+    println("Ktor HttpArena server starting on :8080 (HTTP/1.1), :8081 (JSON + TLS), :8082 (HTTP/3), :8443 (HTTPS/HTTP2)")
     val deps = ArenaApplicationDepsFactory.load()
     val environment = applicationEnvironment {}
 
     val server = embeddedServer(Netty, environment, {
         enableHttp2 = true
+        @OptIn(ExperimentalKtorApi::class)
         enableHttp3()
 
         connector {

--- a/frameworks/ktor-ghost/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor-ghost/src/main/kotlin/com/httparena/Application.kt
@@ -43,6 +43,7 @@ fun main() {
 
     val server = embeddedServer(Netty, environment, {
         enableHttp2 = true
+        enableHttp3()
 
         connector {
             port = 8080

--- a/frameworks/ktor-ghost/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor-ghost/src/main/kotlin/com/httparena/Application.kt
@@ -1,27 +1,22 @@
 package com.httparena
 
+import com.ghost.serialization.Ghost
 import com.httparena.DbResponse.Companion.toResponse
 import io.ktor.http.*
 import io.ktor.http.content.*
-import com.ghost.serialization.Ghost
-import io.ktor.http.content.ByteArrayContent
-import io.ktor.server.request.receive
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.html.*
 import io.ktor.server.http.content.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.compression.*
-import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
-import io.netty.channel.ChannelOption
-import io.netty.channel.WriteBufferWaterMark
-import io.netty.handler.flush.FlushConsolidationHandler
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.html.*
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -34,6 +29,8 @@ import org.jetbrains.exposed.v1.jdbc.upsert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
+import kotlin.io.path.Path
+import kotlin.time.Duration.Companion.milliseconds
 
 fun main() {
     Ghost.prewarm()
@@ -243,7 +240,7 @@ private fun Application.configureRouting(appData: ArenaApplicationDeps) {
          * Static files
          * https://www.http-arena.com/docs/test-profiles/h1/isolated/static/
          */
-        staticFiles("/static", File("/data/static")) {
+        staticFiles("/static", dir = File("/data/static"), index = null) {
             preCompressed(CompressedFileType.BROTLI, CompressedFileType.GZIP)
         }
 
@@ -301,6 +298,16 @@ private fun Application.configureRouting(appData: ArenaApplicationDeps) {
                     }
                 }
             }
+        }
+
+        /**
+         * Async Delay benchmark.  Measures what a framework does with a request it cannot answer yet.
+         * https://www.http-arena.com/docs/test-profiles/h1/isolated/async/implementation/
+         */
+        get("/delay/{ms}") {
+            val delayParam = call.parameters["ms"] ?: "0"
+            delay(delayParam.toLong().milliseconds)
+            call.respond(TextContent(delayParam, ContentType.Text.Plain))
         }
 
     }

--- a/frameworks/ktor-ghost/src/test/kotlin/com/httparena/ApplicationTest.kt
+++ b/frameworks/ktor-ghost/src/test/kotlin/com/httparena/ApplicationTest.kt
@@ -259,4 +259,12 @@ class ApplicationTest {
         assertEquals(HttpStatusCode.NotFound.value, response.status.value)
     }
 
+    @Test
+    fun delayTest() = testApplication {
+        setup()
+        val response = client.get("/delay/1000")
+        assertEquals(HttpStatusCode.OK.value, response.status.value)
+        assertEquals("1000", response.bodyAsText())
+    }
+
 }

--- a/frameworks/ktor/Dockerfile
+++ b/frameworks/ktor/Dockerfile
@@ -15,12 +15,8 @@ ENTRYPOINT ["java", \
   "-XX:+UseG1GC", \
   "-XX:+UseNUMA", \
   "-XX:+AlwaysPreTouch", \
-  "-XX:-OmitStackTraceInFastThrow", \
   "-Dio.netty.transport.noNative=false", \
   "-Dio.netty.buffer.checkBounds=false", \
   "-Dio.netty.buffer.checkAccessible=false", \
-  "-Dio.netty.allocator.maxOrder=10", \
   "-Dio.netty.leakDetection.level=disabled", \
-  "-Dio.netty.recycler.maxCapacityPerThread=4096", \
-  "-Dio.netty.eventLoopThreads=0", \
   "-jar", "ktor-httparena.jar"]

--- a/frameworks/ktor/Dockerfile
+++ b/frameworks/ktor/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:9.5.1-jdk21-corretto AS build
+FROM gradle:9.5.1-jdk25-corretto AS build
 WORKDIR /app
 COPY build.gradle.kts settings.gradle.kts gradle.properties ./
 COPY gradle/libs.versions.toml ./gradle/
@@ -6,7 +6,7 @@ RUN gradle dependencies --no-daemon -q 2>/dev/null || true
 COPY src ./src
 RUN gradle buildFatJar --no-daemon -q
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/ktor-httparena.jar .
 EXPOSE 8080 8081 8082 8443

--- a/frameworks/ktor/Dockerfile
+++ b/frameworks/ktor/Dockerfile
@@ -9,7 +9,7 @@ RUN gradle buildFatJar --no-daemon -q
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/ktor-httparena.jar .
-EXPOSE 8080 8443
+EXPOSE 8080 8443/tcp 8443/udp
 ENTRYPOINT ["java", \
   "-server", \
   "-XX:+UseG1GC", \

--- a/frameworks/ktor/Dockerfile
+++ b/frameworks/ktor/Dockerfile
@@ -9,7 +9,7 @@ RUN gradle buildFatJar --no-daemon -q
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/ktor-httparena.jar .
-EXPOSE 8080 8443/tcp 8443/udp
+EXPOSE 8080 8081 8082 8443
 ENTRYPOINT ["java", \
   "-server", \
   "-XX:+UseG1GC", \

--- a/frameworks/ktor/build.gradle.kts
+++ b/frameworks/ktor/build.gradle.kts
@@ -40,5 +40,5 @@ ktor {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }

--- a/frameworks/ktor/build.gradle.kts
+++ b/frameworks/ktor/build.gradle.kts
@@ -27,7 +27,8 @@ dependencies {
     implementation(libs.logback.classic)
     implementation(libs.postgresql)
     implementation(libs.hikaricp)
-    runtimeOnly(libs.netty.native.epoll)
+    runtimeOnly(variantOf(libs.netty.native.epoll) { classifier("linux-aarch_64") })
+    runtimeOnly(variantOf(libs.netty.native.openssl) { classifier("linux-aarch_64") })
 
     testImplementation(kotlin("test"))
     testImplementation(ktorLibs.server.testHost)

--- a/frameworks/ktor/build.gradle.kts
+++ b/frameworks/ktor/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(ktorLibs.plugins.ktor)
+    alias(libs.plugins.ktor)
 }
 
 group = "com.httparena"

--- a/frameworks/ktor/build.sh
+++ b/frameworks/ktor/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+# Expose the host's local maven repository to the build so mavenLocal()
+# can resolve locally published (e.g. SNAPSHOT) Ktor artifacts.
+M2_REPO="${M2_REPO:-$HOME/.m2/repository}"
+
+args=(-t httparena-ktor)
+if [ -d "$M2_REPO" ]; then
+    args+=(--build-context "m2=$M2_REPO")
+fi
+
+docker build "${args[@]}" "$SCRIPT_DIR"

--- a/frameworks/ktor/gradle/libs.versions.toml
+++ b/frameworks/ktor/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-exposed = "1.2.0"
-kotlin = "2.3.21"
+exposed = "1.5.0"
+kotlin = "2.4.10"
 
 [libraries]
-logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.15" }
-netty-native-epoll = { module = "io.netty:netty-transport-native-epoll", version = "4.2.14.Final" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.38" }
+netty-native-epoll = { module = "io.netty:netty-transport-native-epoll", version = "4.2.16.Final" }
 
 # Database
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }

--- a/frameworks/ktor/gradle/libs.versions.toml
+++ b/frameworks/ktor/gradle/libs.versions.toml
@@ -14,5 +14,6 @@ postgresql = { module = "org.postgresql:postgresql", version = "42.7.4" }
 hikaricp = { module = "com.zaxxer:HikariCP", version = "6.2.1" }
 
 [plugins]
+ktor = { id = "io.ktor.plugin", version = "3.5.2" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/frameworks/ktor/gradle/libs.versions.toml
+++ b/frameworks/ktor/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ kotlin = "2.4.10"
 [libraries]
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.38" }
 netty-native-epoll = { module = "io.netty:netty-transport-native-epoll", version = "4.2.16.Final" }
+netty-native-openssl = { module = "io.netty:netty-tcnative-boringssl-static", version = "2.0.81.Final" }
 
 # Database
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }

--- a/frameworks/ktor/meta.json
+++ b/frameworks/ktor/meta.json
@@ -26,6 +26,8 @@
     "static-h2",
     "baseline-h2c",
     "json-h2c",
+    "baseline-h3",
+    "static-h3",
     "echo-ws",
     "echo-ws-pipeline",
     "fortunes"

--- a/frameworks/ktor/meta.json
+++ b/frameworks/ktor/meta.json
@@ -14,8 +14,11 @@
   "repo": "https://github.com/ktorio/ktor",
   "enabled": true,
   "tests": [
-    "baseline", "latency-1m", "latency-10k",
+    "baseline",
+    "latency-1m",
+    "latency-10k",
     "limited-conn",
+    "async",
     "pipelined",
     "json-comp",
     "json-tls",

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1672")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1673")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1669")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1670")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-eap-1654")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1660")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1670")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1672")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1660")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1663")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -8,9 +8,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.5.0")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-eap-1654")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1673")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1674")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1668")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1669")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-http3-eap-1663")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1665")
     }
 }
 

--- a/frameworks/ktor/settings.gradle.kts
+++ b/frameworks/ktor/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         maven("https://redirector.kotlinlang.org/maven/ktor-eap")
     }
     versionCatalogs {
-        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1665")
+        create("ktorLibs").from("io.ktor:ktor-version-catalog:3.6.0-opt-eap-1668")
     }
 }
 

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -16,9 +16,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
-import io.netty.channel.ChannelOption
-import io.netty.channel.WriteBufferWaterMark
-import io.netty.handler.flush.FlushConsolidationHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.html.*
@@ -33,13 +30,15 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 
+@OptIn(ExperimentalKtorApi::class)
 fun main() {
-    println("Ktor HttpArena server starting on :8080 (HTTP/1.1) and :8443 (HTTPS/HTTP+2)")
+    println("Ktor HttpArena server starting on :8080 (HTTP/1.1) and :8443 (HTTPS/HTTP2/HTTP3)")
     val deps = ArenaApplicationDepsFactory.load()
     val environment = applicationEnvironment {}
 
     val server = embeddedServer(Netty, environment, {
         enableHttp2 = true
+        enableHttp3()
 
         connector {
             port = 8080

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -17,6 +17,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.html.*
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -29,6 +30,8 @@ import org.jetbrains.exposed.v1.jdbc.upsert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
+import kotlin.io.path.Path
+import kotlin.time.Duration.Companion.milliseconds
 
 fun main() {
     println("Ktor HttpArena server starting on :8080 (HTTP/1.1), :8081 (JSON + TLS), :8082 (HTTP/3), :8443 (HTTPS/HTTP2)")
@@ -37,14 +40,22 @@ fun main() {
 
     val server = embeddedServer(Netty, environment, {
         enableHttp2 = true
+        enableH2c = true
         @OptIn(ExperimentalKtorApi::class)
         enableHttp3()
 
+        // HTTP/1.1
         connector {
             port = 8080
             host = "0.0.0.0"
         }
+        // h2c
+        connector {
+            port = 8082
+            host = "0.0.0.0"
+        }
         deps.keyStore?.let { keyStore ->
+            // JSON + TLS
             sslConnector(
                 keyStore = keyStore,
                 keyAlias = KEY_ALIAS,
@@ -54,6 +65,7 @@ fun main() {
                 port = 8081
                 host = "0.0.0.0"
             }
+            // HTTP/2 HTTP/3
             sslConnector(
                 keyStore = keyStore,
                 keyAlias = KEY_ALIAS,
@@ -67,31 +79,6 @@ fun main() {
     }) {
         mainModule(deps)
     }
-
-    // Spin up a second server for H2C
-    embeddedServer(Netty, environment, {
-        enableH2c = true
-
-        connector {
-            port = 8082
-            host = "0.0.0.0"
-        }
-    }) {
-        // Reject any non-HTTP/2 request hitting the H2C connector
-        intercept(ApplicationCallPipeline.Plugins) {
-            val version = call.request.httpVersion
-            if (!version.startsWith("HTTP/2")) {
-                call.response.headers.append(HttpHeaders.Upgrade, "h2c")
-                call.response.headers.append(HttpHeaders.Connection, "Upgrade")
-                call.respond(HttpStatusCode.UpgradeRequired, "HTTP/2 (h2c) required")
-                finish()
-                return@intercept
-            }
-        }
-        // Import the same endpoints for this server
-        mainModule(deps)
-
-    }.start(wait = false)
 
     server.start(wait = true)
 }
@@ -245,7 +232,7 @@ private fun Application.configureRouting(appData: ArenaApplicationDeps) {
          * Static files
          * https://www.http-arena.com/docs/test-profiles/h1/isolated/static/
          */
-        staticFiles("/static", File("/data/static")) {
+        staticFiles("/static", dir = File("/data/static"), index = null) {
             preCompressed(CompressedFileType.BROTLI, CompressedFileType.GZIP)
         }
 
@@ -303,6 +290,16 @@ private fun Application.configureRouting(appData: ArenaApplicationDeps) {
                     }
                 }
             }
+        }
+
+        /**
+         * Async Delay benchmark.  Measures what a framework does with a request it cannot answer yet.
+         * https://www.http-arena.com/docs/test-profiles/h1/isolated/async/implementation/
+         */
+        get("/delay/{ms}") {
+            val delayParam = call.parameters["ms"] ?: "0"
+            delay(delayParam.toLong().milliseconds)
+            call.respond(TextContent(delayParam, ContentType.Text.Plain))
         }
 
     }

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -41,9 +41,7 @@ fun main() {
     val server = embeddedServer(Netty, environment, {
         dispatchCallStartOnIoExecutor = true
         shareWorkGroup = true
-        enableHttp2 = true
         enableH2c = true
-        enableHttp3()
 
         // HTTP/1.1
         connector {
@@ -56,6 +54,9 @@ fun main() {
             host = "0.0.0.0"
         }
         deps.keyStore?.let { keyStore ->
+            enableHttp2 = true
+            enableHttp3()
+
             // JSON + TLS
             sslConnector(
                 keyStore = keyStore,

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -30,14 +30,14 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 
-@OptIn(ExperimentalKtorApi::class)
 fun main() {
-    println("Ktor HttpArena server starting on :8080 (HTTP/1.1) and :8443 (HTTPS/HTTP2/HTTP3)")
+    println("Ktor HttpArena server starting on :8080 (HTTP/1.1), :8081 (JSON + TLS), :8082 (HTTP/3), :8443 (HTTPS/HTTP2)")
     val deps = ArenaApplicationDepsFactory.load()
     val environment = applicationEnvironment {}
 
     val server = embeddedServer(Netty, environment, {
         enableHttp2 = true
+        @OptIn(ExperimentalKtorApi::class)
         enableHttp3()
 
         connector {
@@ -185,13 +185,15 @@ private fun Application.configureRouting(appData: ArenaApplicationDeps) {
                 if (count < 0) count = 0
                 if (count > appData.dataset.size) count = appData.dataset.size
                 val m = call.request.queryParameters["m"]?.toIntOrNull() ?: 1
-                val processed = appData.dataset.take(count).map { d ->
-                    ProcessedItem(
-                        id = d.id, name = d.name, category = d.category,
-                        price = d.price, quantity = d.quantity, active = d.active,
-                        tags = d.tags, rating = d.rating,
-                        total = d.price.toLong() * d.quantity * m
-                    )
+                val processed = buildList(count) {
+                    for (i in 0..<count) {
+                        add(appData.dataset[i].let { d -> ProcessedItem(
+                            id = d.id, name = d.name, category = d.category,
+                            price = d.price, quantity = d.quantity, active = d.active,
+                            tags = d.tags, rating = d.rating,
+                            total = d.price.toLong() * d.quantity * m
+                        )})
+                    }
                 }
                 call.respond(JsonResponse(items = processed, count = count))
             }

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -42,6 +42,9 @@ fun main() {
         workerGroupSize = parallelism + 1
         enableHttp2 = true
         enableH2c = true
+        maxConnections = 128
+        connectionBacklog = 128
+
         @OptIn(ExperimentalKtorApi::class)
         enableHttp3()
 

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -38,9 +38,8 @@ fun main() {
     val environment = applicationEnvironment {}
 
     val server = embeddedServer(Netty, environment, {
-        runHandlersOnEventLoop = true
         shareWorkGroup = true
-        workerGroupSize = parallelism * 4
+        workerGroupSize = parallelism + 1
         enableHttp2 = true
         enableH2c = true
         @OptIn(ExperimentalKtorApi::class)

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -38,12 +38,10 @@ fun main() {
     val environment = applicationEnvironment {}
 
     val server = embeddedServer(Netty, environment, {
-        shareWorkGroup = true
-        workerGroupSize = parallelism + 1
         enableHttp2 = true
         enableH2c = true
-        maxConnections = 128
-        connectionBacklog = 128
+        workerGroupSize = parallelism + 1
+        callGroupSize = parallelism + 1
 
         @OptIn(ExperimentalKtorApi::class)
         enableHttp3()

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -30,15 +30,17 @@ import org.jetbrains.exposed.v1.jdbc.upsert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
-import kotlin.io.path.Path
 import kotlin.time.Duration.Companion.milliseconds
 
 fun main() {
-    println("Ktor HttpArena server starting on :8080 (HTTP/1.1), :8081 (JSON + TLS), :8082 (HTTP/3), :8443 (HTTPS/HTTP2)")
+    println("Ktor HttpArena server starting on :8080 (HTTP/1.1), :8081 (JSON + TLS), :8082 (H2C), :8443 (HTTPS/HTTP2/HTTP3)")
     val deps = ArenaApplicationDepsFactory.load()
     val environment = applicationEnvironment {}
 
     val server = embeddedServer(Netty, environment, {
+        runHandlersOnEventLoop = true
+        shareWorkGroup = true
+        workerGroupSize = parallelism * 4
         enableHttp2 = true
         enableH2c = true
         @OptIn(ExperimentalKtorApi::class)

--- a/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
+++ b/frameworks/ktor/src/main/kotlin/com/httparena/Application.kt
@@ -37,13 +37,12 @@ fun main() {
     val deps = ArenaApplicationDepsFactory.load()
     val environment = applicationEnvironment {}
 
+    @OptIn(ExperimentalKtorApi::class)
     val server = embeddedServer(Netty, environment, {
+        dispatchCallStartOnIoExecutor = true
+        shareWorkGroup = true
         enableHttp2 = true
         enableH2c = true
-        workerGroupSize = parallelism + 1
-        callGroupSize = parallelism + 1
-
-        @OptIn(ExperimentalKtorApi::class)
         enableHttp3()
 
         // HTTP/1.1

--- a/frameworks/ktor/src/test/kotlin/com/httparena/ApplicationTest.kt
+++ b/frameworks/ktor/src/test/kotlin/com/httparena/ApplicationTest.kt
@@ -259,4 +259,12 @@ class ApplicationTest {
         assertEquals(HttpStatusCode.NotFound.value, response.status.value)
     }
 
+    @Test
+    fun delayTest() = testApplication {
+        setup()
+        val response = client.get("/delay/1000")
+        assertEquals(HttpStatusCode.OK.value, response.status.value)
+        assertEquals("1000", response.bodyAsText())
+    }
+
 }


### PR DESCRIPTION
## Description

In 3.6.0, we're introducing HTTP/3 support and improving memory allocations in a few places.  In anticipation of the release, I thought I'd run an early access build against the HttpArena benchmarks to see how it performs.  I'll update this PR with the proper release artifact after it is published.

## Fixes

* See https://github.com/ktorio/ktor/pull/5822 - our initial implementation was getting pinned to a single thread, so we had to make several changes to the Netty implementation to use multiple ports / load balance over multiple threads.  This should take advantage of parallelism in the benchmarks now.  There were also a few tweaks that should improve overall throughput.