### PR TITLE
validate: drop the h2c h1-rejection check

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -985,24 +985,10 @@ if has_test "baseline-h2c"; then
         fail_with_link "[HTTP/2 cleartext (prior-knowledge)]: server responded with HTTP/$h2c_proto, expected HTTP/2" "$H2C_DOCS"
     fi
 
-    # Anti-cheat #2: the same port MUST NOT also serve HTTP/1.1. If it did,
-    # the benchmark could be measuring h1 throughput (much higher on some
-    # stacks) while labeled as h2c. --http1.1 forces curl to refuse the
-    # h2 preface; we check that the server didn't happily answer.
-    h1_code=$(curl -s --max-time 5 --http1.1 \
-        -o /dev/null -w '%{http_code}' \
-        "http://localhost:$H2C_PORT/baseline2?a=1&b=1" 2>/dev/null || echo "000")
-    if [ "$h1_code" != "200" ]; then
-        echo "  PASS [h2c-only: port $H2C_PORT rejects plain HTTP/1.1] (got $h1_code)"
-        PASS=$((PASS + 1))
-    else
-        fail_with_link "[h2c-only]: port $H2C_PORT also answered HTTP/1.1 with 200 — dual-serving lets the benchmark measure h1 throughput instead of h2c. The h2c listener must refuse HTTP/1.1 requests." "$H2C_DOCS"
-    fi
-
     check "GET /baseline2?a=13&b=42 over h2c" "55" "$H2C_DOCS" \
         -s --http2-prior-knowledge "http://localhost:$H2C_PORT/baseline2?a=13&b=42"
 
-    # Anti-cheat #3: randomized sum
+    # Anti-cheat #2: randomized sum
     A4=$((RANDOM % 900 + 100))
     B4=$((RANDOM % 900 + 100))
     check "GET /baseline2?a=$A4&b=$B4 over h2c (random)" "$((A4 + B4))" "$H2C_DOCS" \

--- a/site/content/docs/scoring/composite-score.md
+++ b/site/content/docs/scoring/composite-score.md
@@ -75,7 +75,7 @@ Not all profiles count toward the composite score. Profiles marked as **scored**
 |---|---|---|
 | Baseline | Yes | Query parsing over TLS with multiplexed streams |
 | Static | Yes | 20 static files served over TLS with multiplexed streams |
-| Baseline h2c | Yes | Query parsing over cleartext h2 on port 8082 (prior-knowledge, anti-cheat rejects dual-serving HTTP/1.1) |
+| Baseline h2c | Yes | Query parsing over cleartext h2 on port 8082 (prior-knowledge) |
 | JSON h2c | Yes | JSON serialization workload over cleartext h2 on port 8082 |
 
 ### H/3

--- a/site/content/docs/test-profiles/h2/baseline-h2c/implementation.md
+++ b/site/content/docs/test-profiles/h2/baseline-h2c/implementation.md
@@ -20,11 +20,12 @@ Same `/baseline2?a=…&b=…` sum endpoint as the HTTP/2-TLS baseline, served as
 
 - HTTP/2 framing + HPACK + multiplexing *without* TLS overhead
 - Protocol implementation cost in isolation - the delta against `baseline-h2` is roughly the TLS cost
-- How cleanly the framework refuses non-h2 traffic on a port declared h2c-only
 
-## The port must be h2c-only
+## Dual-serving h1 on the same port is allowed
 
-Validation explicitly checks that port 8082 refuses plain HTTP/1.1 requests. A server that dual-serves h1 and h2c on the same port would let the benchmark measure whichever protocol the client picked - useless for ranking. Frameworks that want to expose h1 too must do it on a **different** port.
+Port 8082 may also answer HTTP/1.1. The benchmark cannot pick it up: `h2load -p h2c` writes the HTTP/2 connection preface as the first bytes of every connection and never sends an HTTP/1.1 request, so the h1 path is unreachable during a measured run. Validation asserts the same way, with `curl --http2-prior-knowledge`.
+
+This is what RFC 9113 expects of a cleartext listener - distinguish the h2 preface from an HTTP/1.1 request line and serve each accordingly - and what nginx (1.25.1+), Apache (`Protocols h2c http/1.1`) and h2o all do. The harness itself relies on it: the gRPC profiles run cleartext HTTP/2 against port 8080, the same listener that serves the HTTP/1.1 baseline.
 
 ## Expected request/response
 

--- a/site/content/docs/test-profiles/h2/baseline-h2c/validation.md
+++ b/site/content/docs/test-profiles/h2/baseline-h2c/validation.md
@@ -10,9 +10,7 @@ The following checks are executed by `validate.sh` for every framework subscribe
 
 Sends `GET /baseline2?a=1&b=1` to `http://localhost:8082` with `curl --http2-prior-knowledge`. The negotiated protocol (`%{http_version}`) must report **HTTP/2**. A server answering HTTP/1.1 here fails this check.
 
-## Anti-cheat: h2c-only listener
-
-Sends the same request with `curl --http1.1`. The server must **not** respond with an HTTP/1.1 200. If it does, the port is dual-serving h1 and h2c, which means the benchmark could silently measure HTTP/1.1 throughput instead of h2c. The check accepts any non-200 response (connection reset, GOAWAY, 400, etc.).
+The listener may also serve HTTP/1.1 on the same port. Nothing in the benchmark reaches that path: `h2load -p h2c` sends the HTTP/2 connection preface as the first bytes of every connection and never issues an HTTP/1.1 request, so a dual-serving port is still measured as h2c.
 
 ## GET /baseline2 over h2c
 

--- a/site/content/docs/test-profiles/h2/json-h2c/implementation.md
+++ b/site/content/docs/test-profiles/h2/json-h2c/implementation.md
@@ -24,7 +24,6 @@ The load generator rotates through the same seven `(count, m)` pairs as the H/1 
 
 - JSON serialization throughput over h2c (no TLS in the way)
 - h2 multiplexing efficiency when response bodies vary in size (1 → 50 items)
-- How cleanly the framework refuses HTTP/1.1 on the h2c-only port (validated per `baseline-h2c`'s anti-cheat)
 
 ## Expected request/response
 

--- a/site/content/docs/test-profiles/h2/json-h2c/validation.md
+++ b/site/content/docs/test-profiles/h2/json-h2c/validation.md
@@ -4,7 +4,7 @@ seo_title: "JSON over HTTP/2 Cleartext Benchmark — Validation Checks"
 description: "The correctness checks validate.sh runs against the JSON over HTTP/2 cleartext benchmark before a framework's results are accepted."
 ---
 
-The following checks are executed by `validate.sh` for every framework subscribed to the `json-h2c` test. Port 8082 must already be answering h2c prior-knowledge before these checks begin (the `baseline-h2c` anti-cheat block covers the h1-rejection check - this block assumes it has passed).
+The following checks are executed by `validate.sh` for every framework subscribed to the `json-h2c` test. Port 8082 must already be answering h2c prior-knowledge before these checks begin.
 
 ## /json HTTP/2 cleartext
 


### PR DESCRIPTION
Closes #1201.

@joanhey is right that the check blocks RFC-conformant servers, and there is a second reason to drop it: **its stated failure mode is unreachable.**

## The rationale was wrong

`validate.sh` failed an entry whose port 8082 also answered HTTP/1.1, with:

> dual-serving lets the benchmark measure h1 throughput instead of h2c

It can't. `scripts/lib/tools/h2load.sh:44` invokes the load generator with `-p h2c`, which writes the HTTP/2 connection preface as the first bytes of every connection and never issues an HTTP/1.1 request. The h1 path is unreachable during a measured run.

Verified by enabling the commented-out h2c listener in `frameworks/nginx/nginx.conf` and running the harness's own command against it:

```
$ h2load "http://localhost:8082/baseline2?a=1&b=1" -p h2c -c 64 -m 100 -t 8 -D 5
Application protocol: h2c
finished in 5.01s, 2512848.80 req/s
requests: 12564244 total, 12564244 succeeded, 0 failed, 0 errored
traffic: 515.23MB headers (space savings 52.75%)
```

12.5M requests against a server that happily answers HTTP/1.1 on that port, all measured as h2c. The 52.75% header savings is HPACK, which only happens on HTTP/2 framing. The adapter comment at `h2load.sh:37` already said as much.

## It was redundant

Anti-cheat #1 forces `--http2-prior-knowledge` and asserts `%{http_version}` is `2`. That already rejects any server not really speaking h2c. Same nginx, both checks verbatim:

| check | result |
|---|---|
| #1 prior-knowledge → `http_version` | `2` — PASS |
| #1 body `a=13&b=42` → `55` | PASS |
| #2 forced HTTP/1.1 → `http_code` | `200` — **FAIL** |

It proves it speaks real h2c and gets failed anyway.

## It was never applied consistently

`h2load.sh` runs the gRPC profiles as cleartext HTTP/2 against **port 8080** — the same listener that serves the HTTP/1.1 baseline. Every gRPC entry dual-serves h1 and cleartext h2 on one port and nothing complains.

## What it cost

RFC 9113 expects a cleartext listener to distinguish an h2 preface from an HTTP/1.1 request line. nginx (1.25.1+, [trac #808](https://trac.nginx.org/nginx/ticket/808) / [#816](https://trac.nginx.org/nginx/ticket/816)), Apache (`Protocols h2c http/1.1`) and h2o all do this. So the check excluded every infrastructure-tier server from both h2c profiles, and #1200 had to strip its h2c tests to merge ("Remove h2c tests for now") — the listener is still sitting commented out in `nginx.conf`.

18 entries subscribe to an h2c profile today and not one is infrastructure tier.

## Changes

- `scripts/validate.sh` — remove the h1-rejection block, renumber the surviving anti-cheat
- Six doc locations, including two that listed h1-refusal as something the profile *measures*:
  - `test-profiles/h2/baseline-h2c/validation.md` (section removed, replaced with why dual-serving is safe)
  - `test-profiles/h2/baseline-h2c/implementation.md` (measured-list entry + "The port must be h2c-only" section)
  - `test-profiles/h2/json-h2c/validation.md` (cross-reference)
  - `test-profiles/h2/json-h2c/implementation.md` (measured-list entry)
  - `scoring/composite-score.md` (profile table)

`bash -n scripts/validate.sh` passes; `gen_leaderboard_data.py` builds the same 132 doc pages and `check_badge_parity.js` still matches.

## Note on the issue text

The issue cites RFC 7540 §3.2 for `Upgrade: h2c`. RFC 7540 is obsoleted by RFC 9113, which removed that mechanism — prior knowledge is now the only defined way to start HTTP/2 on cleartext. Doesn't change the conclusion, and the docs here cite 9113.

## Possible follow-up (not in this PR)

Dropping this leaves anti-cheat #1 as the sole guard. h2load already prints `Application protocol:` on every run and `h2load_parse` ignores it — parsing it and failing the run when it isn't `h2c` would give a per-run guarantee at measurement time, which is strictly stronger than the validation-time probe being removed. Happy to add it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)