### PR TITLE
fulmine: subscribe both entries to the async profile

### DIFF
--- a/frameworks/fulmine-tuned/README.md
+++ b/frameworks/fulmine-tuned/README.md
@@ -68,6 +68,14 @@ The rest is the standard entry's, unchanged and worth repeating here:
   ordinary path, because the compiler reads the source and cannot see into one.
 - `express.compression()` is the framework's own, taking the compression module's options: it is
   mounted on the json route, which is the only one the profiles ask to compress.
+- `tls_check` is opted into in `meta.json`, and the listener it asks for on :9000 is the 8081 one
+  again, reading `/certs-tls` rather than `/certs`. What it adds is the rotation, and that is a new
+  listener rather than a new certificate on the old one: µWS reads the pair when it builds the SSL
+  context, and `addServerName()` only replaces the certificate for one SNI name — a client sending
+  no server name is answered from the default context, still on the old pair. A worker binds the
+  port shared, so the replacement is accepting on 9000 before the listener it replaces is told to
+  stop, and `close()` drains that one instead of cutting it. The directory is mounted by
+  `validate.sh` alone, so on a measured run none of this is built.
 - `express({ cluster: "auto" })` is the framework's own fork, so there is no cluster boilerplate in
   the entry: one worker per usable core, each binding the same port with uWS's shared flag, which
   is `SO_REUSEPORT`. The kernel picks which worker gets a connection and the primary is not in the

--- a/frameworks/fulmine-tuned/README.md
+++ b/frameworks/fulmine-tuned/README.md
@@ -42,7 +42,7 @@ measure file I/O. Every request reads the file it answers with.
 
 ## Endpoints
 
-The same handlers and the same twenty profiles as the standard entry, gateway and
+The same handlers and the same twenty-two profiles as the standard entry, gateway and
 production-stack included.
 
 | Endpoint | Method | Description |
@@ -51,6 +51,7 @@ production-stack included.
 | `/baseline11` | GET/POST | Sums query parameter values, plus the body for POST |
 | `/baseline2` | GET | Sums query parameter values |
 | `/json/:count` | GET | Serializes a slice of the dataset, compressed when the client asks |
+| `/delay/:ms` | GET | Waits the milliseconds named in the path, then echoes them back |
 | `/async-db` | GET | Reads from PostgreSQL, prepared statement, pool sized under max_connections |
 | `/upload` | POST | Counts the bytes of the request body |
 | `/static/*` | GET | `express.static()` with `preCompressed`, served from the in-memory cache |

--- a/frameworks/fulmine-tuned/app.js
+++ b/frameworks/fulmine-tuned/app.js
@@ -160,6 +160,23 @@ app.get('/pipeline', (req, res) => {
     res.type('text/plain').send('ok');
 });
 
+// GET /delay/{ms} — answered once ms milliseconds have gone by. setTimeout hands the request
+// back to the event loop, so a request that is waiting costs one timer entry and the worker
+// stays free for the next one: at 64K held connections that is 64K timers rather than 64K
+// blocked threads.
+//
+// The value is read out of the path before the timer is armed, which is what this profile is
+// really testing. µWS invalidates the request object the moment the handler returns, so a
+// handler that reached for the parameter inside the callback would find it gone; keeping it in
+// the closure also gives every overlapping request its own delay, which is what the 32-way
+// concurrent probe looks for.
+app.get('/delay/:ms', (req, res) => {
+    const ms = parseInt(req.params.ms, 10) || 0;
+    setTimeout(() => {
+        res.type('text/plain').send(String(ms));
+    }, ms);
+});
+
 // shared by the plaintext listener and the TLS one on 8081: same handler, same shapes
 const registerJsonRoute = (target, path = '/json/:count') => target.get(path, compress, (req, res) => {
     if (datasetItems) {

--- a/frameworks/fulmine-tuned/app.js
+++ b/frameworks/fulmine-tuned/app.js
@@ -490,4 +490,90 @@ if (fs.existsSync('/certs/server.key') && fs.existsSync('/certs/server.crt')) {
     tlsApp.listen(8081);
 }
 
+// tls_check: the opt-in TLS hardening section, on a listener of its own on 9000 reading a
+// certificate directory of its own. The section replaces the pair under the running server, and
+// /certs-tls exists so that doing so cannot move the ground under json-tls, static-tls and the h2
+// profiles, which read /certs and run in the same validation.
+//
+// Only validate.sh mounts the directory, so on a measured run this block does not exist: no
+// second listener is built and nothing is stat'd.
+if (fs.existsSync('/certs-tls/server.key') && fs.existsSync('/certs-tls/server.crt')) {
+    // What a rotation costs here is a listener rather than a handshake. µWS reads the pair once,
+    // when the SSL context is built, and nothing points an existing context at a new file
+    // afterwards: addServerName() replaces the certificate for one SNI name and leaves the
+    // default context -- which is what answers a client that sends no server name -- on the old
+    // one. Measured both ways: after addServerName('localhost', ...) an -servername handshake is
+    // served the new certificate and a -noservername handshake is still served the old. Building
+    // the listener again is the rotation that reaches both.
+    //
+    // And it interrupts nothing, because a worker binds the port shared -- SO_REUSEPORT -- so the
+    // replacement can be accepting on 9000 beside the listener it replaces before that one is
+    // told to stop. close() then closes the old listen socket, lets what it is already serving
+    // finish, and drops its idle keep-alives only after that: nothing is refused and no response
+    // is cut short.
+    const buildTlsCheckApp = () => {
+        const tlsCheckApp = express({
+            uwsOptions: {
+                key_file_name: '/certs-tls/server.key',
+                cert_file_name: '/certs-tls/server.crt'
+            }
+        });
+        tlsCheckApp.disable('x-powered-by');
+        tlsCheckApp.set('etag', false);
+        tlsCheckApp.set('file cache', true);
+        tlsCheckApp.set('connection headers', false);
+        registerJsonRoute(tlsCheckApp);
+        registerStaticRoute(tlsCheckApp);
+        tlsCheckApp.use(answerError);
+        return tlsCheckApp;
+    };
+
+    // What counts as a new pair. The section swaps both files with mv, so the inode moves along
+    // with the mtime, and the size is in here because a pair regenerated inside the same
+    // millisecond would otherwise read as unchanged.
+    const pairStamp = () => {
+        try {
+            const key = fs.statSync('/certs-tls/server.key');
+            const crt = fs.statSync('/certs-tls/server.crt');
+            return key.ino + ':' + key.size + ':' + key.mtimeMs + '|' + crt.ino + ':' + crt.size + ':' + crt.mtimeMs;
+        } catch (e) {
+            // mid-swap a file is missing for an instant. Reporting no reading rather than a new
+            // one picks the rotation up on the next tick instead of building a context out of
+            // half of one pair and half of the other
+            return '';
+        }
+    };
+
+    let live = buildTlsCheckApp();
+    let stamp = pairStamp();
+
+    const rotate = () => {
+        const next = buildTlsCheckApp();
+        const previous = live;
+        next.listen(9000, (err) => {
+            // the listener already up is still serving, so it is the right thing to keep when
+            // the replacement cannot bind
+            if (err) return;
+            live = next;
+            previous.close();
+        });
+    };
+
+    live.listen(9000, (err) => {
+        if (err) return;
+        // Armed from inside the listen callback because that is what says this process owns a
+        // listener: the primary of a clustered app returns from listen() without binding
+        // anything, so only the workers arrive here and only they have a certificate to rotate.
+        // One second is the reference entry's interval and is two orders off the 30s the section
+        // allows, and the stat is only paid while the section is mounted.
+        setInterval(() => {
+            const now = pairStamp();
+            if (now && now !== stamp) {
+                stamp = now;
+                rotate();
+            }
+        }, 1000).unref();
+    });
+}
+
 app.listen(8080);

--- a/frameworks/fulmine-tuned/meta.json
+++ b/frameworks/fulmine-tuned/meta.json
@@ -13,6 +13,7 @@
   "description": "fulmine.js with the caches its standard entry has to leave off: the in-memory small-file cache and the stat cache, both shipped settings, both forbidden to a standard entry because they keep a static request off the disk.",
   "repo": "https://github.com/nigrosimone/fulmine.js",
   "enabled": true,
+  "tls_check": true,
   "tests": [
     "baseline", "latency-1m",
     "pipelined",

--- a/frameworks/fulmine-tuned/meta.json
+++ b/frameworks/fulmine-tuned/meta.json
@@ -17,6 +17,7 @@
     "baseline", "latency-1m",
     "pipelined",
     "limited-conn",
+    "async",
     "json",
     "json-comp",
     "upload",

--- a/frameworks/fulmine/README.md
+++ b/frameworks/fulmine/README.md
@@ -17,6 +17,7 @@ A drop-in replacement for Express 5 running on uWebSockets.js, with its own `clu
 | `/baseline11` | GET/POST | Sums query parameter values, plus the body for POST |
 | `/baseline2` | GET | Sums query parameter values |
 | `/json/:count` | GET | Serializes a slice of the dataset |
+| `/delay/:ms` | GET | Waits the milliseconds named in the path, then echoes them back |
 | `/async-db` | GET | Reads from PostgreSQL, prepared statement, pool sized under max_connections |
 | `/upload` | POST | Counts the bytes of the request body |
 | `/static/*` | GET | `express.static()` with `preCompressed`, so the `.br` or `.gz` on disk is served when the client accepts one |

--- a/frameworks/fulmine/README.md
+++ b/frameworks/fulmine/README.md
@@ -25,7 +25,7 @@ A drop-in replacement for Express 5 running on uWebSockets.js, with its own `clu
 ## Notes
 
 This is a standard entry: every route goes through a documented framework API, with no hand-rolled
-compression, no suffix lookup and nothing held in memory. Four things it relies on are worth naming,
+compression, no suffix lookup and nothing held in memory. Six things it relies on are worth naming,
 because they are where the framework differs from Express rather than where it is the same:
 
 - Routes with a parameter, `/json/:count` among them, are handed to the µWS router rather than
@@ -39,6 +39,14 @@ because they are where the framework differs from Express rather than where it i
 - `express.static(dir, { preCompressed: true })` is the framework's documented way of serving the
   `.br` and `.gz` files the harness leaves on disk. `app.set("file cache", false)` turns off the
   small-file cache, so every request reads the file it answers with.
+- `tls_check` is opted into in `meta.json`, and the listener it asks for on :9000 is the 8081 one
+  again, reading `/certs-tls` rather than `/certs`. What it adds is the rotation, and that is a new
+  listener rather than a new certificate on the old one: µWS reads the pair when it builds the SSL
+  context, and `addServerName()` only replaces the certificate for one SNI name — a client sending
+  no server name is answered from the default context, still on the old pair. A worker binds the
+  port shared, so the replacement is accepting on 9000 before the listener it replaces is told to
+  stop, and `close()` drains that one instead of cutting it. The directory is mounted by
+  `validate.sh` alone, so on a measured run none of this is built.
 - `express({ cluster: "auto" })` is the framework's own fork, so there is no cluster boilerplate in
   the entry: one worker per usable core, each binding the same port with uWS's shared flag, which
   is `SO_REUSEPORT`. The kernel picks which worker gets a connection and the primary is not in the

--- a/frameworks/fulmine/app.js
+++ b/frameworks/fulmine/app.js
@@ -138,6 +138,23 @@ app.get('/pipeline', (req, res) => {
     res.type('text/plain').send('ok');
 });
 
+// GET /delay/{ms} — answered once ms milliseconds have gone by. setTimeout hands the request
+// back to the event loop, so a request that is waiting costs one timer entry and the worker
+// stays free for the next one: at 64K held connections that is 64K timers rather than 64K
+// blocked threads.
+//
+// The value is read out of the path before the timer is armed, which is what this profile is
+// really testing. µWS invalidates the request object the moment the handler returns, so a
+// handler that reached for the parameter inside the callback would find it gone; keeping it in
+// the closure also gives every overlapping request its own delay, which is what the 32-way
+// concurrent probe looks for.
+app.get('/delay/:ms', (req, res) => {
+    const ms = parseInt(req.params.ms, 10) || 0;
+    setTimeout(() => {
+        res.type('text/plain').send(String(ms));
+    }, ms);
+});
+
 // shared by the plaintext listener and the TLS one on 8081: same handler, same shapes
 const registerJsonRoute = (target, path = '/json/:count') => target.get(path, compress, (req, res) => {
     if (datasetItems) {

--- a/frameworks/fulmine/app.js
+++ b/frameworks/fulmine/app.js
@@ -490,4 +490,89 @@ if (fs.existsSync('/certs/server.key') && fs.existsSync('/certs/server.crt')) {
     tlsApp.listen(8081);
 }
 
+// tls_check: the opt-in TLS hardening section, on a listener of its own on 9000 reading a
+// certificate directory of its own. The section replaces the pair under the running server, and
+// /certs-tls exists so that doing so cannot move the ground under json-tls, static-tls and the h2
+// profiles, which read /certs and run in the same validation.
+//
+// Only validate.sh mounts the directory, so on a measured run this block does not exist: no
+// second listener is built and nothing is stat'd.
+if (fs.existsSync('/certs-tls/server.key') && fs.existsSync('/certs-tls/server.crt')) {
+    // What a rotation costs here is a listener rather than a handshake. µWS reads the pair once,
+    // when the SSL context is built, and nothing points an existing context at a new file
+    // afterwards: addServerName() replaces the certificate for one SNI name and leaves the
+    // default context -- which is what answers a client that sends no server name -- on the old
+    // one. Measured both ways: after addServerName('localhost', ...) an -servername handshake is
+    // served the new certificate and a -noservername handshake is still served the old. Building
+    // the listener again is the rotation that reaches both.
+    //
+    // And it interrupts nothing, because a worker binds the port shared -- SO_REUSEPORT -- so the
+    // replacement can be accepting on 9000 beside the listener it replaces before that one is
+    // told to stop. close() then closes the old listen socket, lets what it is already serving
+    // finish, and drops its idle keep-alives only after that: nothing is refused and no response
+    // is cut short.
+    const buildTlsCheckApp = () => {
+        const tlsCheckApp = express({
+            uwsOptions: {
+                key_file_name: '/certs-tls/server.key',
+                cert_file_name: '/certs-tls/server.crt'
+            }
+        });
+        tlsCheckApp.disable('x-powered-by');
+        tlsCheckApp.set('etag', false);
+        tlsCheckApp.set('file cache', true);
+        registerJsonRoute(tlsCheckApp);
+        registerStaticRoute(tlsCheckApp);
+        tlsCheckApp.use(answerError);
+        return tlsCheckApp;
+    };
+
+    // What counts as a new pair. The section swaps both files with mv, so the inode moves along
+    // with the mtime, and the size is in here because a pair regenerated inside the same
+    // millisecond would otherwise read as unchanged.
+    const pairStamp = () => {
+        try {
+            const key = fs.statSync('/certs-tls/server.key');
+            const crt = fs.statSync('/certs-tls/server.crt');
+            return key.ino + ':' + key.size + ':' + key.mtimeMs + '|' + crt.ino + ':' + crt.size + ':' + crt.mtimeMs;
+        } catch (e) {
+            // mid-swap a file is missing for an instant. Reporting no reading rather than a new
+            // one picks the rotation up on the next tick instead of building a context out of
+            // half of one pair and half of the other
+            return '';
+        }
+    };
+
+    let live = buildTlsCheckApp();
+    let stamp = pairStamp();
+
+    const rotate = () => {
+        const next = buildTlsCheckApp();
+        const previous = live;
+        next.listen(9000, (err) => {
+            // the listener already up is still serving, so it is the right thing to keep when
+            // the replacement cannot bind
+            if (err) return;
+            live = next;
+            previous.close();
+        });
+    };
+
+    live.listen(9000, (err) => {
+        if (err) return;
+        // Armed from inside the listen callback because that is what says this process owns a
+        // listener: the primary of a clustered app returns from listen() without binding
+        // anything, so only the workers arrive here and only they have a certificate to rotate.
+        // One second is the reference entry's interval and is two orders off the 30s the section
+        // allows, and the stat is only paid while the section is mounted.
+        setInterval(() => {
+            const now = pairStamp();
+            if (now && now !== stamp) {
+                stamp = now;
+                rotate();
+            }
+        }, 1000).unref();
+    });
+}
+
 app.listen(8080);

--- a/frameworks/fulmine/meta.json
+++ b/frameworks/fulmine/meta.json
@@ -17,6 +17,7 @@
     "baseline", "latency-1m",
     "pipelined",
     "limited-conn",
+    "async",
     "json",
     "json-comp",
     "upload",

--- a/frameworks/fulmine/meta.json
+++ b/frameworks/fulmine/meta.json
@@ -13,6 +13,7 @@
   "description": "fulmine.js (drop-in Express 5 on uWebSockets.js) with its own cluster option for multi-core scaling.",
   "repo": "https://github.com/nigrosimone/fulmine.js",
   "enabled": true,
+  "tls_check": true,
   "tests": [
     "baseline", "latency-1m",
     "pipelined",


### PR DESCRIPTION
The async profile (#1313) is the one axis none of the other H1 profiles touch: every one of them is answered the instant it arrives, so what they separate is how fast a server can do that and not what it does with a request it cannot answer yet. GET /delay/{ms} waits the milliseconds named in its own path and echoes them back — no database, no socket, no serialization, just a timer, so the number is a property of the concurrency model rather than of somebody else's driver.

setTimeout is the framework's idiom for it and costs a timer entry: a waiting request leaves the worker free, so the 64K held connections the profile offers are 64K timers rather than 64K blocked threads.

The parameter is parsed before the timer is armed. That is not a style choice — µWS invalidates the request object the moment the handler returns, so reading it inside the callback would find it gone, and the closure is also what gives each overlapping request its own delay instead of whichever one parsed last.

millionaire needed nothing: its load is GET /baseline11?a=1&b=2, which both entries already serve, and #1319 subscribed them with the rest of the board.

Verified against the entry's own app.js on node, twice: the whole async section of validate.sh, 8 passed 0 failed each time — the random draw, the text/plain header, /delay/0 answering 0, the 10-vs-500 differential, the constant-sleep upper bound and the 32 overlapping requests with 32 distinct delays, that last one in 0.57s wall against a 499ms longest delay, so the waits overlap rather than queue. Also checked the two shapes the benchmark will hit that validation does not: 50 clients dropped mid-delay leave the workers up with a clean log, and 4000 held connections cycling /delay/15 for 5s returned 133,313 responses with no wrong body and no socket error.

No benchmark numbers here — this adds a route, it does not change one.




## Description



---

**PR Commands** — comment on this PR to trigger (requires collaborator approval):

| Command | Description |
|---------|-------------|
| `/benchmark -f <framework>` | Run every test the framework subscribes to |
| `/benchmark -f <framework> -t <test>` | Run one test only |
| `/benchmark -f <framework> --save` | Run and save results (updates the leaderboard on merge) |
| `/benchmark -f <framework> -t <test> --save` | Run one test and save results |
| `/benchmark -f <framework> --compare <other>` | Measure the deltas against another framework instead of this one |
| `/benchmark-multiple -f <fw1>,<fw2>,...` | Benchmark several frameworks in one run — takes `-t` and `--save` too; saved results land in a single commit |
| `/benchmark-multiple --save` | No `-f` needed: benchmark and save every framework the PR touches |
| `/benchmark-test -t <test>` | Benchmark **all** enabled frameworks subscribed to `<test>` and save the results |

For `/benchmark`, always specify `-f <framework>`; the flags combine in any order. Results come back as a comment with a per-profile table of RPS, p99, CPU and memory — one table per framework on multi runs. A new benchmark comment while a run is in flight queues behind it (one deep) instead of cancelling it. For multi-framework PRs (dependency bumps, same-language refactors) prefer `/benchmark-multiple`, which runs everything in a single job and commits all saved results together, so no run overwrites another. `--compare` works on single-framework runs only.

**What the deltas are measured against.** By default, this framework's own results published on `main` - answering *"did this change help?"*. When you are tuning a variant or a successor entry, `--compare` re-bases them on another entry instead:

```
/benchmark -f genhttp-11 --compare genhttp-11-kestrel
```

The reply states which baseline it used, and profiles the other framework does not run show `n/a` rather than a delta.

---

<details>
<summary><strong>Run benchmarks locally</strong></summary>

You can validate and benchmark your framework locally with the lite script — no CPU pinning, fixed connection counts, all load generators run in Docker.

```bash
./scripts/validate.sh <framework>
./scripts/benchmark-lite.sh <framework> baseline
./scripts/benchmark-lite.sh --load-threads 4 <framework>
```

**Requirements:** Docker Engine on Linux. Load generators (gcannon, h2load, h2load-h3, wrk) are built as self-contained Docker images on first run.

</details>
