### PR TITLE
aspnet entries: serve static from the mounted directory, not a build-time copy

### DIFF
--- a/frameworks/aspnet-minimal-ioxide/Dockerfile
+++ b/frameworks/aspnet-minimal-ioxide/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:11.0-preview AS build
 WORKDIR /app
 COPY frameworks/aspnet-minimal-ioxide/ .
-COPY data/static/ wwwroot/static/
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:11.0-preview

--- a/frameworks/aspnet-minimal-ioxide/Program.cs
+++ b/frameworks/aspnet-minimal-ioxide/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 using ioxide.Kestrel;
 using ioxide.pg;
+using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
@@ -99,6 +100,25 @@ app.MapPut("/crud/items/{id:int}", Handlers.CrudUpdate);
 // — the standard ASP.NET production path for HTML responses.
 app.MapRazorPages();
 
-app.MapStaticAssets();
+// Served straight out of the directory the profile mounts, rather than a copy
+// taken at image build. MapStaticAssets, which this used before, resolves assets
+// through a manifest generated at compile time from wwwroot: the container ended
+// up holding two copies of the corpus and answering from the one the harness
+// cannot touch, so a file replaced on disk was never reflected in a response.
+//
+// UseStaticFiles reads the file per request through the file provider, so what is
+// served follows the mounted directory. Compression is still ASP.NET's own
+// response compression middleware, configured above.
+var staticContentTypes = new FileExtensionContentTypeProvider();
+staticContentTypes.Mappings[".webp"] = "image/webp";
+staticContentTypes.Mappings[".woff2"] = "font/woff2";
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider("/data/static"),
+    RequestPath = "/static",
+    ContentTypeProvider = staticContentTypes,
+    ServeUnknownFileTypes = false
+});
 
 app.Run();

--- a/frameworks/aspnet-minimal/Dockerfile
+++ b/frameworks/aspnet-minimal/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /app
 COPY frameworks/aspnet-minimal/ .
-COPY data/static/ wwwroot/static/
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0

--- a/frameworks/aspnet-minimal/Program.cs
+++ b/frameworks/aspnet-minimal/Program.cs
@@ -4,6 +4,8 @@ using HttpArena.Services;
 using HttpArena.Types;
 
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
@@ -105,6 +107,25 @@ app.MapPut("/crud/items/{id:int}", Handlers.CrudUpdate);
 // — the standard ASP.NET production path for HTML responses.
 app.MapRazorPages();
 
-app.MapStaticAssets();
+// Served straight out of the directory the profile mounts, rather than a copy
+// taken at image build. MapStaticAssets, which this used before, resolves assets
+// through a manifest generated at compile time from wwwroot: the container ended
+// up holding two copies of the corpus and answering from the one the harness
+// cannot touch, so a file replaced on disk was never reflected in a response.
+//
+// UseStaticFiles reads the file per request through the file provider, so what is
+// served follows the mounted directory. Compression is still ASP.NET's own
+// response compression middleware, configured above.
+var staticContentTypes = new FileExtensionContentTypeProvider();
+staticContentTypes.Mappings[".webp"] = "image/webp";
+staticContentTypes.Mappings[".woff2"] = "font/woff2";
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider("/data/static"),
+    RequestPath = "/static",
+    ContentTypeProvider = staticContentTypes,
+    ServeUnknownFileTypes = false
+});
 
 app.Run();

--- a/frameworks/fastendpoints/Dockerfile
+++ b/frameworks/fastendpoints/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /app
 COPY frameworks/fastendpoints/ .
-COPY data/static/ wwwroot/static/
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0

--- a/frameworks/fastendpoints/Program.cs
+++ b/frameworks/fastendpoints/Program.cs
@@ -7,6 +7,8 @@ using HttpArena.Services;
 using HttpArena.Types;
 
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
@@ -87,6 +89,25 @@ app.UseFastEndpoints(c =>
 _ = app.Services.GetRequiredService<DatasetService>();
 _ = app.Services.GetRequiredService<ItemService>();
 
-app.MapStaticAssets();
+// Served straight out of the directory the profile mounts, rather than a copy
+// taken at image build. MapStaticAssets, which this used before, resolves assets
+// through a manifest generated at compile time from wwwroot: the container ended
+// up holding two copies of the corpus and answering from the one the harness
+// cannot touch, so a file replaced on disk was never reflected in a response.
+//
+// UseStaticFiles reads the file per request through the file provider, so what is
+// served follows the mounted directory. Compression is still ASP.NET's own
+// response compression middleware, configured above.
+var staticContentTypes = new FileExtensionContentTypeProvider();
+staticContentTypes.Mappings[".webp"] = "image/webp";
+staticContentTypes.Mappings[".woff2"] = "font/woff2";
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider("/data/static"),
+    RequestPath = "/static",
+    ContentTypeProvider = staticContentTypes,
+    ServeUnknownFileTypes = false
+});
 
 app.Run();

--- a/frameworks/servicestack/Dockerfile
+++ b/frameworks/servicestack/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /app
 COPY frameworks/servicestack/ .
-COPY data/static/ wwwroot/static/
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0

--- a/frameworks/servicestack/Program.cs
+++ b/frameworks/servicestack/Program.cs
@@ -2,6 +2,8 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using ServiceStack;
 using ServiceStack.Benchmarks;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 
 var certPath = Environment.GetEnvironmentVariable("TLS_CERT") ?? "/certs/server.crt";
 var keyPath = Environment.GetEnvironmentVariable("TLS_KEY") ?? "/certs/server.key";
@@ -32,7 +34,26 @@ var app = builder.Build();
 
 app.UseResponseCompression();
 
-app.MapStaticAssets();
+// Served straight out of the directory the profile mounts, rather than a copy
+// taken at image build. MapStaticAssets, which this used before, resolves assets
+// through a manifest generated at compile time from wwwroot: the container ended
+// up holding two copies of the corpus and answering from the one the harness
+// cannot touch, so a file replaced on disk was never reflected in a response.
+//
+// UseStaticFiles reads the file per request through the file provider, so what is
+// served follows the mounted directory. Compression is still ASP.NET's own
+// response compression middleware, configured above.
+var staticContentTypes = new FileExtensionContentTypeProvider();
+staticContentTypes.Mappings[".webp"] = "image/webp";
+staticContentTypes.Mappings[".woff2"] = "font/woff2";
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider("/data/static"),
+    RequestPath = "/static",
+    ContentTypeProvider = staticContentTypes,
+    ServeUnknownFileTypes = false
+});
 
 app.UseServiceStack(new AppHost(), options => {
     options.MapEndpoints();


### PR DESCRIPTION
All four .NET entries copied `data/static` into the image at build and served it
with `MapStaticAssets`, which resolves assets through a **manifest generated at
compile time** from `wwwroot`. The container ended up holding two copies of the
corpus and answering from the one the harness cannot touch.

Measured on `aspnet-minimal` before the change:

| | bytes |
|---|---|
| host file after replace | 46086 |
| container at `/data/static` | **46086** — the mount change lands |
| container at `/app/wwwroot/static` | 46080 — its own copy |
| **what it served** | **46080** — the copy |

So it is not a cache going stale: it is a build-time snapshot, and no cache
window can reach it. It also means these entries were **not measured on the same
input as the rest of the field**, which is invisible in a result.

### The change

`UseStaticFiles` with a `PhysicalFileProvider` on `/data/static` reads the file
per request through the provider, so what is served follows the directory the
profile mounts.

- **Compression is unaffected in kind**: every one of these already registers
  ASP.NET's own response compression middleware, so nothing is served
  uncompressed.
- `webp` and `woff2` are added to the content type provider — `MapStaticAssets`
  knew them, the default extension map does not.

**Their published static numbers will move.** `MapStaticAssets` served the `.br`
twins out of its manifest; response compression now gzips on the fly instead. On
`aspnet-minimal` the suite goes from 15 files compressed to 13.

### Validation

Run against the hardened suite in #1267, which is what surfaced this:

| entry | result |
|---|---|
| aspnet-minimal | **83 passed** |
| fastendpoints | **78 passed, 0 failed** |
| servicestack | **55 passed, 0 failed** |
| aspnet-minimal-ioxide | 51 passed, 5 failed |

All four now serve a replaced file in **0s** and the original back in **0s**.

Two failures that are **not** this change:

- `aspnet-minimal-ioxide`'s 5 failures are all `json-tls` — its kTLS listener is
  broken independently, as noted when `static-tls` was dropped from it earlier.
- `aspnet-minimal` intermittently fails the `fortunes` XSS check. It does not
  reproduce against the running container: three direct fetches return
  `&lt;script&gt;` correctly escaped with no raw `<script>alert`, and the Razor
  page uses `@f.Message`, which auto-escapes. Unrelated to static; worth its own
  look.

Depends on #1267 for the staleness check to run at all, but the entry change
stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)