### PR TITLE
ci: show CPU/req, p99, p99.9 and rate_ratio for the paced profiles in PR results [skip-maintainer-ping]

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -322,17 +322,48 @@ jobs:
                       if cur_profile and re.match(r"^=== Best:", line):
                           m2 = re.match(r"^=== Best: (\d+) req/s \(CPU: ([\d.]+)%, Mem: ([^\)]+)\)", line)
                           if m2:
-                              rows.append((cur_profile, cur_conns, int(m2.group(1)), m2.group(2), m2.group(3)))
-                          cur_profile = None
+                              rows.append({"prof": cur_profile, "conns": cur_conns,
+                                           "rps": int(m2.group(1)), "cpu": m2.group(2),
+                                           "mem": m2.group(3)})
+                          continue
+                      # The paced profiles report what they are actually ranked
+                      # on. rps is the same for every entry that held the rate,
+                      # so on its own it says nothing about them.
+                      m3 = re.match(r"^=== Fixed-rate: cpu/req (\S+) \| p99 (\S+) \| p99\.9 (\S+) \| rate_ratio (\S+) ===$", line)
+                      if m3 and rows:
+                          rows[-1].update(cpureq=m3.group(1), p99=m3.group(2),
+                                          p999=m3.group(3), ratio=m3.group(4))
               return rows
 
           def table(rows, deltas):
-              out = ["| Test | Conn | RPS | CPU | Mem | Δ RPS | Δ Mem |",
-                     "|------|------|-----|-----|-----|-------|-------|"]
-              for prof, conns, rps, cpu, mem in rows:
-                  d = deltas.get(prof + "/" + conns, {})
-                  out.append("| {} | {} | {:,} | {}% | {} | {} | {} |".format(
-                      prof, conns, rps, cpu, mem, d.get("rps", ""), d.get("mem", "")))
+              paced = any("cpureq" in r for r in rows)
+              if paced:
+                  out = ["| Test | Conn | RPS | Rate | CPU/req | p99 | p99.9 | CPU | Mem | Δ RPS | Δ Mem |",
+                         "|------|------|-----|------|---------|-----|-------|-----|-----|-------|-------|"]
+              else:
+                  out = ["| Test | Conn | RPS | CPU | Mem | Δ RPS | Δ Mem |",
+                         "|------|------|-----|-----|-----|-------|-------|"]
+              for r in rows:
+                  d = deltas.get(r["prof"] + "/" + r["conns"], {})
+                  base = "| {} | {} | {:,} |".format(r["prof"], r["conns"], r["rps"])
+                  tail_ = " {}% | {} | {} | {} |".format(
+                      r["cpu"], r["mem"], d.get("rps", ""), d.get("mem", ""))
+                  if paced:
+                      # A rate_ratio under 0.98 means the offered load was not
+                      # the load the profile is defined by, so flag it here
+                      # rather than leaving it to be inferred from a low rps.
+                      ratio = r.get("ratio", "")
+                      try:
+                          if ratio and float(ratio) < 0.98:
+                              ratio = "**" + ratio + "** ⚠️"
+                      except ValueError:
+                          pass
+                      mid = " {} | {} | {} | {} |".format(
+                          ratio or "—", r.get("cpureq", "—"),
+                          r.get("p99", "—"), r.get("p999", "—"))
+                      out.append(base + mid + tail_)
+                  else:
+                      out.append(base + tail_)
               return "\n".join(out)
 
           def tail(path, n):

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -402,6 +402,17 @@ run_one() {
             info "exact CPU: $(awk -v c="$best_cpu_usec" 'BEGIN{printf "%.2f", c/1e6}') core-seconds \
 | $(awk -v c="$best_cpu_usec" -v r="${BEST_M[status_2xx]}" 'BEGIN{printf "%.3f", c/r}') us/req"
         fi
+        # One machine-readable line carrying what this profile is actually
+        # ranked on. The results table in a PR comment reports rps, which on a
+        # paced profile is the same number for everyone who held the rate and
+        # says nothing; these are the figures the score is built from. Parsed by
+        # .github/workflows/benchmark-pr.yml - keep the shape stable.
+        local _cpr="n/a"
+        if [ -n "$best_cpu_usec" ] && [ "${BEST_M[status_2xx]:-0}" -gt 0 ] 2>/dev/null; then
+            _cpr=$(awk -v c="$best_cpu_usec" -v r="${BEST_M[status_2xx]}" 'BEGIN{printf "%.2fus", c/r}')
+        fi
+        echo "=== Fixed-rate: cpu/req ${_cpr} | p99 ${BEST_M[p99_lat]:-n/a} | p99.9 ${BEST_M[p999_lat]:-n/a} | rate_ratio ${best_rate_ratio:-n/a} ==="
+
         # Below ~0.98 the client never delivered the rate the profile is defined
         # by, so the CPU figure describes a different, lighter workload than
         # every other entry's. Louder than a note: it invalidates the comparison.


### PR DESCRIPTION
The results table in a benchmark comment reports rps, CPU% and memory. On `latency-1m`, `latency-10k` and `8gbit` **the rate is pinned**, so rps is the same number for everyone who held it and the row says nothing about the entry. The figures the score is actually built from — CPU per request, p99, p99.9 — weren't in the table at all.

Worse, the `CPU` column isn't even the CPU the score uses: that one is sampled from `docker stats`, while the metric comes from the container's cgroup. The two differ by 5–13%, which is why a run selection can look inexplicable from the log.

## What it looks like now

```
| Test        | Conn | RPS       | Rate         | CPU/req  | p99      | p99.9    | CPU     | Mem    |
|-------------|------|-----------|--------------|----------|----------|----------|---------|--------|
| baseline    | 512  | 2,565,216 | —            | —        | —        | —        | 5711.6% | 117MiB |
| 8gbit       | 512  | 49,368    | 0.9874       | 57.02us  | 1059.0us | 4402.0us | 281.3%  | 655MiB |
| latency-10k | 1024 | 9,979     | **0.9264** ⚠️ | 279.41us | 812.0us  | 3106.0us | 27.9%   | 124MiB |
```

`benchmark.sh` prints one machine-readable line for those profiles and the workflow widens the table whenever a run carries it.

A `rate_ratio` below 0.98 is emboldened and flagged — below that the offered load was not the load the profile is defined by, and the CPU number is not comparable with runs that held it. That was already a warning buried in the log; now it's in the table.

## Backwards compatible

Rows from unpaced profiles in the same table show a dash in the new columns, and a framework with **no** paced profile keeps the original narrow table unchanged.

## Tested

I extracted the embedded Python out of the workflow and ran it against synthetic logs for all three shapes — paced only, unpaced only, and both mixed in one table — in both the single-framework and multi-framework paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsAGTadPkBtwXaYEngJomx