### PR TITLE
fulmine, fulmine-tuned: fulmine.js 5.18.2

### DIFF
--- a/frameworks/fulmine-tuned/package.json
+++ b/frameworks/fulmine-tuned/package.json
@@ -2,7 +2,7 @@
   "name": "httparena-fulmine",
   "private": true,
   "dependencies": {
-    "fulmine.js": "^5.18.1",
+    "fulmine.js": "^5.18.2",
     "pg": "^8.13.0",
     "pg-native": "^3.8.0",
     "pg-telaio": "^0.1.2",

--- a/frameworks/fulmine/package.json
+++ b/frameworks/fulmine/package.json
@@ -2,7 +2,7 @@
   "name": "httparena-fulmine",
   "private": true,
   "dependencies": {
-    "fulmine.js": "^5.18.1",
+    "fulmine.js": "^5.18.2",
     "pg": "^8.13.0",
     "pg-native": "^3.8.0",
     "ejs": "^3.1.10",


### PR DESCRIPTION
fulmine.js 5.18.2 moves the recurring header names and values across the uWS boundary as cached Buffers instead of strings, which measured about 10% less CPU per response on the baseline route locally. The caret already resolves to it at build; this bumps the manifest so the run is on record against the version it measured.
