### PR TITLE
validate: a skipped check is an environment gap, not a failed entry

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2923,12 +2923,24 @@ else
 fi
 
 # An entry that ran no assertions at all is unvalidated, not validated-clean.
-# Exiting 0 here is what let H3-only entries show a green check while nothing
-# had been verified about them; say so plainly and fail instead.
+# Exiting 0 there is what let H3-only entries show a green check while nothing
+# had been verified about them.
+#
+# But "no assertions" has two very different causes, and only one of them is the
+# entry's problem. If coverage exists and the tool it needs was simply absent,
+# that is an environment gap: the validate job runs on ubuntu-latest, which never
+# builds the load-generator images (benchmark.sh does that, on the self-hosted
+# runner), so h3 checks skip there and would fail every h3-only entry for a
+# reason that has nothing to do with the entry. Warn loudly and pass.
+# Fail only when validate.sh genuinely has no checks for anything subscribed.
 if [ "$PASS" -eq 0 ] && [ "$FAIL" -eq 0 ]; then
     echo ""
-    echo "FAIL: no checks ran for $FRAMEWORK — every subscribed test ($TESTS) is one validate.sh has no coverage for, so this run proves nothing"
-    exit 1
+    if [ "$SKIPPED" -ne 0 ]; then
+        echo "WARNING: $FRAMEWORK is UNVALIDATED — the only coverage for its subscribed tests ($TESTS) was skipped for want of a tool on this machine. Nothing here was verified about the entry; run it where the load-generator images exist to get a real verdict."
+    else
+        echo "FAIL: no checks ran for $FRAMEWORK — every subscribed test ($TESTS) is one validate.sh has no coverage for, so this run proves nothing"
+        exit 1
+    fi
 fi
 
 if [ "$FAIL" -ne 0 ]; then


### PR DESCRIPTION
My #1304 broke CI. Reported on the #1303 run — [zix-http3 job](https://github.com/MDA2AV/HttpArena/actions/runs/32759835350/job/97536072459?pr=1303):

```
SKIP [h3]: no h2load-h3 image — build docker/h2load-h3.Dockerfile to validate HTTP/3
=== Results: 0 passed, 0 failed, 1 skipped ===
FAIL: no checks ran for zix-http3 — every subscribed test (baseline-h3 static-h3) ...
```

## What I got wrong

#1304 made a run with **no assertions** fail, so an h3-only entry could not show a green check while nothing had been verified. That reasoning holds for genuine missing coverage. It does not hold for the case CI actually hits.

The per-framework validate job runs on `ubuntu-latest`. Load-generator images are built by `benchmark.sh` on the **self-hosted** runner, so `h2load-h3` does not exist on the validate runner and never will under the current workflow. The h3 checks skip, the run ends 0/0, and #1304 turned that into a hard failure — zix-http3 fails for a missing image on the runner, not for anything about the entry.

## Fix

Split the two causes:

| situation | verdict |
|---|---|
| coverage exists, its tool was absent | `WARNING: … is UNVALIDATED`, **exit 0** |
| validate.sh has no checks at all for the subscribed tests | `FAIL`, exit 1 |

Nothing is proven in the first case, but nothing is wrong with the entry either — so it says so plainly rather than failing it.

## Verification

Both reachable paths, against `zix-http3`:

| condition | result |
|---|---|
| `h2load-h3` present | 2 passed, 0 failed, exit 0 |
| `h2load-h3` absent (CI's situation) | 0 passed, 0 failed, 1 skipped, WARNING, exit 0 |

## Still open

Real h3 coverage on CI needs the image to exist there — built and cached in the workflow, or pulled from a registry. Neither is in this change; the h3 checks stay fully effective locally and on the self-hosted runner, where the image is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)