### PR TITLE
ioxide: pin the .NET preview and turn on runtime async

### DIFF
--- a/frameworks/ioxide/Dockerfile
+++ b/frameworks/ioxide/Dockerfile
@@ -1,4 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:11.0-preview AS build
+# Pinned rather than floating. 11.0-preview moved from preview.6 (2026-07-28)
+# to preview.7 (2026-08-28) and took baseline-4096 from 4.11M to 3.90M with no
+# change to this entry, which is not something a tag should be able to do
+# silently. SDK and runtime version their tags differently: 11.0.1xx vs 11.0.0.
+ARG DOTNET_SDK_TAG=11.0.100-preview.7
+ARG DOTNET_RUNTIME_TAG=11.0.0-preview.7
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_TAG} AS build
 WORKDIR /source
 COPY ioxide-arena.csproj ./
 RUN dotnet restore
@@ -8,7 +14,8 @@ RUN dotnet publish -c Release --no-self-contained -o /app/out
 # ioxide drives io_uring through direct libc syscalls (no liburing). The bench
 # harness runs containers with --security-opt seccomp=unconfined (required for
 # io_uring_setup/enter); engine="io_uring" makes validate.sh enable it too.
-FROM mcr.microsoft.com/dotnet/runtime:11.0-preview
+ARG DOTNET_RUNTIME_TAG
+FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_RUNTIME_TAG}
 WORKDIR /app
 COPY --from=build /app/out ./
 EXPOSE 8080 8081 8443 8443/udp

--- a/frameworks/ioxide/ioxide-arena.csproj
+++ b/frameworks/ioxide/ioxide-arena.csproj
@@ -6,7 +6,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <!--<Features>runtime-async=on</Features>-->
+        <!-- Runtime async: the runtime suspends and resumes async methods
+             itself instead of the compiler generating a state machine. Needs
+             EnablePreviewFeatures and net11.0 on the .NET 11 SDK; the old
+             DOTNET_RuntimeAsync=1 env gate is gone as of preview 1. $(Features)
+             is prepended so this appends rather than replacing whatever the SDK
+             already set. Still not the default upstream. -->
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Features>$(Features);runtime-async=on</Features>
         <RootNamespace>IoxideArena</RootNamespace>
         <AssemblyName>ioxide-arena</AssemblyName>
         <ServerGarbageCollection>true</ServerGarbageCollection>


### PR DESCRIPTION
Two changes, both about the runtime rather than this entry's own code.

## Pin the base images

`11.0-preview` is a floating tag and it moved:

| tag | published | resolves to |
|---|---|---|
| `11.0.0-preview.6` | 2026-07-28 | `11.0.0-preview.6.26359.118` |
| `11.0.0-preview.7` | **2026-08-28** | `11.0.0-preview.7.26381.103` |

`baseline-4096` was **4,108,420 rps @ 6401.5% CPU** on 2026-08-09 and **3,896,541 @ 5983.6%** on 2026-08-28 — the day preview.7 shipped — with nothing in this entry changing between them.

That was confirmed the hard way: rebuilding ioxide **0.4.169 verbatim** and benchmarking it showed the same regression, so the library was never the variable. A floating tag shouldn't be able to move a published number silently.

SDK and runtime version their tags differently (`11.0.1xx` vs `11.0.0`), so there are two build args.

> **Wider issue, not fixed here:** 24 entries build from floating .NET tags (22 on `sdk:10.0` alone). Every one can shift runtime under a republish the same way. Worth its own issue.

## Enable runtime async

The runtime suspends and resumes async methods itself instead of the compiler emitting a state machine — the shape this entry already leans on, being a shared-nothing io_uring reactor with inline `IValueTaskSource` continuations.

- Needs `<EnablePreviewFeatures>` and `net11.0` on the .NET 11 SDK.
- `DOTNET_RuntimeAsync=1` is **not** needed — that gate is gone as of preview 1.
- `$(Features)` is prepended so the setting appends rather than replacing whatever the SDK already set. (The previously commented-out line lacked this.)

### Verified in the assembly, not assumed

| | runtime-async ON | classic |
|---|---|---|
| `AsyncStateMachineAttribute` refs | **0** | 2 |
| `<...>d__` state machine types | **0** | 8 |

Smoke tested: baseline GET/POST/chunked, json, gzip, 20 MB upload, and `Connection: close` closing.

## What is not verified

`json-tls` could not be checked locally — this box has no `tls` kernel module, so kTLS fails with `TCP_ULP errno 2` regardless of this change.

Runtime async is **still not the default upstream** (tail calls, some generic constraints, diagnostic tooling). So this wants a benchmark before it's treated as settled — both for whether it recovers what preview.7 cost, and for whether it changes ioxide's comparability against the rest of the C# field. Note `genhttp-11-ioxide` already enables it while every other C# entry does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iyXstHcyyy1y47jAoBHid
