### PR TITLE
edixoi, ioxide-pipes: say why receive stays in userspace, having measured it

### DIFF
--- a/frameworks/edixoi/Program.cs
+++ b/frameworks/edixoi/Program.cs
@@ -82,8 +82,15 @@ internal static class Program
         //
         // Only when the kernel actually offers the ULP: ioxide throws on the handoff when the tls
         // module is missing, and a TLS port that refuses every connection is a far worse trade
-        // than an encrypt. Receive stays in userspace - kernel RX is experimental and its handoff
-        // fails on about one first connection in twelve.
+        // than an encrypt.
+        //
+        // Receive stays in userspace, and that is measured rather than assumed - kernel RX cost
+        // about 3% on json-tls here (792,642 / 796,898 and 797,053 / 802,664 against 772,330 /
+        // 776,448 and 772,363 / 770,476) and did nothing for the echo. It would also buy a
+        // failure mode: under kTLS RX a TLS 1.3 KeyUpdate or alert is only readable through
+        // recvmsg with a control message, and the reactor's hot path is IORING_OP_RECV, which
+        // carries none - so the kernel refuses the read and that connection is lost. Paying 3%
+        // for that is the wrong way round.
         var tlsOptions = new TlsOptions
         {
             CertificatePath = certPath,

--- a/frameworks/ioxide-pipes/Program.cs
+++ b/frameworks/ioxide-pipes/Program.cs
@@ -88,8 +88,15 @@ internal static class Program
         //
         // Only when the kernel actually offers the ULP: ioxide throws on the handoff when the tls
         // module is missing, and a TLS port that refuses every connection is a far worse trade
-        // than an encrypt. Receive stays in userspace - kernel RX is experimental and its handoff
-        // fails on about one first connection in twelve.
+        // than an encrypt.
+        //
+        // Receive stays in userspace, and that is measured rather than assumed - kernel RX cost
+        // about 3% on json-tls here (792,642 / 796,898 and 797,053 / 802,664 against 772,330 /
+        // 776,448 and 772,363 / 770,476) and did nothing for the echo. It would also buy a
+        // failure mode: under kTLS RX a TLS 1.3 KeyUpdate or alert is only readable through
+        // recvmsg with a control message, and the reactor's hot path is IORING_OP_RECV, which
+        // carries none - so the kernel refuses the read and that connection is lost. Paying 3%
+        // for that is the wrong way round.
         var tlsOptions = new TlsOptions
         {
             CertificatePath = certPath,


### PR DESCRIPTION
## Description

Follow-up to [#1444](https://github.com/MDA2AV/HttpArena/pull/1444), which left kernel RX off with a reason that was wrong.

It said the handoff *"fails on about one first connection in twelve"*. It does not fail. A handshake that left a partial record means bytes the kernel never saw and no sequence number recovers, so that connection **silently stays on the userspace path** — graceful, and not a reason for anything.

Asked properly, there are two reasons, in the order they matter.

## It is slower

Four runs each, `wrk -t4 -c256` over the json-tls rotation, 8 reactors, kernel TX on throughout:

| | round 1 | round 2 |
|---|---|---|
| TX only | 792,642 / 796,898 | 797,053 / 802,664 |
| TX + kernel RX | 772,330 / 776,448 | 772,363 / 770,476 |

About **3% down**, in two independent rounds whose ranges do not overlap. On the 8gbit echo it was noise either way — 454,535 / 485,406 against 460,601 / 455,309 — so there is nothing to trade the 3% for.

Worth recording because the intuition runs the other way: with RX on, `recv` returns plaintext straight into ring memory and the zero-copy reader works on a TLS connection exactly as on a cleartext one. It still did not pay.

## And it would buy a failure mode

Under kTLS RX a TLS 1.3 KeyUpdate or an alert is only retrievable through `recvmsg` with a `TLS_GET_RECORD_TYPE` control message. The reactor's TCP hot path is `IORING_OP_RECV`, which carries no control data — so the kernel refuses the read and that connection is lost. Every client these profiles use is unaffected, but paying 3% for a hazard is the wrong way round.

## Not a behaviour change

This corrects a comment and records the measurement behind it. Both entries were validated at **50 passed, 0 failed** on these exact files.

For the record, #1444's kernel TX did what it was meant to — json-tls went **1,327,184 → 1,743,647** for `ioxide-pipes` and **1,804,773** for `edixoi`, against the `ioxide` entry's 1,803,723.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
