### PR TITLE
bananabread: disable

### DIFF
--- a/frameworks/bananabread/meta.json
+++ b/frameworks/bananabread/meta.json
@@ -12,7 +12,7 @@
   "engine": "seagreen",
   "description": "Seagreen — a TypeScript port of GenHTTP — on Bun's raw-TCP engine, with kotlinx-style decorators and Bun's built-in SQL.",
   "repo": "https://github.com/dotnet-web-stack/Seagreen",
-  "enabled": true,
+  "enabled": false,
   "tests": [
     "baseline",
     "pipelined",


### PR DESCRIPTION
`bananabread` was `enabled: true` but has no result file, so it validated on every sweep while appearing nowhere on the board.

One line, `enabled: true` → `false`. The entry is left in place, so re-enabling is a one-line edit whenever someone wants to run it.

## Context

It is one of **15** enabled entries with no results:

```
araara, araara-standard, aspnet-minimal_caddy, aspnet-minimal_nginx,
bananabread, hanami, httpjl, pedestal, spring-jvm-grpc, tonic-grpc,
vibed, web-framework-{cc,cpp,csharp,python}
```

Only `bananabread` is disabled here. The other 14 are left alone — four of them are the orphan `production`-tier `web-framework-*` entries that no league renders, which is a separate question.

For the record: it validated clean in the current sweep (`validate (bananabread): success`), so this is about it being unpublished, not broken. I earlier flagged its `repo` as mismatched — that was wrong, and the description explains why: Seagreen is a TypeScript port of GenHTTP, so a `dotnet-web-stack` repo for a TS entry is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)