### PR TITLE
benchmark: force the checkout in the save step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -202,7 +202,14 @@ jobs:
 
           branch="benchmark-results/$(date +%Y%m%d-%H%M%S)"
           git fetch origin main
-          git checkout -B "$branch" origin/main
+          # -f is required, not cosmetic. When the benchmarked ref already
+          # carries result files for the frameworks being run -- which is the
+          # case for any branch that keeps an entry and its results together --
+          # rebuild_site_data.py rewrites tracked files, and a plain checkout
+          # aborts with "Your local changes would be overwritten by checkout".
+          # Discarding them here is safe: everything was copied to /tmp above,
+          # and it is restored from there immediately after the switch.
+          git checkout -f -B "$branch" origin/main
           rm -rf site/data site/static/logs
           mkdir -p site/static
           cp -r /tmp/bench_out/data site/data


### PR DESCRIPTION
Saving results for a branch that already contains result files for the frameworks being run fails outright. Run [33249828230](https://github.com/MDA2AV/HttpArena/actions/runs/33249828230) benchmarked all five frameworks successfully — **jooby included** — and then threw every result away here:

```
error: Your local changes to the following files would be overwritten by checkout:
	site/data/frameworks.json
	site/data/results/carter.json
	site/data/results/ntex.json
	site/data/results/reitit.json
	site/data/results/salvo.json
Please commit your changes or stash them before you switch branches.
Aborting
```

## Why it happens

The save step copies `site/data` and `site/static/logs` to `/tmp`, switches to a fresh branch off `main`, then restores them. By that point `rebuild_site_data.py` has rewritten files that are **tracked on the benchmarked ref**, so `git checkout -B "$branch" origin/main` refuses.

It only ever worked while those files were absent from the ref — that is, while an entry and its results always lived on separate branches. As soon as a branch keeps an implementation and its results together (#1362), the next run against that branch cannot save.

## The change

One flag: `git checkout -f -B`. Discarding the working-tree copies is safe because they were copied to `/tmp` on the line immediately above and are copied back immediately after the switch — the existing design already depends on that.

## Note

This is a prerequisite for re-running the benchmark on #1362. Without it, any branch that carries both an entry and its results is stuck: it benchmarks fine and then discards the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iyXstHcyyy1y47jAoBHid
