### PR TITLE
benchmark: make save a checkbox

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,9 +18,10 @@ on:
         required: false
         default: ''
       save:
-        description: 'Open a PR with the results (true/false). Anything else runs the benchmark and reports without committing'
+        description: 'Open a PR with the results. Unchecked runs the benchmark and reports without committing'
         required: false
-        default: 'false'
+        default: false
+        type: boolean
       ref:
         description: 'Branch or SHA to benchmark'
         required: false
@@ -169,7 +170,7 @@ jobs:
       # The results land on a fresh branch off the benchmarked ref rather than
       # being pushed to it, so a run against main never writes to main directly.
       - name: Open a PR with the results
-        if: inputs.save == 'true'
+        if: inputs.save
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LIST: ${{ steps.resolve.outputs.list }}


### PR DESCRIPTION
`save` was a free-text input compared against the exact string `'true'`:

```yaml
save:
  default: 'false'
...
  if: inputs.save == 'true'
```

Typing `True`, `yes` or `1` — all reasonable guesses at a field described as
"true/false" — **skipped the save step silently, after the benchmark had already
run**. For a popular profile across every subscribed framework that is hours of
machine time that quietly commits nothing, with a green job at the end.

`type: boolean` renders a checkbox, so there is nothing to mistype, and the guard
becomes `if: inputs.save` against a real boolean rather than a string compare.

Found while answering "where do I put save" — the field was the third one, but
the answer to *what to put in it* was too easy to get wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)