### PR TITLE
swoole: size the crud table for the id space it actually holds

### DIFF
--- a/frameworks/swoole/Crud.php
+++ b/frameworks/swoole/Crud.php
@@ -31,8 +31,16 @@ class Crud
     /**
      * Allocate the shared table. Must run before $http->start() so the mapping
      * is inherited by every worker.
+     *
+     * Sized well above the id space the profile reads, which is 50,000. A
+     * Swoole\Table holds fewer rows than it is declared with - the hash keeps a
+     * bounded conflict pool, and a table declared 65,536 stopped accepting new
+     * keys at about 34,900 and topped out near 43,400. At that point every write
+     * failed and each one logged, which is how one crud run produced 66,157
+     * copies of "Swoole\Table::set(): failed to set". 131,072 takes 60,000
+     * distinct keys with room to spare.
      */
-    public static function initCache(int $rows = 1 << 16): void
+    public static function initCache(int $rows = 1 << 17): void
     {
         $table = new Table($rows);
         $table->column('body', Table::TYPE_STRING, 1024);
@@ -40,6 +48,26 @@ class Crud
         $table->column('expires', Table::TYPE_INT, 8);
         $table->create();
         self::$cache = $table;
+    }
+
+    /**
+     * Drop rows whose deadline has passed.
+     *
+     * The table cannot grow, and a row is otherwise only removed when a read
+     * finds it expired - an id written once and never read again holds its slot
+     * for the life of the process. Sweeping keeps a long run from filling it.
+     */
+    private static function sweepExpired(): void
+    {
+        if (self::$cache === null) {
+            return;
+        }
+        $now = (int)(microtime(true) * 1000);
+        foreach (self::$cache as $key => $row) {
+            if ($row['expires'] <= $now) {
+                self::$cache->del($key);
+            }
+        }
     }
 
     private static function pdo(): ?PDO
@@ -96,10 +124,18 @@ class Crud
         if (self::$cache === null || strlen($body) > 1024) {
             return;
         }
-        self::$cache->set($key, [
+        $row = [
             'body'    => $body,
             'expires' => (int)(microtime(true) * 1000) + self::TTL_MS,
-        ]);
+        ];
+        // A full table answers false and raises a warning. Sweep the expired
+        // rows and try once more; if it still will not fit, the read simply
+        // goes to Postgres next time, which is the same outcome as a miss and
+        // costs nothing but the query.
+        if (@self::$cache->set($key, $row) === false) {
+            self::sweepExpired();
+            @self::$cache->set($key, $row);
+        }
     }
 
     private static function cacheDel(string $key): void


### PR DESCRIPTION
The crud run in #1266 committed a container log carrying **66,157** copies of:

```
PHP Warning:  Swoole\Table::set(): failed to set('crud:N')
```

and that is the **truncated tail** — the log had already been cut to the last 8MB
by the cap from #1263, so the real count is higher. (The cap working as intended
is the only reason that run finished and pushed at all.)

### Cause

A `Swoole\Table` holds fewer rows than it is declared with — the hash keeps a
bounded conflict pool, and the table cannot grow. Measured on the entry's own
image:

| declared | distinct keys stored (of 60,000 offered) | first failure at |
|---|---|---|
| 65,536 | **43,440** | key #34,865 |
| 131,072 | 60,000 | none |

The crud profile reads ids at random out of **50,000**, so the table filled
partway through the run and every write after that failed and logged. Mine, from
#1256.

### What it means for the published number

The reads still answered — a failed `set` is a miss and the next read goes to
Postgres — so the profile did not error and `status_5xx` is 0. But what it
measured after the table filled was **a cache-aside with no cache**, which is not
what the profile is for. The **264,191 rps** that PR publishes understates the
entry and is worth re-running once this lands.

### Fix

- Table declared `1 << 17`, which takes 60,000 distinct keys with room to spare.
- A failed `set` stops being silent-but-noisy: it sweeps the rows whose deadline
  has passed and retries once. If it still will not fit, the read goes to
  Postgres next time — a query, and nothing else.
- The sweep exists because a row is otherwise **only dropped when a read finds it
  expired**, so an id written once and never read again holds its slot for the
  life of the process. That is the part that would have bitten again at any size.

### Verified

On the image, 400,000 writes against a 50,000-id space:

```
writes=400000  sweeps=0  hard failures=0  rows now=49987
```

Validation: **71 passed, 0 failed**, and not one `failed to set` in the container
log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)