### PR TITLE
board: SVG crown, and move the heat map to a button beside Head to Head [skip-maintainer-ping]

### DIFF
--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -448,7 +448,16 @@
      ink (visibility, not display - display:none collapses the row height), and
      the bar is stretched over the whole cell by its four offsets rather than by
      a width. Nothing here sets a padding, a height or a row height. */
-  .heatkey{display:flex; align-items:center; flex-wrap:wrap; gap:.1rem .55rem; margin-top:.3rem;
+  /* Deliberately not a .toggle. The two switches above the table change how the
+     numbers are computed - memory in the score, what the scale is relative to -
+     and belong with the heading that describes them. This changes how the table
+     is drawn, so it sits with the other thing that acts on the table, and looks
+     like a button you press rather than a setting you leave set. */
+  .heat-btn{cursor:pointer; font-family:inherit; font-size:.78rem; padding:.4rem .66rem}
+  .heat-btn svg{width:14px; height:14px; flex:none; fill:currentColor}
+  .heat-btn:hover{background:var(--accent); color:var(--bg)}
+  .heat-btn[aria-pressed="true"]{background:var(--accent); color:var(--bg); border-color:var(--accent)}
+  .heatkey{display:flex; align-items:center; flex-wrap:wrap; gap:.1rem .55rem;
     font-size:.66rem; color:var(--muted)}
   .heatkey .hk-l{margin-right:.1rem}
   .heatkey .hk{display:inline-flex; align-items:center; gap:.28rem; white-space:nowrap}
@@ -668,6 +677,9 @@
           <input id="q" type="search" placeholder="Search name, language, engine - comma to combine, ! to exclude (e.g. rust, !go)" autocomplete="off">
         </div>
         <a class="fw-btn cmp-btn" href="/compare/all/" data-tip="Put any two entries side by side - every profile they both run, requests per second, p99 and the delta. Any two, in any language."><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8h13"/><path d="m14 5 3 3-3 3"/><path d="M20 16H7"/><path d="m10 13-3 3 3 3"/></svg><span>Head to Head Comparison</span></a>
+        <button class="fw-btn heat-btn" id="heatBtn" type="button" aria-pressed="false"
+                data-tip="Colour every profile cell by its score as a share of that column\u2019s leader, instead of printing the number. For reading a column\u2019s shape at a glance; the figures stay in the hover popup."><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="7.6" height="7.6" rx="1.2"/><rect x="13.4" y="3" width="7.6" height="7.6" rx="1.2" opacity=".5"/><rect x="3" y="13.4" width="7.6" height="7.6" rx="1.2" opacity=".5"/><rect x="13.4" y="13.4" width="7.6" height="7.6" rx="1.2"/></svg><span>Heat map</span></button>
+        <div class="heatkey" id="heatKey" style="display:none"></div>
         <span class="count" id="count"></span>
       </div>
 
@@ -889,6 +901,35 @@ document.addEventListener('DOMContentLoaded', function(){
     return '<div class="dh">'+esc(fw)+'</div><div class="dsub">'+esc(p.label)
          + (p.category?' \u00b7 '+esc(p.category):'')+esc(why)+'</div>'+blocks
          + (foot?'<div class="dfoot">'+esc(foot)+'</div>':'');
+  }
+
+  // The heat-map control lives in the tools row beside Head to Head Comparison
+  // rather than with the two switches over the heading, and is wired once here
+  // instead of being rebuilt by renderHead: the button's own handler calls
+  // render(), which redraws the table and not the control strip, so anything
+  // rebuilt there would not react to the click that changed it.
+  function initHeat(){
+    var btn=document.getElementById('heatBtn'), key=document.getElementById('heatKey');
+    if(!btn||!key) return;
+    key.innerHTML='<span class="hk-l">share of column leader</span>'
+      + HEAT_BANDS.map(function(b){
+          return '<span class="hk"><i style="background:'+b[1]+'"></i>'+esc(b[2])+'</span>';
+        }).join('')
+      + '<span class="hk"><i class="hk-crown">'+CROWN_SVG+'</i>best in column</span>';
+    key.setAttribute('data-tip','Each cell is coloured by its score as a share of the best score in that column.');
+    function paint(){
+      btn.setAttribute('aria-pressed', state.heat?'true':'false');
+      key.style.display = state.heat ? '' : 'none';
+    }
+    btn.onclick=function(){ state.heat=!state.heat; paint(); render(); };
+    paint();
+  }
+  // Only the composite view has profile columns to colour.
+  function syncHeatCtl(){
+    var btn=document.getElementById('heatBtn'), key=document.getElementById('heatKey');
+    var on = state.view==='composite';
+    if(btn) btn.style.display = on ? '' : 'none';
+    if(key) key.style.display = (on && state.heat) ? '' : 'none';
   }
 
   function initTips(){
@@ -1337,28 +1378,6 @@ document.addEventListener('DOMContentLoaded', function(){
       rs.setAttribute('data-tip','Off: each profile is worth 100 to the best entry in the whole field, so scores stay comparable while you filter. On: rescale to the frameworks currently shown, to compare a subset against itself.');
       rs.onclick=function(){ state.rescale=!state.rescale; rs.classList.toggle('on', state.rescale); render(); };
       ctl.appendChild(rs);
-      var hm=document.createElement('div'); hm.className='toggle'+(state.heat?' on':'');
-      hm.innerHTML='<span class="sw"><i></i></span> Heat map';
-      hm.setAttribute('data-tip','Replace every profile cell with a colour block: dark red for the weakest score in that column, through orange and yellow, to green for the leader. The numbers stay in the hover popup - this is for reading a column\u2019s shape at a glance.');
-      ctl.appendChild(hm);
-      // Without this the colours are a code nobody was given. Built once and
-      // shown with the toggle: the toggle's own handler calls render(), which
-      // redraws the table but not this control strip, so a legend created only
-      // when state.heat is already true would never appear on the click that
-      // set it.
-      var lg=document.createElement('div'); lg.className='heatkey';
-      lg.setAttribute('data-tip','Each cell is coloured by its score as a share of the best score in that column.');
-      lg.innerHTML='<span class="hk-l">share of column leader</span>'+HEAT_BANDS.map(function(b){
-        return '<span class="hk"><i style="background:'+b[1]+'"></i>'+esc(b[2])+'</span>';
-      }).join('')+'<span class="hk"><i class="hk-crown">'+CROWN_SVG+'</i>best in column</span>';
-      lg.style.display = state.heat ? '' : 'none';
-      ctl.appendChild(lg);
-      hm.onclick=function(){
-        state.heat=!state.heat;
-        hm.classList.toggle('on', state.heat);
-        lg.style.display = state.heat ? '' : 'none';
-        render();
-      };
       // Arriving on #lang=X (from a language rank badge) filters the board to
       // one language. Say so, and make it one click to leave - a filter with no
       // visible cause reads as missing data.
@@ -1710,6 +1729,7 @@ document.addEventListener('DOMContentLoaded', function(){
     }
     if(dv)dv.style.display='none';
     if(grid)grid.style.display=''; if(tools)tools.style.display=''; if(phead)phead.style.display='';
+    syncHeatCtl();
     if(seo)seo.style.display='';
     if(state.view==='composite'){ th.style.display='none'; if(mn)mn.classList.add('cmfull'); renderComposite(); }
     else { th.style.display=''; if(mn)mn.classList.remove('cmfull'); renderProfile(); }
@@ -2080,7 +2100,7 @@ document.addEventListener('DOMContentLoaded', function(){
   try{ var _fc=localStorage.getItem('lb-fwcompact'); if(_fc!==null) state.compactFw=_fc==='1'; }catch(e){}
   document.getElementById('tunedToggle').addEventListener('click', function(){ state.showTuned=!state.showTuned; saveTuned(); render(); });
   restoreFromHash();
-  initTips(); initModal(); initDocLinks(); initSearchHelp(); initRounds(); initTheme(); initNavSearch(); hw(); buildNav(); renderHead(); render();
+  initTips(); initHeat(); initModal(); initDocLinks(); initSearchHelp(); initRounds(); initTheme(); initNavSearch(); hw(); buildNav(); renderHead(); render();
   (function(){ var b=document.getElementById('brandHome'); if(b) b.onclick=function(e){ e.preventDefault(); pickScope('h1'); }; })();
   window.addEventListener('hashchange', function(){ restoreFromHash(); buildNav(); renderHead(); render(); });
   var _rz; window.addEventListener('resize', function(){ clearTimeout(_rz); _rz=setTimeout(function(){ if(state.view==='profile') render(); else if(state.view==='composite') syncTopScroll(); }, 150); });

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -458,11 +458,12 @@
      included - so the one cell that won the column carried no mark at all. Sits
      over the band rather than replacing it, so the band still reads. */
   .cm td.pc .hcrown{display:none}
-  .cm.heat td.pc .hcrown{display:block; position:absolute; left:0; right:0; top:50%;
-    z-index:1; transform:translateY(-50%); text-align:center; line-height:1;
-    font-size:.74rem; pointer-events:none; filter:drop-shadow(0 1px 1px rgba(0,0,0,.45))}
-  .heatkey .hk i.hk-crown{width:auto; height:auto; font-size:.8rem; line-height:1;
-    filter:drop-shadow(0 1px 1px rgba(0,0,0,.35))}
+  .cm.heat td.pc .hcrown{display:flex; position:absolute; inset:0; z-index:1;
+    align-items:center; justify-content:center; pointer-events:none}
+  .cm.heat td.pc .hcrown svg{width:17px; height:17px; display:block;
+    fill:var(--gold); filter:drop-shadow(0 1px 1.2px rgba(0,0,0,.55))}
+  .heatkey .hk i.hk-crown{width:auto; height:auto; display:inline-flex; align-items:center}
+  .heatkey .hk i.hk-crown svg{width:13px; height:13px; display:block; fill:var(--gold)}
   .cm.heat td.pc .pcv{visibility:hidden}
   .cm.heat td.pc .cbar{left:0; right:0; top:0; bottom:0; width:auto; height:auto; opacity:1}
   /* .cm td.pc.lead .cbar sets opacity:.7 for the non-heat bar and sits later in
@@ -1349,7 +1350,7 @@ document.addEventListener('DOMContentLoaded', function(){
       lg.setAttribute('data-tip','Each cell is coloured by its score as a share of the best score in that column.');
       lg.innerHTML='<span class="hk-l">share of column leader</span>'+HEAT_BANDS.map(function(b){
         return '<span class="hk"><i style="background:'+b[1]+'"></i>'+esc(b[2])+'</span>';
-      }).join('')+'<span class="hk"><i class="hk-crown">\u{1F451}</i>best in column</span>';
+      }).join('')+'<span class="hk"><i class="hk-crown">'+CROWN_SVG+'</i>best in column</span>';
       lg.style.display = state.heat ? '' : 'none';
       ctl.appendChild(lg);
       hm.onclick=function(){
@@ -1653,6 +1654,12 @@ document.addEventListener('DOMContentLoaded', function(){
     [0.75, 'rgb(226,192,44)', '50-75%'],
     [1.01, 'rgb(45,172,94)',  'over 75%']
   ];
+  // Six points and a base, filled rather than stroked: a stroked outline closes
+  // up at this size and reads as a smudge. Gold is the token the board already
+  // uses for a first place in the rank column.
+  var CROWN_SVG='<svg viewBox="0 0 24 24" aria-hidden="true">'
+    + '<path d="M3.2 17.6 1.7 6.4 7.6 11 12 3.8 16.4 11 22.3 6.4 20.8 17.6Z"/>'
+    + '<rect x="3.2" y="18.6" width="17.6" height="2.2"/></svg>';
   function heatColor(t){
     t=(!isFinite(t)||t<0)?0:(t>1?1:t);
     for(var i=0;i<HEAT_BANDS.length;i++) if(t<HEAT_BANDS[i][0]) return HEAT_BANDS[i][1];
@@ -1863,7 +1870,7 @@ document.addEventListener('DOMContentLoaded', function(){
         var inner = '<span class="pcv"><span class="crps">'+head+'</span><span class="cmem">'+fmtMem(cell.mem)+'</span></span>'
           + (state.heat
               ? '<span class="cbar" style="background:'+heatColor(barPct/100)+'"></span>'
-                + (cell.best?'<span class="hcrown" aria-label="best in this column">\u{1F451}</span>':'')
+                + (cell.best?'<span class="hcrown" aria-label="best in this column">'+CROWN_SVG+'</span>':'')
               : '<span class="cbar" style="width:'+barPct.toFixed(0)+'%"></span>');
         var dat=' data-pid="'+esc(pid)+'" data-fw="'+esc(r.fw)+'"'+(cell.c?'':' data-nc="1"');
         if(cell.c){ tr+='<td class="num pc'+(cell.best?' lead':'')+'"'+dat+'>'+inner+'</td>'; }


### PR DESCRIPTION
Two changes to the heat map.

## 1. The crown is an SVG

The 👑 emoji is a different picture in every browser, carries its own colours whatever the cell is doing, and at that size resolves to a blob. Replaced with one inline path — **six points and a base bar, filled rather than stroked**, because a stroked outline closes up at 17px and reads as a smudge. **Bigger** too (17px vs ~12), filled with `var(--gold)`, the token the rank column already uses for first place. Defined once as `CROWN_SVG` and used by both the cell and the legend key, so the key can't drift from what it explains.

## 2. It's a button now, beside Head to Head Comparison

It was a third switch above the heading. The two that remain there — Memory efficiency, Rescale to selection — change how the numbers are **computed**, and belong with the sentence describing the scoring. This one changes how the table is **drawn**, so it sits with the other control that acts on the table, and looks like a button you press rather than a setting you leave set: a pressed state on `aria-pressed`, filled with the accent, against the outlined Head to Head button beside it.

The legend moves with it, inline in the same row. The control is hidden outside the composite view — detail views have no profile columns to colour, and the tools row is shown there too.

Wired once at init rather than rebuilt by `renderHead`, for the same reason the legend was: the handler calls `render()`, which redraws the table and not the control strip.

## A note on verifying this

Headless Chrome with `--virtual-time-budget` **freezes CSS transitions at their start value**. The pressed button measured as `var(--accent-weak)` and photographed as a colour *between* the two states — it read exactly like a specificity bug, and I went looking for one. It isn't: with transitions disabled the computed style is `rgb(138,180,248)` on `rgb(32,33,36)`, the accent on the background, which is what the rule says.

Any future check of a transitioned property in this harness has to disable transitions first.

## Verified

12 crowns across 12 profile columns, one legend key, header switches down to 2, and cell geometry still **diff 0.00** on table, cell and row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsAGTadPkBtwXaYEngJomx