### PR TITLE
ci: validate every entry when the validator itself changes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,13 @@ on:
       - 'frameworks/**'
       - 'scripts/validate.sh'
       - 'scripts/validate-ws.py'
+      - '.github/workflows/validate.yml'
+  workflow_dispatch:
+    inputs:
+      framework:
+        description: 'Entry name, a comma-separated list, or "all" for every enabled entry'
+        required: false
+        default: 'all'
 
 jobs:
   detect:
@@ -30,9 +37,45 @@ jobs:
         # The split is per entry, not per profile: validate.sh runs everything
         # in an entry's `tests` array in one process, so a gateway-subscribed
         # entry has to run its isolated profiles there too.
+        env:
+          DISPATCH_INPUT: ${{ github.event.inputs.framework }}
         run: |
-          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
-            | grep '^frameworks/' | cut -d'/' -f2 | sort -u || true)
+          # Which entries this run covers.
+          #
+          #   * a manual run takes the name, list, or "all" it was given
+          #   * a change to the validator itself covers everything, because a
+          #     validator change can affect any entry. Without this the job
+          #     triggers on scripts/validate.sh and then finds no changed
+          #     frameworks/ paths, so it validates nothing at all -- which is
+          #     what happened to the static staleness probe when it landed.
+          #   * otherwise, just the entries the PR touches
+          all_entries() {
+            for m in frameworks/*/meta.json; do
+              fw=$(basename "$(dirname "$m")")
+              jq -e '.enabled != false' "$m" >/dev/null 2>&1 && echo "$fw"
+            done
+          }
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -z "$DISPATCH_INPUT" ] || [ "$DISPATCH_INPUT" = "all" ]; then
+              changed=$(all_entries)
+              echo "manual run over every enabled entry"
+            else
+              changed=$(echo "$DISPATCH_INPUT" | tr ',' '\n' | sed 's/[^A-Za-z0-9._-]//g' | sort -u)
+              echo "manual run over: $(echo $changed)"
+            fi
+          else
+            validator_changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+              | grep -E '^(scripts/validate\.sh|scripts/validate-ws\.py|\.github/workflows/validate\.yml)$' || true)
+            if [ -n "$validator_changed" ]; then
+              changed=$(all_entries)
+              echo "the validator changed, so every enabled entry is covered"
+            else
+              changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+                | grep '^frameworks/' | cut -d'/' -f2 | sort -u || true)
+            fi
+          fi
+
           std=(); gw=()
           for fw in $changed; do
             # Deleted in this PR, or the shared authsvc rather than an entry.
@@ -54,7 +97,11 @@ jobs:
     needs: detect
     if: needs.detect.outputs.frameworks != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # A full sweep reaches entries that never appear in a normal PR, and some of
+    # them build from source on a four-core hosted runner -- h2o, the LTO Rust
+    # entries, Swift. 30 minutes was sized for the handful of entries a PR
+    # touches and is not enough for those.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +115,9 @@ jobs:
     needs: detect
     if: needs.detect.outputs.gateway != '[]'
     runs-on: self-hosted
-    timeout-minutes: 90
+    # Sequential by construction (see below), so the budget has to cover every
+    # compose entry in the run, not just one. There are eight.
+    timeout-minutes: 300
     # One at a time, and never alongside a benchmark. Every gateway and
     # production stack binds the host's ports directly — edge 8443, authsvc
     # 9090, server 8080 — so two stacks on one box fight over them and the


### PR DESCRIPTION
Opens a full validation sweep over every enabled entry, and fixes the gap that made one impossible.

## The gap

`validate.yml` triggers on `scripts/validate.sh`, then builds its framework list from changed `frameworks/**` paths:

```
changed=$(git diff --name-only origin/$BASE...HEAD | grep '^frameworks/' | cut -d'/' -f2 | sort -u)
```

A PR that only touches the validator matches the trigger and then validates **nothing** — the list is empty and both jobs are skipped by `if: ... != '[]'`.

That is not hypothetical. It happened when the static staleness probe landed in #1267, and again when it was hardened in #1284. Both changed what every entry is checked against; neither ran a single entry.

## The change

- A validator change (`scripts/validate.sh`, `scripts/validate-ws.py`, or this workflow) now covers **every enabled entry**.
- The workflow file joins the trigger paths, since editing it can change what validation means just as much as editing the script. That also makes this PR self-demonstrating: it validates everything.
- Adds `workflow_dispatch` taking an entry name, a comma-separated list, or `all`, so a sweep can be run on demand without inventing a commit.

## Scale

185 enabled entries — **177** on the matrix (GitHub's cap is 256) and **8** compose entries running sequentially on the self-hosted box.

Timeouts were sized for the handful of entries a normal PR touches, so both are raised:

| job | was | now | why |
|---|---|---|---|
| matrix | 30 min | 60 min | a sweep reaches entries that build from source on a four-core hosted runner — h2o, the LTO Rust entries, Swift |
| self-hosted | 90 min | 300 min | one sequential loop now covers all eight compose entries, not one or two |

## What to expect from this run

This is the first sweep against the hardened static probe, so it is also the blast-radius measurement for #1284. From a 12-entry local sample, **no entry that passed the old probe fails the new one** — every failure below already fails on `main`:

| | old probe | new probes |
|---|---|---|
| bun, caddy, elysia, hono-bun, h2o-mruby, slimeweb, genhttp-11-ioxide | PASS | PASS |
| humming-bird, frankenphp-trueasync, genhttp-11, genhttp-11-kestrel, ioxide | FAIL | FAIL |

Two things that sample already surfaced, both independent of the hardening:

- `genhttp-11` and `genhttp-11-kestrel` serve from GenHTTP's `Assets.From`, which never revalidates — 35s after the file changed on disk they still serve the original bytes. Their sibling `genhttp-11-ioxide` passes because `IoxideFiles.From` re-stats per request. Same framework, different handler.
- `ioxide` is stale on both the identity and variant paths out to 35s, despite `Program.cs:100` describing the plain path as read-per-request.

Expect some failures in this sweep to be infrastructure rather than entries — a four-core hosted runner is not the benchmark box, and a few builds are slow or flaky there. Worth reading the first run as a survey, not a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
