### PR TITLE
validate: exhaustive TCP fragmentation for baseline

### DIFF
--- a/frameworks/h2o/src/main.c
+++ b/frameworks/h2o/src/main.c
@@ -314,9 +314,20 @@ static int on_baseline11(h2o_handler_t *h, h2o_req_t *req)
     int64_t sum = sum_query_values(req);
     if (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("POST"))
         && req->entity.len > 0) {
-        const char *p = req->entity.base;
-        const char *end = p + req->entity.len;
-        while (p < end && *p <= ' ') p++;
+        /* req->entity is length-delimited, NOT NUL-terminated, so strtoll()
+           cannot be pointed at it directly: it scans until a non-digit and
+           happily runs past entity.len into whatever the pool holds next.
+           With a multi-chunk chunked body the decoder compacts the payload
+           and leaves the old chunk framing right behind it, so "20" was
+           being read as "202" or "2020" and the sum came back wrong.
+           Copy into a bounded, NUL-terminated buffer first. */
+        char nbuf[32];
+        size_t nlen = req->entity.len < sizeof(nbuf) - 1
+                    ? req->entity.len : sizeof(nbuf) - 1;
+        memcpy(nbuf, req->entity.base, nlen);
+        nbuf[nlen] = '\0';
+        const char *p = nbuf;
+        while (*p != '\0' && *p <= ' ') p++;
         char *ep;
         long long n = strtoll(p, &ep, 10);
         if (ep > p) sum += n;
@@ -399,7 +410,9 @@ static int on_json(h2o_handler_t *h, h2o_req_t *req)
             if (eq - p == 1 && *p == 'm') {
                 char *ep;
                 long long n = strtoll(eq + 1, &ep, 10);
-                if (ep > eq + 1) m = n;
+                /* Same hazard as the body parse above: bound the accept to
+                   this parameter's span so a digit after it cannot be read. */
+                if (ep > eq + 1 && ep <= amp) m = n;
                 break;
             }
             p = amp < end ? amp + 1 : end;

--- a/scripts/validate-frag.py
+++ b/scripts/validate-frag.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Exhaustive TCP-fragmentation validation for HttpArena.
+
+Where validate.sh's check_fragmented picks a handful of split points by hand,
+this splits every request shape at EVERY byte offset. Hand-picked splits only
+cover the boundaries someone thought of; the parser bugs that survive are the
+ones nobody picks - between the CR and the LF, mid Content-Length digits, mid
+chunk-size hex, one byte into the terminating 0\\r\\n\\r\\n.
+
+For each offset: open a connection, write the first part, pause, write the
+rest, and require 200 with the exact expected body. The pause is what makes it
+a real test - it guarantees the server's read loop returns with a partial
+buffer and has to carry parser state across recv() calls, instead of the kernel
+coalescing both writes into one.
+
+Every shape carries the `?a=…&b=…` query string, so query parsing is on the
+split path too, not just the request line and headers.
+
+Approach borrowed from uWebSockets/tests/fragment_test.ts, which does the same
+byte-by-byte sweep. Two differences: the body is asserted, not just the status
+(a server can answer 200 with the wrong sum), and connections are opened in
+batches so one pause covers a whole batch rather than one offset.
+
+Usage: python3 validate-frag.py [host] [port] [delay_ms]
+  Defaults: localhost 8080 200
+  Exit code 0 = all passed, 1 = failures
+"""
+
+import random
+import socket
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "localhost"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 8080
+DELAY = (int(sys.argv[3]) if len(sys.argv) > 3 else 200) / 1000.0
+
+# Sockets held open at once. Each batch pays the pause once, so the whole run
+# costs ceil(offsets / BATCH) * DELAY rather than offsets * DELAY. Kept well
+# under the default 1024 fd limit.
+BATCH = 384
+
+CONNECT_TIMEOUT = 10
+
+PASS = 0
+FAIL = 0
+
+# ── Request shapes ────────────────────────────────────────────────────────
+# The three the baseline profile defines (GET, POST + Content-Length, POST +
+# chunked), each in more than one spelling. Randomized operands appear in two
+# of them so a hardcoded response fails here as well as in the main checks.
+
+RA, RB = random.randint(100, 999), random.randint(100, 999)
+RBODY = random.randint(10, 99)
+
+
+def shapes():
+    return [
+        ("GET, minimal",
+         f"GET /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nConnection: close\r\n\r\n", "55"),
+
+        ("GET, several headers",
+         f"GET /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nUser-Agent: arena-frag/1.0\r\n"
+         f"Accept: text/plain\r\nAccept-Encoding: identity\r\n"
+         f"Connection: close\r\n\r\n", "55"),
+
+        ("GET, lower-cased field names",
+         f"GET /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"host: {HOST}\r\nuser-agent: arena-frag/1.0\r\nconnection: close\r\n\r\n", "55"),
+
+        ("GET, randomized query",
+         f"GET /baseline11?a={RA}&b={RB} HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nConnection: close\r\n\r\n", str(RA + RB)),
+
+        ("POST, Content-Length",
+         f"POST /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nContent-Type: text/plain\r\n"
+         f"Content-Length: 2\r\nConnection: close\r\n\r\n20", "75"),
+
+        ("POST, lower-cased content-length",
+         f"POST /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"host: {HOST}\r\ncontent-type: text/plain\r\n"
+         f"content-length: 2\r\nconnection: close\r\n\r\n20", "75"),
+
+        ("POST, randomized body",
+         f"POST /baseline11?a={RA}&b={RB} HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nContent-Type: text/plain\r\n"
+         f"Content-Length: {len(str(RBODY))}\r\nConnection: close\r\n\r\n{RBODY}",
+         str(RA + RB + RBODY)),
+
+        ("POST, chunked",
+         f"POST /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nContent-Type: text/plain\r\n"
+         f"Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+         f"2\r\n20\r\n0\r\n\r\n", "75"),
+
+        ("POST, chunked in two chunks",
+         f"POST /baseline11?a=13&b=42 HTTP/1.1\r\n"
+         f"Host: {HOST}\r\nContent-Type: text/plain\r\n"
+         f"Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+         f"1\r\n2\r\n1\r\n0\r\n0\r\n\r\n", "75"),
+    ]
+
+
+# ── Response parsing ──────────────────────────────────────────────────────
+
+def parse(raw):
+    """(status, body) from a raw HTTP/1.1 response. Decodes a chunked body."""
+    try:
+        head, sep, rest = raw.partition(b"\r\n\r\n")
+        if not sep:
+            return -1, ""
+        lines = head.split(b"\r\n")
+        status = int(lines[0].split(b" ")[1])
+        hdrs = {}
+        for line in lines[1:]:
+            k, _, v = line.partition(b":")
+            hdrs[k.strip().lower()] = v.strip()
+        if hdrs.get(b"transfer-encoding", b"").lower() == b"chunked":
+            out = b""
+            while True:
+                size_line, _, rest = rest.partition(b"\r\n")
+                n = int(size_line.split(b";")[0] or b"0", 16)
+                if n == 0:
+                    break
+                out, rest = out + rest[:n], rest[n + 2:]
+            body = out
+        elif b"content-length" in hdrs:
+            body = rest[:int(hdrs[b"content-length"])]
+        else:
+            body = rest
+        return status, body.decode("utf-8", "replace").strip()
+    except Exception:
+        return -1, ""
+
+
+# ── One batch: open, write first half, pause once, finish ─────────────────
+
+def run_batch(batch):
+    handles = []
+    for offset, first, second in batch:
+        try:
+            s = socket.create_connection((HOST, PORT), timeout=CONNECT_TIMEOUT)
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)  # no Nagle coalescing
+            s.sendall(first)
+            handles.append((s, offset, second, None))
+        except Exception as e:
+            handles.append((None, offset, second, f"{type(e).__name__}: {e}"))
+
+    # The whole point: the server is now sitting on a partial request.
+    time.sleep(DELAY)
+
+    def finish(h):
+        s, offset, second, err = h
+        if err:
+            return offset, -1, "", err
+        try:
+            s.sendall(second)
+            buf = b""
+            while True:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            status, body = parse(buf)
+            return offset, status, body, None
+        except socket.timeout:
+            return offset, -1, "", "timeout (server never answered or never closed)"
+        except Exception as e:
+            return offset, -1, "", f"{type(e).__name__}: {e}"
+        finally:
+            try:
+                s.close()
+            except Exception:
+                pass
+
+    with ThreadPoolExecutor(max_workers=64) as ex:
+        return list(ex.map(finish, handles))
+
+
+def esc(s):
+    return s.replace("\r", "\\r").replace("\n", "\\n")
+
+
+def check_shape(name, request, expected):
+    global PASS, FAIL
+    raw = request.encode("latin-1")
+    splits = [(i, raw[:i], raw[i:]) for i in range(1, len(raw))]
+
+    results = []
+    for i in range(0, len(splits), BATCH):
+        results.extend(run_batch(splits[i:i + BATCH]))
+
+    bad = [r for r in results if r[1] != 200 or r[2] != expected]
+    if not bad:
+        PASS += 1
+        print(f"  PASS [frag: {name}] all {len(results)} offsets -> 200 {expected!r}")
+        return
+
+    FAIL += 1
+    print(f"  FAIL [frag: {name}] {len(bad)}/{len(results)} offsets wrong "
+          f"(expected 200 {expected!r})")
+    for offset, status, body, err in bad[:5]:
+        detail = err if err else f"status={status} body={body!r}"
+        print(f"    offset {offset:>3}: {detail}")
+        pre, post = raw[:offset].decode("latin-1"), raw[offset:].decode("latin-1")
+        print(f"      ...{esc(pre[-40:])} >>>SPLIT<<< {esc(post[:40])}...")
+    if len(bad) > 5:
+        print(f"    ... and {len(bad) - 5} more offsets")
+
+
+# ── Run ───────────────────────────────────────────────────────────────────
+
+all_shapes = shapes()
+total = sum(len(s[1].encode("latin-1")) - 1 for s in all_shapes)
+print(f"[frag] {len(all_shapes)} request shapes, {total} split offsets, "
+      f"{int(DELAY * 1000)}ms pause per batch of {BATCH}")
+
+for name, request, expected in all_shapes:
+    check_shape(name, request, expected)
+
+print(f"\n=== Frag Results: {PASS} passed, {FAIL} failed ===")
+sys.exit(1 if FAIL > 0 else 0)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -677,6 +677,27 @@ if has_test "baseline" || has_test "limited-conn" || has_test "api-4" || has_tes
     check_fragmented "POST /baseline11 — lower-cased content-length" "75" "$BASELINE_DOCS" \
         $'POST /baseline11?a=13&b=42 HTTP/1.1\r\nhost: localhost\r\ncontent-type: text/plain\r\ncontent-length: 2\r\nconnection: close\r\n\r\n' \
         "20"
+
+    # Exhaustive fragmentation. The checks above split at points a human chose;
+    # this splits nine request shapes at EVERY byte offset (~1,000 of them),
+    # which is where the parser bugs actually live - between the CR and the LF,
+    # mid Content-Length digits, mid chunk-size hex. It also covers chunked
+    # bodies under fragmentation, which nothing else here does: the chunked
+    # check above goes through curl in one write, and check_fragmented only
+    # ever fragments Content-Length bodies.
+    #
+    # Runs in ~2s: connections are opened in batches and each batch pays the
+    # 200ms pause once, rather than once per offset.
+    echo "[test] baseline exhaustive fragmentation"
+    FRAG_OUTPUT=$(python3 "$SCRIPT_DIR/validate-frag.py" localhost "$PORT" 200 2>&1) || true
+    echo "$FRAG_OUTPUT"
+    FRAG_PASS=$(echo "$FRAG_OUTPUT" | grep -oP '(\d+) passed' | grep -oP '\d+')
+    FRAG_FAIL=$(echo "$FRAG_OUTPUT" | grep -oP '(\d+) failed' | grep -oP '\d+')
+    PASS=$((PASS + ${FRAG_PASS:-0}))
+    FAIL=$((FAIL + ${FRAG_FAIL:-0}))
+    if [ "${FRAG_FAIL:-0}" -gt 0 ]; then
+        echo "        → $BASELINE_DOCS"
+    fi
 fi
 
 # ───── Pipelined (GET /pipeline) ─────

--- a/site/content/docs/test-profiles/h1/isolated/baseline/validation.md
+++ b/site/content/docs/test-profiles/h1/isolated/baseline/validation.md
@@ -39,3 +39,32 @@ Every fragmented request sets `Connection: close` so the server closes the socke
 - **Split before headers** - the request line arrives in one write, then each header line arrives in its own write (`Host:`, `User-Agent:`, `Connection:`). Expects body `55`.
 - **POST split headers/body** - the full header block (including terminating `\r\n\r\n`) is one write, then the body arrives in a separate write after the pause. Expects body `75`.
 - **POST split body bytes** - headers in one write, then the 2-byte body (`"20"`) arrives as two 1-byte writes. Stresses the parser's ability to reassemble a Content-Length body across multiple `recv()` calls. Expects body `75`.
+- **POST lower-cased field names** - the same POST, spelled `host:`, `content-type:`, `content-length:`, `connection:`. HTTP field names are case-insensitive (RFC 9110 §5.1), so a parser that only matches `Content-Length` would not find the body length. Only meaningful over HTTP/1.1 - HTTP/2 and HTTP/3 mandate lowercase on the wire. Expects body `75`.
+
+## Exhaustive TCP fragmentation
+
+The splits above land where a person chose to put them, which only covers the boundaries someone thought of. This check sweeps **every** one: `validate-frag.py` takes nine request shapes and splits each at every byte offset - roughly 1,000 in total - then requires HTTP 200 with the exact expected body on all of them.
+
+For each offset it opens a connection, writes the first part, pauses **200 ms**, writes the rest, and reads to EOF. The pause is the substance of the test: it guarantees the server's read loop returns holding a partial request and has to carry parser state across `recv()` calls, rather than the kernel coalescing both writes into one segment. Connections are opened in batches of 384 and each batch pays the pause once, so the whole sweep runs in about two seconds.
+
+Every shape carries a `?a=…&b=…` query string, so query parsing sits on the split path too - not just the request line and headers.
+
+The nine shapes:
+
+| Shape | Expected |
+|---|---|
+| `GET`, minimal headers | `55` |
+| `GET`, several headers (`User-Agent`, `Accept`, `Accept-Encoding`) | `55` |
+| `GET`, lower-cased field names | `55` |
+| `GET`, randomized `a` and `b` | `a + b` |
+| `POST`, `Content-Length` body | `75` |
+| `POST`, lower-cased `content-length` | `75` |
+| `POST`, randomized query and body | `a + b + body` |
+| `POST`, chunked body in one chunk | `75` |
+| `POST`, chunked body in two chunks | `75` |
+
+Two of the shapes randomize their operands, so a hardcoded or cached response fails here as well as in the anti-cheat checks above.
+
+The offsets that matter are the ones nobody picks by hand: between the `\r` and the `\n` of a header line, midway through the `Content-Length` digits, inside the chunk-size hex, and one byte into the terminating `0\r\n\r\n`. The chunked shapes are the only place in the suite where a chunked body is fragmented at all - the chunked check above sends its request through curl in a single write, and the hand-picked splits only ever fragment `Content-Length` bodies.
+
+The approach is borrowed from [uWebSockets' `fragment_test.ts`](https://github.com/uNetworking/uWebSockets/blob/master/tests/fragment_test.ts), which does the same byte-by-byte sweep. Two differences here: the response body is asserted rather than just the status code, since a server can answer `200` with the wrong sum; and connections are batched so one pause covers a batch instead of one offset.


### PR DESCRIPTION
`check_fragmented` splits each request where a person chose to split it, which only covers the boundaries someone thought of. `scripts/validate-frag.py` sweeps every one: **nine request shapes split at every byte offset, ~1,000 in total**, each requiring 200 with the exact expected body.

Approach borrowed from [uWebSockets' `fragment_test.ts`](https://github.com/uNetworking/uWebSockets/blob/master/tests/fragment_test.ts).

## What it adds over the existing checks

Every shape carries the `?a=…&b=…` query string, so query parsing sits on the split path too — not just the request line and headers. Two shapes randomize their operands, so a hardcoded or cached response fails here as well as in the anti-cheat checks.

| Shape | Expected |
|---|---|
| `GET`, minimal headers | `55` |
| `GET`, several headers (`User-Agent`, `Accept`, `Accept-Encoding`) | `55` |
| `GET`, lower-cased field names | `55` |
| `GET`, randomized `a` and `b` | `a + b` |
| `POST`, `Content-Length` body | `75` |
| `POST`, lower-cased `content-length` | `75` |
| `POST`, randomized query and body | `a + b + body` |
| `POST`, chunked body in one chunk | `75` |
| `POST`, chunked body in two chunks | `75` |

**It closes a real gap.** The baseline profile defines three request shapes including a chunked body, but nothing fragmented a chunked one — the chunked check goes through curl in a single write, and `check_fragmented` only ever fragments `Content-Length` bodies. Two of the nine shapes are chunked, one across two chunks.

The offsets that matter are the ones nobody picks by hand: between the `\r` and the `\n` of a header line, mid `Content-Length` digits, inside the chunk-size hex, one byte into the terminating `0\r\n\r\n`.

## Cost

**200 ms** pause, and connections open in batches of 384 so each batch pays it once rather than each offset. The whole sweep runs in **~2 s**:

```
[frag] 9 request shapes, 1047 split offsets, 200ms pause per batch of 384
  PASS [frag: GET, minimal] all 73 offsets -> 200 '55'
  ...
=== Frag Results: 9 passed, 0 failed ===
real 0m1.946s
```

Kept `check_fragmented` — it does 3-to-5-way splits, which this 2-way sweep does not cover. The two are complementary. Verified passing on nginx and Caddy, and on h2o after the fix below.

## It found a bug in the h2o entry

`on_baseline11` pointed `strtoll()` straight at `req->entity`, which is length-delimited and **not NUL-terminated**, so the parse ran past `entity.len` into adjacent pool bytes:

```c
const char *p = req->entity.base;
const char *end = p + req->entity.len;
while (p < end && *p <= ' ') p++;
char *ep;
long long n = strtoll(p, &ep, 10);   /* scans past `end` */
if (ep > p) sum += n;                /* and accepts whatever it consumed */
```

With a multi-chunk chunked body the decoder compacts the payload and leaves the old chunk framing right behind it, so `"20"` was read as `"202"` or `"2020"` and the sum came back `257` / `2075` instead of `75`.

Intermittent, because it depends on what the pool held: **3 of 15 runs**, at a different offset each time. That inconsistency is what prompted checking whether my test was flaky — and the answer was no. It also reproduces with **no fragmentation at all**, just the two-chunk request sent whole over 384 concurrent connections, which is what confirmed it as a body-parse bug rather than a fragmentation one.

**0 of 20 runs after the fix.**

The `m` multiplier parse at line ~401 had the same unguarded accept and is now bounded to its own parameter span. `sum_query_values` already guarded correctly with `ep <= amp` and is untouched.

**Upstream h2o is not implicated** — this is the entry's own handler.

## Files

- `scripts/validate-frag.py` — new
- `scripts/validate.sh` — wired into the baseline block, following the `validate-ws.py` pattern
- `frameworks/h2o/src/main.c` — the bounded parse
- `test-profiles/h1/isolated/baseline/validation.md` — documents the new sweep, and adds the lower-cased-field-names bullet that was missing from the existing fragmentation list

`bash -n scripts/validate.sh` passes; `./scripts/validate.sh h2o` runs the new block end to end; docs build to the same 132 pages and badge parity holds.

## Worth knowing before merge

This will fail entries whose parsers mishandle a split the hand-picked five never reached, and chunked-under-fragmentation is newly covered for everyone. I've only run it against nginx, Caddy and h2o — the three images I had built. A sweep across the rest of the `baseline` subscribers before this merges would tell you the real blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)