### PR TITLE
board: put the TUNED pill before the name

### DIFF
--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -1490,7 +1490,7 @@ document.addEventListener('DOMContentLoaded', function(){
       var fav=favs.has(r.fw);
       var tr='<tr class="'+(fav?'fav':'')+'" data-fw-row="'+esc(r.fw)+'">'
         + '<td class="sticky rankc'+(rank<=3?' r'+rank:'')+'">'+rank+'</td>'
-        + '<td class="sticky fwcell"><span class="fl">'+starHtml(r.fw)+'<span class="tsq tsq-'+t+'" data-tip="'+esc(typeTip(t))+'"></span><span class="lang" style="color:'+(dark?c.textDark:c.text)+'">'+esc(r.lang)+'</span><span class="nm">'+nm+'</span>'+tunedPill(r.fw)+medalChips(r.fw)+'</span></td>'
+        + '<td class="sticky fwcell"><span class="fl">'+starHtml(r.fw)+'<span class="tsq tsq-'+t+'" data-tip="'+esc(typeTip(t))+'"></span><span class="lang" style="color:'+(dark?c.textDark:c.text)+'">'+esc(r.lang)+'</span>'+tunedPill(r.fw)+'<span class="nm">'+nm+'</span>'+medalChips(r.fw)+'</span></td>'
         + '<td class="sticky scorec" title="'+esc(cmpTip(r))+'"><span class="sc"><b>'+r.score.toFixed(0)+cmpDelta(r)+'</b><span class="bar"><i style="width:'+Math.max(pct,2).toFixed(0)+'%;background:rgba('+c.rgb+','+(dark?0.55:0.42)+')"></i></span></span></td>';
       pids.forEach(function(pid){
         var cell=r.cells[pid];
@@ -1532,7 +1532,7 @@ document.addEventListener('DOMContentLoaded', function(){
   }
   function profileCell(k, r, x){
     if(k==='rank') return '<div class="c rank'+(x.rank<=3?' r'+x.rank:'')+'">'+x.rank+'</div>';
-    if(k==='fw'){ var nm=esc(r.fw); return '<div class="c fw">'+starHtml(r.fw)+'<span class="tsq tsq-'+x.t+'" data-tip="'+esc(typeTip(x.t))+'"></span><span class="lang" style="color:'+(x.dark?x.lc.textDark:x.lc.text)+'">'+esc(r.lang||'')+'</span><span class="nm">'+nm+'</span>'+tunedPill(r.fw)+'</div>'; }
+    if(k==='fw'){ var nm=esc(r.fw); return '<div class="c fw">'+starHtml(r.fw)+'<span class="tsq tsq-'+x.t+'" data-tip="'+esc(typeTip(x.t))+'"></span><span class="lang" style="color:'+(x.dark?x.lc.textDark:x.lc.text)+'">'+esc(r.lang||'')+'</span>'+tunedPill(r.fw)+'<span class="nm">'+nm+'</span></div>'; }
     if(k==='rps'){ var pct=x.maxRps>0?Math.max((r.rps||0)/x.maxRps*100,(r.rps>0?1.5:0)):0; return '<div class="c meter"><span class="mtop"><span class="v'+(r.rps>0?'':' zero')+'">'+fmt(r.rps||0)+'</span>'+statusHtml(r)+'</span><span class="bar"><i style="width:'+pct.toFixed(1)+'%;background:rgba('+x.lc.rgb+','+(x.dark?0.55:0.42)+')"></i></span></div>'; }
     if(k==='bw') return '<div class="c num sub">'+esc(r.bandwidth||'-')+'</div>';
     if(k==='bwreq'){ var b=bw(r.bandwidth), q=r.rps||0; return '<div class="c num sub">'+(b>0&&q>0?fmtBytes(b/q):'-')+'</div>'; }


### PR DESCRIPTION
Follow-up to #1225. The pill went in *after* the name, where it landed next to the medals and read as part of that cluster. It now sits before the name, between the language code and the name itself — a qualifier on the name reads better in front of it.

Both row renderers move. Two lines. The modal keeps its pill after the name: there the name is an `<h3>` with the type badge beside it, and TUNED belongs in that badge cluster rather than in front of the title.

One consequence: the pill sits in the flex row, so a tuned row's name starts about 55px further right than a standard one, and the left edge of the name column is no longer straight.

Verified: `check_badge_parity.js` at 783 ranks (markup only, no scoring touched), the inline script parses, and rendered in a browser at 1500×760.

---

**Correction (added after merge).** The title and body of this PR were briefly edited to describe a larger change — a smaller row-scale pill, moved to the type square, in a fixed slot. That work was pushed to this branch *after* the merge, so **it is not in this PR's merge commit** (`9d68ce95`, "board: put the TUNED pill before the name"). The description above has been restored to what actually merged. The rest is in **#1228**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
