### PR TITLE
board: four heat-map bands and a legend instead of a gradient [skip-maintainer-ping]

### DIFF
--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -448,6 +448,11 @@
      ink (visibility, not display - display:none collapses the row height), and
      the bar is stretched over the whole cell by its four offsets rather than by
      a width. Nothing here sets a padding, a height or a row height. */
+  .heatkey{display:flex; align-items:center; flex-wrap:wrap; gap:.1rem .55rem; margin-top:.3rem;
+    font-size:.66rem; color:var(--muted)}
+  .heatkey .hk-l{margin-right:.1rem}
+  .heatkey .hk{display:inline-flex; align-items:center; gap:.28rem; white-space:nowrap}
+  .heatkey .hk i{width:11px; height:11px; border-radius:2px; display:inline-block}
   .cm.heat td.pc .pcv{visibility:hidden}
   .cm.heat td.pc .cbar{left:0; right:0; top:0; bottom:0; width:auto; height:auto; opacity:1}
   .cm.heat td.pc.nc .cbar{opacity:.55}
@@ -1318,8 +1323,25 @@ document.addEventListener('DOMContentLoaded', function(){
       var hm=document.createElement('div'); hm.className='toggle'+(state.heat?' on':'');
       hm.innerHTML='<span class="sw"><i></i></span> Heat map';
       hm.setAttribute('data-tip','Replace every profile cell with a colour block: dark red for the weakest score in that column, through orange and yellow, to green for the leader. The numbers stay in the hover popup - this is for reading a column\u2019s shape at a glance.');
-      hm.onclick=function(){ state.heat=!state.heat; hm.classList.toggle('on', state.heat); render(); };
       ctl.appendChild(hm);
+      // Without this the colours are a code nobody was given. Built once and
+      // shown with the toggle: the toggle's own handler calls render(), which
+      // redraws the table but not this control strip, so a legend created only
+      // when state.heat is already true would never appear on the click that
+      // set it.
+      var lg=document.createElement('div'); lg.className='heatkey';
+      lg.setAttribute('data-tip','Each cell is coloured by its score as a share of the best score in that column.');
+      lg.innerHTML='<span class="hk-l">share of column leader</span>'+HEAT_BANDS.map(function(b){
+        return '<span class="hk"><i style="background:'+b[1]+'"></i>'+esc(b[2])+'</span>';
+      }).join('');
+      lg.style.display = state.heat ? '' : 'none';
+      ctl.appendChild(lg);
+      hm.onclick=function(){
+        state.heat=!state.heat;
+        hm.classList.toggle('on', state.heat);
+        lg.style.display = state.heat ? '' : 'none';
+        render();
+      };
       // Arriving on #lang=X (from a language rank badge) filters the board to
       // one language. Say so, and make it one click to leave - a filter with no
       // visible cause reads as missing data.
@@ -1598,23 +1620,27 @@ document.addEventListener('DOMContentLoaded', function(){
   // says nothing about completeness rather than reporting a clean sheet it was
   // never given.
   function cmpGraded(fw){ return cmpInScope() && CMP_TYPES.indexOf(typeOf(fw))>=0; }
-  // Dark red -> orange -> amber -> yellow-green -> green. Explicit stops rather
-  // than an HSL sweep: straight hue interpolation runs through an olive that
-  // reads as "bad" in the middle of the range, which is the one place the ramp
-  // has to stay legible.
-  var HEAT_STOPS=[[0,124,25,25],[0.25,205,74,10],[0.5,224,168,0],[0.75,138,192,30],[1,58,198,110]];
+  // Four bands rather than a continuous ramp.
+  //
+  // A gradient asks the eye to read a value off a hue, which it cannot do: with
+  // five stops interpolated, 62% and 74% are two barely different yellow-greens
+  // and the column stops being scannable. It also spent most of its hues on a
+  // range almost nothing occupies - measured over all 1,650 published cells the
+  // distribution is bimodal, 24% of them under 10% of their column leader and
+  // 22% over 90%, median 27%.
+  //
+  // Four steps, one hue each, so a cell has a band rather than a shade and the
+  // legend beside the toggle says what each one means.
+  var HEAT_BANDS=[
+    [0.25, 'rgb(198,60,48)',  'under 25%'],
+    [0.50, 'rgb(228,126,30)', '25-50%'],
+    [0.75, 'rgb(226,192,44)', '50-75%'],
+    [1.01, 'rgb(45,172,94)',  'over 75%']
+  ];
   function heatColor(t){
     t=(!isFinite(t)||t<0)?0:(t>1?1:t);
-    for(var i=1;i<HEAT_STOPS.length;i++){
-      var b=HEAT_STOPS[i];
-      if(t<=b[0]){
-        var a=HEAT_STOPS[i-1], f=(t-a[0])/(b[0]-a[0]);
-        return 'rgb('+Math.round(a[1]+(b[1]-a[1])*f)+','
-                    +Math.round(a[2]+(b[2]-a[2])*f)+','
-                    +Math.round(a[3]+(b[3]-a[3])*f)+')';
-      }
-    }
-    return 'rgb(58,198,110)';
+    for(var i=0;i<HEAT_BANDS.length;i++) if(t<HEAT_BANDS[i][0]) return HEAT_BANDS[i][1];
+    return HEAT_BANDS[HEAT_BANDS.length-1][1];
   }
 
   function cmpTip(r){


### PR DESCRIPTION
The gradient asked the eye to read a value off a hue, which it can't do. With five stops interpolated, 62% and 74% were two barely different yellow-greens — so a column couldn't be scanned, which is the only thing the heat map is for.

## It was also aimed at the wrong range

Measured across all **1,650 published cells**, a cell's score against its column leader is bimodal, not spread:

```
  0-9%    24.1%  ######################################
 10-19%   17.2%  ###########################
 20-29%   11.9%  ###################
 30-39%    7.8%  ############
 40-49%    5.9%  #########
 50-59%    3.9%  ######
 60-69%    2.7%  ####
 70-79%    1.9%  ###
 80-89%    2.8%  ####
 90-99%   21.9%  ###################################
```

Median 27%. The continuous ramp gave its finest distinctions to the sparse middle and none to the two ends where the cells actually are.

## Four bands, and a legend

| | |
|---|---|
| 🟥 red | under 25% of the column leader |
| 🟧 orange | 25–50% |
| 🟨 yellow | 50–75% |
| 🟩 green | over 75% |

One flat hue each, with a legend beside the toggle saying exactly that. A cell now has a *band* rather than a shade, and the code the colours speak is written down instead of guessed at.

## One thing worth noting

The legend is built once and shown with the toggle, not created when `state.heat` is true. The toggle's handler calls `render()`, which redraws the table but **not** the control strip — so a conditionally-built legend wouldn't have appeared until some later re-render. I only found that by rendering it and seeing no legend.

Cell geometry is untouched (the #1401 rules still set no padding, height or width), and the bands were checked on both the dark and light themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsAGTadPkBtwXaYEngJomx