### PR TITLE
ci: let a PR opt out of the maintainer ping

### DIFF
--- a/.github/workflows/notify-maintainers.yml
+++ b/.github/workflows/notify-maintainers.yml
@@ -12,6 +12,21 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # Opt-out for repo-wide sweeps. A change that touches every entry - renaming a
+    # profile, retiring an endpoint - is not news to any single maintainer, and the
+    # ping is a notification to dozens of people who have nothing to do.
+    #
+    # Both forms are checked because they fail differently. The label is the
+    # discoverable one and can be added after the fact; the body marker is the one
+    # that is guaranteed to be in the payload of the `opened` event, before a label
+    # applied by a second API call could race the run that pings everybody.
+    #
+    # pull_request_target reads this file from the BASE branch, so a PR cannot
+    # grant itself the opt-out - it has to already be on main. That is the point.
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'skip-maintainer-ping') &&
+      !contains(github.event.pull_request.body, '[skip-maintainer-ping]') &&
+      !contains(github.event.pull_request.title, '[skip-maintainer-ping]')
     steps:
       # No ref: on pull_request_target the default is the base branch, which is the only side this
       # job needs. It reads meta.json to know who to ping, and that must come from the base anyway.


### PR DESCRIPTION
The notify job pings every maintainer of every framework a PR touches. That is right for a change to one entry and wrong for a repo-wide sweep.

The `upload` → `in-out` rework touches **128 framework directories** and would ping **29 people** who have nothing to do about it.

## The opt-out

```yaml
if: >-
  !contains(github.event.pull_request.labels.*.name, 'skip-maintainer-ping') &&
  !contains(github.event.pull_request.body, '[skip-maintainer-ping]') &&
  !contains(github.event.pull_request.title, '[skip-maintainer-ping]')
```

Three forms, because they fail differently:

- the **label** is the discoverable one, and can be applied after the fact
- the **body/title markers** are guaranteed to be in the payload of the `opened` event. `gh pr create --label` applies a label in a *second* API call, which can race the very run that pings everybody — so a marker present at creation is the only reliable way to suppress the first run

## This PR cannot suppress itself, by design

`pull_request_target` reads the workflow from the **base** branch, so the opt-out must already be on `main` before a sweep can use it. That is also what stops a PR from granting itself the exemption — which is the security property `pull_request_target` exists for.

It touches no `frameworks/**` path, so the notify job does not fire on it anyway.

## Not included

A blunter guard would be an automatic cap — skip the ping when a PR touches more than N frameworks, since that is always a sweep. That changes behaviour for everyone else's PRs rather than only for the ones that ask, so I have left it out; easy to add if you'd prefer it.