### PR TITLE
ioxide: update to 0.7.210, follow the disk, count chunked bodies

### DIFF
--- a/frameworks/ioxide/HttpSession.cs
+++ b/frameworks/ioxide/HttpSession.cs
@@ -200,8 +200,9 @@ internal sealed unsafe partial class HttpSession
         int bodyLen = 0;
         if (chunked)
         {
-            if (!DecodeChunked(buf[bodyStart..], out bodyInt, out int used)) return false;
+            if (!DecodeChunked(buf[bodyStart..], out bodyInt, out int used, out long decoded)) return false;
             total = bodyStart + used;
+            bodyLen = (int)Math.Min(decoded, int.MaxValue);
         }
         else if (contentLength > 0)
         {
@@ -262,6 +263,9 @@ internal sealed unsafe partial class HttpSession
             // Content negotiation is HTTP, so it lives here: serve the best precompressed
             // variant the client accepts (br > gzip), else ioxide.file's identity baked response,
             // else 404. Precompressed responses already carry Content-Encoding and Vary.
+            // Throttled stat of the tree: the rules require a replaced file to be
+            // visible on the next response, and neither cache below watches disk.
+            StaticRefresh.Poll();
             byte[]? pre = _precompressed?.Negotiate(path[7..], acceptBr, acceptGzip);
             if (pre != null)
             {
@@ -481,10 +485,15 @@ internal sealed unsafe partial class HttpSession
 
     /// Decode a chunked body into an integer. Returns false if the terminating
     /// 0-chunk isn't fully buffered. Bodies in these profiles are tiny.
-    private static bool DecodeChunked(ReadOnlySpan<byte> buf, out long bodyInt, out int used)
+    // `decoded` is the body length after de-chunking, which /upload answers with.
+    // It counts every chunk, while `body` below keeps only the first 256 bytes -
+    // that peek exists to parse an integer body for /baseline11 and is not a
+    // length. Reporting blen as the size is what made /upload answer 0.
+    private static bool DecodeChunked(ReadOnlySpan<byte> buf, out long bodyInt, out int used, out long decoded)
     {
         bodyInt = 0;
         used = 0;
+        decoded = 0;
         Span<byte> body = stackalloc byte[256];
         int blen = 0;
         int pos = 0;
@@ -508,6 +517,7 @@ internal sealed unsafe partial class HttpSession
                 buf.Slice(pos, size).CopyTo(body[blen..]);
                 blen += size;
             }
+            decoded += size;
             pos += size;
             if (!buf.Slice(pos, 2).SequenceEqual("\r\n"u8)) return false;
             pos += 2;

--- a/frameworks/ioxide/Precompressed.cs
+++ b/frameworks/ioxide/Precompressed.cs
@@ -14,14 +14,33 @@ internal sealed class Precompressed
 {
     private readonly record struct Variant(byte[]? Br, byte[]? Gz);
 
-    private readonly Dictionary<string, Variant> _byPath = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Variant>.AlternateLookup<ReadOnlySpan<char>> _lookup;
+    // Baked responses are swapped as one object rather than mutated in place. A
+    // reader holding the old snapshot keeps serving consistent bytes while a
+    // rebuild is in flight, and the dictionary and its alternate lookup can
+    // never be seen half-replaced.
+    private sealed class Snapshot
+    {
+        public required Dictionary<string, Variant> ByPath;
+        public required Dictionary<string, Variant>.AlternateLookup<ReadOnlySpan<char>> Lookup;
+    }
 
-    public int Count { get; }
+    private readonly string _root;
+    private Snapshot _snap;
+
+    public int Count => _snap.ByPath.Count;
 
     public Precompressed(string staticDir)
     {
-        string root = Path.GetFullPath(staticDir);
+        _root = Path.GetFullPath(staticDir);
+        _snap = Build(_root);
+    }
+
+    /// <summary>Re-bake every variant from disk. Called when the tree changes.</summary>
+    public void Rebuild() => Volatile.Write(ref _snap, Build(_root));
+
+    private static Snapshot Build(string root)
+    {
+        var byPath = new Dictionary<string, Variant>(StringComparer.Ordinal);
         foreach (string path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
         {
             if (path.EndsWith(".br", StringComparison.Ordinal) || path.EndsWith(".gz", StringComparison.Ordinal))
@@ -34,11 +53,10 @@ internal sealed class Precompressed
             byte[]? gz = File.Exists(path + ".gz") ? Bake(File.ReadAllBytes(path + ".gz"), contentType, "gzip") : null;
             if (br != null || gz != null)
             {
-                _byPath[url] = new Variant(br, gz);
+                byPath[url] = new Variant(br, gz);
             }
         }
-        _lookup = _byPath.GetAlternateLookup<ReadOnlySpan<char>>();
-        Count = _byPath.Count;
+        return new Snapshot { ByPath = byPath, Lookup = byPath.GetAlternateLookup<ReadOnlySpan<char>>() };
     }
 
     /// <summary>Best accepted precompressed response for the URL (br &gt; gzip), or null to use identity.</summary>
@@ -53,7 +71,7 @@ internal sealed class Precompressed
         {
             return null;
         }
-        if (!_lookup.TryGetValue(chars[..n], out Variant v))
+        if (!Volatile.Read(ref _snap).Lookup.TryGetValue(chars[..n], out Variant v))
         {
             return null;
         }

--- a/frameworks/ioxide/Program.cs
+++ b/frameworks/ioxide/Program.cs
@@ -101,6 +101,9 @@ internal static class Program
             : null;
         // Precompressed variants are baked here (HTTP), not in ioxide.file.
         Precompressed? precompressed = Directory.Exists(staticRoot) ? new Precompressed(staticRoot) : null;
+        // Both caches above are built once and would otherwise never look at the
+        // directory again; this is what makes them follow it.
+        StaticRefresh.Init(staticRoot, assets, precompressed);
 
         // Postgres: DATABASE_URL=postgres://user:pass@host:port/db (validation/benchmark sidecar).
         PgOptions? pg = null;

--- a/frameworks/ioxide/StaticRefresh.cs
+++ b/frameworks/ioxide/StaticRefresh.cs
@@ -1,0 +1,95 @@
+using ioxide.file;
+
+namespace IoxideArena;
+
+/// <summary>
+/// Keeps the static tree honest.
+///
+/// Both static paths are built once at startup and neither notices the disk
+/// afterwards: ioxide.file opens a descriptor per asset and reads positionally
+/// off it, and <see cref="Precompressed"/> bakes whole responses into memory.
+/// That is exactly what makes them fast, and it is also why replacing a file
+/// under the mount used to keep serving the bytes the process opened at boot.
+///
+/// The implementation rules require the opposite: replace a file and the next
+/// response has to carry the new bytes. So the tree is stamped and the stamp is
+/// checked before a static request is answered.
+///
+/// The stamp is file count plus the newest write time, not content. It is a
+/// stat per file over a directory of twenty, throttled so a burst of requests
+/// pays for it once, which is cheap next to a rebuild and far cheaper than
+/// reopening per request. Size is deliberately not part of it: the validation
+/// replaces a file with one of exactly the same length, so anything keyed on
+/// size alone would miss it.
+/// </summary>
+internal static class StaticRefresh
+{
+    // Well inside the 2s the rules allow, and long enough that a saturating run
+    // stats the tree a few times a second rather than a few hundred thousand.
+    private const long IntervalTicks = TimeSpan.TicksPerMillisecond * 250;
+
+    private static string? _root;
+    private static StaticAssets? _assets;
+    private static Precompressed? _pre;
+
+    private static long _nextCheck;
+    private static long _stamp;
+    private static int _busy;
+
+    public static void Init(string root, StaticAssets? assets, Precompressed? pre)
+    {
+        _root = Directory.Exists(root) ? root : null;
+        _assets = assets;
+        _pre = pre;
+        _stamp = Stamp();
+        _nextCheck = DateTime.UtcNow.Ticks + IntervalTicks;
+    }
+
+    /// <summary>Reload both caches if the tree changed. Cheap and safe to call per request.</summary>
+    public static void Poll()
+    {
+        if (_root is null) return;
+
+        long now = DateTime.UtcNow.Ticks;
+        if (now < Volatile.Read(ref _nextCheck)) return;
+
+        // One reactor does the work; the others carry on serving the snapshot
+        // they already have rather than queueing behind a directory walk.
+        if (Interlocked.Exchange(ref _busy, 1) == 1) return;
+        try
+        {
+            Volatile.Write(ref _nextCheck, now + IntervalTicks);
+            long s = Stamp();
+            if (s != _stamp)
+            {
+                _stamp = s;
+                _assets?.Reload();
+                _pre?.Rebuild();
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _busy, 0);
+        }
+    }
+
+    private static long Stamp()
+    {
+        if (_root is null) return 0;
+        long newest = 0, count = 0;
+        try
+        {
+            foreach (string f in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+            {
+                count++;
+                long t = File.GetLastWriteTimeUtc(f).Ticks;
+                if (t > newest) newest = t;
+            }
+        }
+        catch (IOException)
+        {
+            return _stamp;   // mid-replacement; try again on the next tick
+        }
+        return newest ^ (count * 1_000_003);
+    }
+}

--- a/frameworks/ioxide/ioxide-arena.csproj
+++ b/frameworks/ioxide/ioxide-arena.csproj
@@ -14,13 +14,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ioxide" Version="0.4.169" />
-        <PackageReference Include="ioxide.pg" Version="0.4.169" />
-        <PackageReference Include="ioxide.file" Version="0.4.169" />
-        <PackageReference Include="ioxide.redis" Version="0.4.169" />
-        <PackageReference Include="ioxide.http2" Version="0.4.169" />
-        <PackageReference Include="ioxide.ngtcp2" Version="0.4.169" />
-        <PackageReference Include="ioxide.nghttp3" Version="0.4.169" />
+        <PackageReference Include="ioxide" Version="0.7.210" />
+        <PackageReference Include="ioxide.pg" Version="0.7.210" />
+        <PackageReference Include="ioxide.file" Version="0.7.210" />
+        <PackageReference Include="ioxide.redis" Version="0.7.210" />
+        <PackageReference Include="ioxide.http2" Version="0.7.210" />
+        <PackageReference Include="ioxide.ngtcp2" Version="0.7.210" />
+        <PackageReference Include="ioxide.nghttp3" Version="0.7.210" />
         <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Builds on #1338. **Everything except TLS now passes.**

| | frag | pass | fail |
|---|---|---|---|
| before (#1289 state) | **0 / 9** | — | 52 across four areas |
| after | **9 / 9** | **56** | **31, every one of them TLS** |

## ioxide 0.4.169 → 0.7.210

All seven `ioxide.*` packages, thirteen releases forward. Builds clean, and on its own changes none of the behaviour below — the fixes are the entry's.

## Static files now follow the disk

Both static paths were built once at startup and never looked at the directory again. `ioxide.file` opens a descriptor per asset and reads positionally off it, so replacing a file left the old inode pinned; `Precompressed` went further and baked whole responses into memory with `File.ReadAllBytes`.

That is what makes them fast, and it is also why a replaced file kept serving the bytes the process opened at boot.

`StaticRefresh` stamps the tree and checks it before answering a static request. **Count plus newest mtime, not content, and explicitly not size** — the validation replaces a file with one of exactly the same length, so anything keyed on size would miss it.

Throttled to 250ms and guarded so one reactor does the walk while the others keep serving the snapshot they hold. Twenty stats a few times a second is nothing next to reopening per request, and well inside the 2s the rules allow. `StaticAssets.Reload()` handles the identity side; `Precompressed` rebuilds into a fresh snapshot swapped as one object, so a reader mid-request never sees a half-replaced dictionary.

```
PASS [static file follows the disk]    (1 file replaced, served in 1s)
PASS [static variant follows the disk] (3 files replaced, served in 1s)
```

## POST /upload with chunked encoding

It answered `0` for any chunked body. `DecodeChunked` copies the first 256 bytes into a stack buffer so `/baseline11` can parse an integer body, and reported *that buffer's fill* as the length — so a body larger than the peek, which is every real upload, measured as whatever fit, and the terminating chunk reset it to nothing.

It now counts every chunk as it decodes, separately from the peek.

```
130,000-byte chunked upload -> "130000"
```

## What is left, and why it is not verified here

All 31 remaining failures are TLS: `json-tls`, `static-tls`, and both 8443 profiles. The **handshake itself passes** — mounted certificate, TLS 1.3, ALPN, and the whole TLS quality suite — but no HTTP comes back over the socket.

The entry does the handshake in userspace and then relies on **kTLS for TX**: outbound writes go out as plaintext and the kernel is expected to produce the records. The `tls` kernel module is **not loaded** on this machine (`/lib/modules/6.14.0-37-generic/kernel/net/tls/tls.ko.zst` exists but is not loaded, and containers here see no `tcp_available_ulp`), so those writes leave as plaintext on a socket the client believes is encrypted and it reports an empty reply. Loading the module needs root I do not have here.

So **TLS is untestable on this box rather than proven broken.** It needs either the `tls` module present on the bench host, or a userspace TX path in `ioxide.tls`. Confirmed not caused by these changes: a pristine build of the entry fails TLS identically.

## Still disabled

It subscribes to `json-tls`, `static-tls`, `baseline-h2`, `static-h2` and both h3 profiles, so re-enabling needs TLS resolved — or those profiles dropped from its `tests`, which is your call rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
