### PR TITLE
validate: the staleness probe must not make the file unreadable

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -473,6 +473,12 @@ static_staleness_probe() {
     # comparison can miss the change
     cat "$file" > "$probe"
     printf 'httparena-staleness-probe-%s\n' "$$" >> "$probe"
+    # mktemp creates 0600, and mv carries the source mode onto the destination.
+    # Left alone that makes the replacement unreadable to any container running
+    # as non-root, which reads back as "the server ignored the disk" -- a false
+    # failure for exactly the entries doing the right thing. Carry the mode of
+    # the file being replaced instead.
+    chmod --reference="$backup" "$probe"
     original_sum="$(sha256sum "$backup" | cut -d' ' -f1)"
     probe_sum="$(sha256sum "$probe" | cut -d' ' -f1)"
 


### PR DESCRIPTION
The static staleness probe added in #1267 built its replacement file with `mktemp`, which creates it `0600`. `mv` carries the source mode onto the destination, so after the replace the static file was `0600` owned by the invoking user.

Any container running as a **non-root user** then got `EACCES` reading it. The probe never saw bytes matching the replacement and failed the entry with:

> `hero.webp` was replaced in the mounted static directory and the server still served the old bytes after 30s. Either a cache is holding the file contents and never revalidating, or the entry is serving a copy taken at image build rather than the directory the profile mounts

which is the opposite of what those entries were doing.

The bias is the wrong way round: every entry that passed the probe so far runs as `root`, so the bug penalised precisely the images following good practice.

## Repro

`phoenix-bandit` runs as `nobody` (65534) and fails the probe on this alone. It reads the mounted directory correctly — replacing `hero.webp` by hand and requesting it back shows the new bytes within 1s over both HTTP/1.1 and h2. Under `validate.sh` it failed twice in a row.

## Fix

Carry the mode of the file being replaced onto the replacement, so the server sees it exactly as it saw the original.

```
chmod --reference="$backup" "$probe"
```

`phoenix-bandit`: 69 passed / 1 failed → **70 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)