### PR TITLE
grpc: probe readiness without ghz

### DIFF
--- a/scripts/benchmark-lite.sh
+++ b/scripts/benchmark-lite.sh
@@ -164,11 +164,10 @@ DOCKER_FLAGS=(
 H2LOAD_CMD="docker run ${DOCKER_FLAGS[*]} $H2LOAD_IMAGE"
 H2LOAD_H3_CMD="docker run ${DOCKER_FLAGS[*]} $H2LOAD_H3_IMAGE"
 WRK_CMD="docker run ${DOCKER_FLAGS[*]} $WRK_IMAGE"
-GHZ_CMD="docker run ${DOCKER_FLAGS[*]} $GHZ_IMAGE"
 
 # Parallel arrays — image names contain ':' (e.g. wrk:local), so packing
 # them into "img:dockerfile" strings breaks `${pair%%:*}` parsing.
-_loadgen_images=("$GCANNON_IMAGE" "$H2LOAD_IMAGE" "$H2LOAD_H3_IMAGE" "$WRK_IMAGE" "$GHZ_IMAGE")
+_loadgen_images=("$GCANNON_IMAGE" "$H2LOAD_IMAGE" "$H2LOAD_H3_IMAGE" "$WRK_IMAGE")
 _loadgen_files=("gcannon.Dockerfile" "h2load.Dockerfile" "h2load-h3.Dockerfile" "wrk.Dockerfile")
 for i in "${!_loadgen_images[@]}"; do
     img="${_loadgen_images[$i]}"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -126,11 +126,10 @@ if [ "$LOADGEN_DOCKER" = "true" ]; then
     H2LOAD_CMD="docker run ${DOCKER_FLAGS[*]} $H2LOAD_IMAGE"
     H2LOAD_H3_CMD="docker run ${DOCKER_FLAGS[*]} $H2LOAD_H3_IMAGE"
     WRK_CMD="docker run ${DOCKER_FLAGS[*]} $WRK_IMAGE"
-    GHZ_CMD="docker run ${DOCKER_FLAGS[*]} $GHZ_IMAGE"
 
     # Parallel arrays — images can't be packed into "img:dockerfile" strings
     # because image names already contain ':' (e.g. wrk:local, h2load:local).
-    _loadgen_images=("$GCANNON_IMAGE" "$H2LOAD_IMAGE" "$H2LOAD_H3_IMAGE" "$WRK_IMAGE" "$GHZ_IMAGE")
+    _loadgen_images=("$GCANNON_IMAGE" "$H2LOAD_IMAGE" "$H2LOAD_H3_IMAGE" "$WRK_IMAGE")
     _loadgen_files=("gcannon.Dockerfile" "h2load.Dockerfile" "h2load-h3.Dockerfile" "wrk.Dockerfile")
     for i in "${!_loadgen_images[@]}"; do
         img="${_loadgen_images[$i]}"

--- a/scripts/lib/framework.sh
+++ b/scripts/lib/framework.sh
@@ -181,7 +181,13 @@ framework_wait_ready() {
 
     case "$endpoint" in
         grpc|grpc-tls)
-            _wait_grpc "$endpoint" && return 0
+            # Return the probe's own verdict. Falling through on failure lands
+            # in the generic loop below, which reads $probe_url -- never set on
+            # this path -- and dies with "unbound variable" under set -u,
+            # hiding the real answer ("the gRPC server never became ready")
+            # behind a shell error.
+            _wait_grpc "$endpoint"
+            return $?
             ;;
         h3|static-h3)
             probe_url="https://localhost:$H2PORT/baseline2?a=1&b=1"
@@ -232,26 +238,50 @@ framework_wait_ready() {
 
 _wait_grpc() {
     local endpoint="$1"
-    local target flag
+    local url proto_flag
     if [[ "$endpoint" == *-tls ]]; then
-        target="localhost:$H2PORT"
-        flag="--skipTLS"
+        url="https://localhost:$H2PORT/benchmark.BenchmarkService/GetSum"
+        proto_flag="-k --http2"
     else
-        target="localhost:$PORT"
-        flag="--insecure"
+        url="http://localhost:$PORT/benchmark.BenchmarkService/GetSum"
+        proto_flag="--http2-prior-knowledge"
     fi
-    local proto="$REQUESTS_DIR/benchmark.proto"
-    [ -f "$proto" ] || proto=$(find "$ROOT_DIR/frameworks/$FRAMEWORK" -name benchmark.proto -type f | head -1)
 
-    local i
+    # A real unary GetSum, framed by hand rather than driven by a gRPC client.
+    # ghz used to do this, and it was the only thing left needing that tool once
+    # the streaming profiles went; a length-prefixed protobuf message is nine
+    # bytes and costs no dependency at all.
+    #
+    #   00                 compressed-flag = 0
+    #   00 00 00 04        big-endian message length
+    #   08 01              field 1 (a) varint 1
+    #   10 02              field 2 (b) varint 2
+    local frame
+    frame=$(mktemp)
+    printf '\x00\x00\x00\x00\x04\x08\x01\x10\x02' > "$frame"
+
+    local i head
     for i in $(seq 1 30); do
-        if "$GHZ" "$flag" --proto "$proto" \
-             --call benchmark.BenchmarkService/GetSum \
-             -d '{"a":1,"b":2}' -c 1 -n 1 "$target" >/dev/null 2>&1; then
+        # Ready means a gRPC answer, not merely an open socket: an h2 server
+        # that has not registered the service yet still accepts connections.
+        #
+        # The verdict is the response *header* block -- 200 plus an
+        # application/grpc content-type. grpc-status is deliberately not the
+        # test: most servers (cardigan, and every grpc-go descendant) send it
+        # as an HTTP/2 trailer, which -D does not capture, so requiring it
+        # would hang the probe on servers that are perfectly ready. A non-gRPC
+        # server on the same port answers 404 with text/plain and is rejected.
+        head=$(curl -s --max-time 3 $proto_flag \
+                    -H 'content-type: application/grpc' -H 'te: trailers' \
+                    --data-binary "@$frame" -o /dev/null -D - "$url" 2>/dev/null)
+        if grep -qiE '^HTTP/2 200' <<<"$head" \
+           && grep -qi '^content-type: *application/grpc' <<<"$head"; then
+            rm -f "$frame"
             info "gRPC server ready"
             return 0
         fi
         sleep 1
     done
+    rm -f "$frame"
     return 1
 }


### PR DESCRIPTION
`#1298` removed the streaming gRPC profiles and, with them, `GHZ`/`GHZ_IMAGE` from `common.sh`. I said at the time that ghz was used only by the stream endpoints — that was wrong. `_wait_grpc()` also shelled out to it as the **readiness probe** for `unary-grpc` and `unary-grpc-tls`, so every gRPC run on main now dies before the benchmark starts:

```
scripts/lib/framework.sh: line 248: GHZ: unbound variable
```

(seen in [run 32748999452](https://github.com/MDA2AV/HttpArena/actions/runs/32748999452/job/97501210516))

## The replacement

A hand-framed unary `GetSum` over curl — a length-prefixed protobuf message is nine bytes, so this costs no dependency:

```
00              compressed-flag = 0
00 00 00 04     big-endian message length
08 01           field 1 (a) varint 1
10 02           field 2 (b) varint 2
```

Readiness is judged on the response **header block** — `HTTP/2 200` plus an `application/grpc` content-type — deliberately *not* on `grpc-status`. Most servers (cardigan, and every grpc-go descendant) send `grpc-status` as an HTTP/2 trailer, which `curl -D` never captures; requiring it would hang the probe against servers that are perfectly ready.

## Latent bug fixed alongside

The dispatch read `_wait_grpc "$endpoint" && return 0`, so a *failed* probe fell through into the generic curl loop below — which reads `$probe_url`, never assigned on the gRPC path. Under `set -u` that turned an honest "the gRPC server never came up" into an unbound-variable abort that hid the real cause. It now returns the probe's own verdict.

## Verification

| case | result |
|---|---|
| `cardigan-grpc` / `unary-grpc` end-to-end | ready, completes — 4.4M req/s |
| `cardigan-grpc-tls` / `unary-grpc-tls` end-to-end | ready, completes — 4.3M req/s |
| nothing listening on :8080 | `rc=1` cleanly, no unbound variable |
| plain HTTP server on :8080 | correctly rejected, not mistaken for gRPC |

Also swept the last `GHZ_CMD`/`GHZ_IMAGE` leftovers out of `benchmark.sh` and `benchmark-lite.sh`, and confirmed every lib under `scripts/lib/` still sources clean under `set -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)