### PR TITLE
millionaire: zrk is not on PATH on the bench host

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -174,6 +174,28 @@ for t in baseline pipelined limited-conn json json-comp json-tls upload \
 done
 $_has_isolated_test && framework_build
 
+# zrk is the one load generator with no native install on the bench host.
+# gcannon, wrk and h2load are all on PATH there, so the adapters can call them
+# bare when LOADGEN_DOCKER is false -- zrk cannot, and a `command not found`
+# inside a tool adapter reads downstream as a server that answered nothing.
+# That is exactly how the first board-wide millionaire run failed: every entry
+# reported 0 req/s and a rate_ratio of 0, and the run looked like 103 broken
+# frameworks instead of one missing binary.
+#
+# Built here rather than in the LOADGEN_DOCKER block because that block is
+# gated on a mode the bench host does not use, and built *before* system_tune()
+# for the reason the framework build above is: this Dockerfile needs DNS to
+# reach github.com, and the daemon restart in system_tune() breaks resolution
+# inside build containers for several seconds afterwards.
+if framework_subscribes_to "millionaire" && [ -z "${ZRK_CMD:-}" ]    && ! command -v "$ZRK" >/dev/null 2>&1; then
+    if ! docker image inspect "$ZRK_IMAGE" >/dev/null 2>&1; then
+        info "building $ZRK_IMAGE from docker/zrk.Dockerfile (no native zrk on PATH)"
+        docker build -t "$ZRK_IMAGE" -f "$ROOT_DIR/docker/zrk.Dockerfile" "$ROOT_DIR/docker"             || fail "$ZRK_IMAGE build failed — millionaire cannot run without it"
+    fi
+    ZRK_CMD="docker run --rm --network host --cpuset-cpus=$GCANNON_CPUS --security-opt seccomp=unconfined --ulimit memlock=-1:-1 --ulimit nofile=1048576:1048576 $ZRK_IMAGE"
+    info "zrk: docker mode ($ZRK_IMAGE)"
+fi
+
 # ── System tuning — NOW, after all image builds are complete ───────────────
 
 if [ "${SKIP_TUNE:-}" != "true" ]; then
@@ -354,11 +376,18 @@ run_one() {
 
     # The millionaire profile's headline number, and the check that it counts.
     if [ "$endpoint" = "millionaire" ]; then
-        if [ -n "$best_cpu_usec" ] && [ "${BEST_M[status_2xx]:-0}" -gt 0 ] 2>/dev/null; then
+        # Two different failures that used to print the same line. "No CPU
+        # reading" is a cgroup problem; "no requests" is a generator or server
+        # problem, and saying the former when it is the latter sent the first
+        # board-wide run looking in the wrong place entirely.
+        if [ "${BEST_M[status_2xx]:-0}" -eq 0 ] 2>/dev/null; then
+            warn "no requests were served — there is nothing to measure here."
+            warn "  this is a load-generator or server failure, not a CPU one; see the zrk output above"
+        elif [ -z "$best_cpu_usec" ]; then
+            warn "no cgroup CPU reading for this run — the millionaire metric is missing"
+        else
             info "exact CPU: $(awk -v c="$best_cpu_usec" 'BEGIN{printf "%.2f", c/1e6}') core-seconds \
 | $(awk -v c="$best_cpu_usec" -v r="${BEST_M[status_2xx]}" 'BEGIN{printf "%.3f", c/r}') us/req"
-        else
-            warn "no cgroup CPU reading for this run — the millionaire metric is missing"
         fi
         # Below ~0.98 the client never delivered the rate the profile is defined
         # by, so the CPU figure describes a different, lighter workload than

--- a/scripts/lib/tools/zrk.sh
+++ b/scripts/lib/tools/zrk.sh
@@ -10,12 +10,32 @@
 
 : "${ZRK_CMD:=}"
 
+# Resolve how to invoke zrk, and refuse rather than guess.
+#
+# The other adapters can fall through to a bare binary name because the bench
+# host has all of theirs on PATH. zrk's is not installed anywhere, so a silent
+# fall-through produces "command not found", an empty summary, and a row of
+# zeros that is indistinguishable from a server that served nothing. Failing
+# here instead aborts the run with the actual reason -- which is the right
+# outcome, because a missing generator fails every entry identically and there
+# is nothing to be learned by measuring the other 102 the same way.
 _zrk_cmd() {
     if [ -n "$ZRK_CMD" ]; then
         printf '%s\n' $ZRK_CMD
-    else
-        printf '%s\n' "$ZRK"
+        return 0
     fi
+    if command -v "$ZRK" >/dev/null 2>&1; then
+        printf '%s\n' "$ZRK"
+        return 0
+    fi
+    if docker image inspect "$ZRK_IMAGE" >/dev/null 2>&1; then
+        printf '%s\n' docker run --rm --network host \
+            --cpuset-cpus="$GCANNON_CPUS" --security-opt seccomp=unconfined \
+            --ulimit memlock=-1:-1 --ulimit nofile=1048576:1048576 "$ZRK_IMAGE"
+        return 0
+    fi
+    fail "zrk not found: '$ZRK' is not on PATH and image '$ZRK_IMAGE' does not exist.
+      Build it with: docker build -t $ZRK_IMAGE -f docker/zrk.Dockerfile docker/"
 }
 
 # The rate the millionaire profile holds, in requests/second. It lives here
@@ -58,11 +78,15 @@ zrk_build_args() {
     printf '%s\n' "${cmd[@]}"
 }
 
+# stdout is the JSON summary and is captured by the caller; stderr is left
+# attached to the console on purpose. It used to go to /dev/null to keep the
+# dashboard out of the log -- but --format json already suppresses the
+# dashboard, so all that redirect ever hid was the reason a run failed.
 zrk_run() {
     if [ -n "$ZRK_CMD" ]; then
-        timeout 60 "$@" 2>/dev/null || true
+        timeout 60 "$@" || true
     else
-        timeout 60 taskset -c "$GCANNON_CPUS" "$@" 2>/dev/null || true
+        timeout 60 taskset -c "$GCANNON_CPUS" "$@" || true
     fi
 }
 
@@ -81,6 +105,11 @@ raw = sys.argv[1]
 # {...} rather than assuming the whole stream is the summary.
 start, end = raw.find("{"), raw.rfind("}")
 if start < 0 or end <= start:
+    # No summary at all. Say so on stderr rather than only emitting zeros,
+    # which downstream cannot tell apart from a server that served nothing.
+    sys.stderr.write("[zrk] no JSON summary in output — the generator did not "
+                     "run, or died before reporting. Raw output was:\n%s\n"
+                     % (raw[:2000] or "<empty>"))
     for k in ("rps=0", "avg_lat=", "p99_lat=", "reconnects=0", "bandwidth=0",
               "status_2xx=0", "status_3xx=0", "status_4xx=0", "status_5xx=0",
               "rate_ratio=0"):


### PR DESCRIPTION
Fixes the failure on #1320, where every entry reported `0 req/s`, `CPU 0%` and `rate_ratio=0`. Nothing was wrong with the frameworks.

## What happened

`gcannon`, `wrk` and `h2load` are all installed natively on the bench host, so their adapters call them bare when `LOADGEN_DOCKER` is false — which is the mode the host actually runs in. **zrk has no native install**, so `zrk_run` invoked a binary that does not exist.

Three things then conspired to make that unreadable:

1. `zrk_run` sent stderr to `/dev/null`, so `command not found` vanished. I put that there to keep the live dashboard out of the log — but `--format json` already suppresses the dashboard, so the redirect only ever hid errors.
2. The parser answers an unparseable summary with a row of zeros, which downstream cannot distinguish from a server that genuinely served nothing.
3. The summary line said *"no cgroup CPU reading"*, pointing at cgroups when the problem was upstream of the server entirely.

So the run read as 103 broken frameworks instead of one missing binary.

## Fixes

- **`benchmark.sh`** builds and uses `zrk:local` when the entry subscribes to `millionaire` and no native `zrk` is on PATH. Placed in the pre-`system_tune()` window alongside the other image builds — this Dockerfile needs DNS to reach github.com, and the daemon restart in `system_tune()` breaks resolution inside build containers for several seconds afterwards.
- **`_zrk_cmd`** resolves `ZRK_CMD` → native binary → image, and calls `fail()` if none exist rather than falling through to a bare name. A missing generator fails every entry identically; there is nothing to learn by measuring the other 102 the same way, so aborting is the right outcome.
- **`zrk_run`** leaves stderr attached.
- **The parser** reports an absent summary on stderr, with the raw output, instead of only emitting zeros.
- **`no requests were served`** and **`no cgroup CPU reading`** are now separate messages — they point at opposite ends of the pipeline.

## Verified

Reproduced the host's exact condition on my box — no `zrk` on PATH, `LOADGEN_DOCKER` unset:

```
[info] zrk: docker mode (zrk:local)
=== Best: 997,852 req/s   rate_ratio 0.9979   106.86 core-seconds   5.353 us/req
```

The not-found path was exercised separately and aborts with the build command in the message rather than producing zeros.

## Worth knowing separately

`rebuild_site_data.py` published actix's `0 req/s` row to `site/data/results/actix.json` — there is currently **no filter that drops a failed run**. #1252 ("benchmark: refuse to publish a run that mostly answered 5xx") is still open and would have caught it. Worth merging before the next board-wide sweep, since a zero row is otherwise indistinguishable from a real measurement once it is on the board.

Once this merges, re-comment `/benchmark-test -t millionaire` on #1320 — that job merges main before running, so it picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
