### PR TITLE
board: reference-only columns sort to the end of the matrix

### DIFF
--- a/scripts/check_badge_parity.js
+++ b/scripts/check_badge_parity.js
@@ -48,6 +48,10 @@ const familyOf = grab(/^\s*function familyOf\(p\)\{.*$/m, 'familyOf()');
 const memFn = grab(/^\s*function mem\(s\)\{.*$/m, 'mem()');
 const bwFn = grab(/^\s*function bw\(s\)\{.*$/m, 'bw()');
 const latFn = grab(/^\s*function lat\(s\)\{.*$/m, 'lat()');
+// computeComposite() calls leagueType() to decide column order, and
+// leagueType() reads this. Lifted rather than restated here so the two lists
+// cannot drift apart.
+const exclTypes = grab(/^\s*var EXCLUSIVE_TYPES=.*$/m, 'EXCLUSIVE_TYPES');
 // The millionaire profile pins its rate, so the composite cannot render its
 // column off rps the way it does every other one and calls into this block for
 // a score instead. Lifted for the same reason as everything else here: the
@@ -82,6 +86,7 @@ const run = new Function('D', `
   ${memFn}
   ${bwFn}
   ${latFn}
+  ${exclTypes}
   ${milFns}
   ${composite}
   return function(scope, types, lang, showTuned){

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -1365,6 +1365,17 @@ document.addEventListener('DOMContentLoaded', function(){
     if(!AGG) AGG=aggregate();
     var A=AGG, useMem=state.useMem;
     var pids=[]; D.profiles.forEach(function(p){ if(state.scope==='all'||familyOf(p)===state.scope) pids.push(p.id); });
+    // Scored columns first, reference-only ones after, each keeping its catalog
+    // order. Reading left to right then follows the score: everything before the
+    // break is in the sum, everything after it is context.
+    //
+    // Decided here rather than by reordering the catalog, because which columns
+    // are reference-only is a property of the league being shown, not of the
+    // profile. Infrastructure scores Pipelined and the framework leagues do not,
+    // so a fixed order would have to be wrong for one of them.
+    var _lt=leagueType(), _scored=[], _ref=[];
+    pids.forEach(function(pid){ (scoredForType(pid,_lt)?_scored:_ref).push(pid); });
+    pids=_scored.concat(_ref);
     // Two different questions, previously answered by one predicate:
     //
     //   outOfLeague — is this entry ranked somewhere else entirely? Types are


### PR DESCRIPTION
Pipelined sat **second**, between Baseline and Short-lived, while contributing nothing to a framework's score. Reference-only columns now come after the scored ones, each group keeping its catalog order.

Reading left to right follows the score: everything before the break is in the sum, everything after it is context.

```
flagship / emerging / experimental
  baseline limited-conn json json-comp json-tls upload
  │ pipelined async millionaire static static-tls async-db crud fortunes

engine
  baseline limited-conn json-tls
  │ pipelined async millionaire json json-comp upload static static-tls
    async-db crud fortunes
```

## Why at render time, not by reordering CATALOG

Which columns are reference-only is a property of **the league on screen**, not of the profile. Infrastructure scores Pipelined and the framework leagues do not, so any fixed catalog order has to be wrong for one of them:

```
infrastructure
  baseline pipelined limited-conn json json-tls static static-tls
  │ async millionaire json-comp upload async-db crud fortunes
```

Pipelined stays exactly where it is there, because there it counts.

The predicate is the same `scoredForType()` the header already uses to decide which columns render faded, so the break always falls precisely where the fading starts — the two cannot disagree.

## check_badge_parity.js

It needed one more stub. `computeComposite()` now calls `leagueType()`, which was inside the lifted block all along but never actually reached, and it reads `EXCLUSIVE_TYPES` from outside it. The harness threw rather than passing quietly, which is the second time it has caught this exact shape. `EXCLUSIVE_TYPES` is now lifted rather than restated, so the two lists cannot drift.

Parity clean: 559 ranks match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
